### PR TITLE
Update to latests nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ test = []
 
 [dependencies]
 crossbeam-channel    = "0.2.4"
-futures-core-preview = "0.3.0-alpha.10"
-futures-io-preview   = "0.3.0-alpha.10"
+futures-core-preview = "0.3.0-alpha.11"
+futures-io-preview   = "0.3.0-alpha.11"
 log                  = "0.4.6"
 mio-st               = "0.1.0"
 num_cpus             = "1.8.0"
@@ -35,5 +35,5 @@ std-logger           = "0.3.1"
 
 [dev-dependencies]
 env_logger           = "0.5.10"
-futures-util-preview = "0.3.0-alpha.10"
+futures-util-preview = "0.3.0-alpha.11"
 lazy_static          = "1.1.0"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2018-12-24
+nightly

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -62,7 +62,7 @@ impl<M> ActorContext<M> {
     /// Same as the example above, but this actor will only wait for a limited
     /// amount of time.
     ///
-    /// ```
+    /// ```ignore
     /// #![feature(async_await, await_macro, futures_api, pin, never_type)]
     ///
     /// use std::time::Duration;

--- a/src/channel/bounded.rs
+++ b/src/channel/bounded.rs
@@ -5,7 +5,8 @@
 
 use std::collections::VecDeque;
 use std::future::Future;
-use std::pin::{Pin, Unpin};
+use std::marker::Unpin;
+use std::pin::Pin;
 use std::task::{Poll, LocalWaker};
 
 use futures_core::stream::Stream;
@@ -180,7 +181,7 @@ mod tests {
     #[test]
     fn sending_wakes_receiver() {
         let (mut sender, receiver) = bounded(1);
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -195,7 +196,7 @@ mod tests {
     #[test]
     fn sending_ok_with_no_waker() {
         let (mut sender, receiver) = bounded(1);
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -207,7 +208,7 @@ mod tests {
     #[test]
     fn wake_when_sender_is_dropped() {
         let (sender, receiver) = bounded::<()>(1);
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -222,7 +223,7 @@ mod tests {
     #[test]
     fn receive_stream_after_sender_drop() {
         let (mut sender, receiver) = bounded(2);
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -276,7 +277,7 @@ mod tests {
     #[test]
     fn sending_no_capacity() {
         let (mut sender, receiver) = bounded(1);
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -307,7 +308,7 @@ mod tests {
     #[test]
     fn no_sender() {
         let (sender, receiver) = bounded::<()>(1);
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         drop(sender);

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -47,7 +47,7 @@
 //! [unbounded]: unbounded/index.html
 //! [bounded]: bounded/index.html
 
-use std::pin::Unpin;
+use std::marker::Unpin;
 
 pub mod bounded;
 pub mod oneshot;

--- a/src/channel/oneshot.rs
+++ b/src/channel/oneshot.rs
@@ -65,7 +65,8 @@
 //! ```
 
 use std::future::Future;
-use std::pin::{Pin, Unpin};
+use std::marker::Unpin;
+use std::pin::Pin;
 use std::task::{Poll, LocalWaker};
 
 use crate::channel::{NoReceiver, NoValue};
@@ -158,7 +159,7 @@ mod tests {
     #[test]
     fn sending_wakes_receiver() {
         let (sender, receiver) = oneshot();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -173,7 +174,7 @@ mod tests {
     #[test]
     fn sending_ok_with_no_waker() {
         let (sender, receiver) = oneshot();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -185,7 +186,7 @@ mod tests {
     #[test]
     fn wake_when_sender_is_dropped() {
         let (sender, receiver) = oneshot::<()>();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -207,7 +208,7 @@ mod tests {
     #[test]
     fn no_sender() {
         let (sender, receiver) = oneshot::<()>();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         drop(sender);

--- a/src/channel/unbounded.rs
+++ b/src/channel/unbounded.rs
@@ -2,7 +2,8 @@
 
 use std::collections::VecDeque;
 use std::future::Future;
-use std::pin::{Pin, Unpin};
+use std::marker::Unpin;
+use std::pin::Pin;
 use std::task::{Poll, LocalWaker};
 
 use futures_core::stream::Stream;
@@ -148,7 +149,7 @@ mod tests {
     #[test]
     fn sending_wakes_receiver() {
         let (mut sender, receiver) = unbounded();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -163,7 +164,7 @@ mod tests {
     #[test]
     fn sending_ok_with_no_waker() {
         let (mut sender, receiver) = unbounded();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -175,7 +176,7 @@ mod tests {
     #[test]
     fn wake_when_sender_is_dropped() {
         let (sender, receiver) = unbounded::<()>();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -190,7 +191,7 @@ mod tests {
     #[test]
     fn receive_stream_after_sender_drop() {
         let (mut sender, receiver) = unbounded();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         assert_eq!(count.get(), 0);
@@ -251,7 +252,7 @@ mod tests {
     #[test]
     fn no_sender() {
         let (sender, receiver) = unbounded::<()>();
-        let mut receiver = Box::pinned(receiver);
+        let mut receiver = Box::pin(receiver);
         let (waker, count) = new_count_waker();
 
         drop(sender);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,14 +64,12 @@
 //! [1]: https://en.wikipedia.org/wiki/Hephaestus
 //! [2]: https://en.wikipedia.org/wiki/Actor_model
 
-#![feature(arbitrary_self_types,
-           async_await,
+#![feature(async_await,
            await_macro,
            const_fn,
            futures_api,
            never_type,
            non_exhaustive,
-           pin,
            read_initializer,
            weak_ptr_eq,
 )]

--- a/src/process/actor.rs
+++ b/src/process/actor.rs
@@ -77,12 +77,12 @@ impl<S, NA> Process for ActorProcess<S, NA>
 
         // The only thing in `ActorProcess` that is `!Unpin` is the actor. So
         // this is safe as long as we don't move the actor.
-        let this = unsafe { Pin::get_mut_unchecked(self) };
+        let this = unsafe { Pin::get_unchecked_mut(self) };
 
         // The actor does need to be called with `Pin`. So we're undoing the
         // previous operation, still making sure that the actor is not moved.
         let pinned_actor = unsafe { Pin::new_unchecked(&mut this.actor) };
-        let result = match pinned_actor.try_poll(&this.waker) {
+        let result = match Actor::try_poll(pinned_actor, &this.waker) {
             Poll::Ready(Ok(())) => ProcessResult::Complete,
             Poll::Ready(Err(err)) => {
                 match this.supervisor.decide(err) {

--- a/src/process/initiator.rs
+++ b/src/process/initiator.rs
@@ -36,7 +36,7 @@ impl<I> Process for InitiatorProcess<I>
         trace!("running initiator process");
 
         // This is safe because we're not moving the initiator.
-        let this = unsafe { Pin::get_mut_unchecked(self) };
+        let this = unsafe { Pin::get_unchecked_mut(self) };
         if let Err(err) = this.initiator.poll(system_ref) {
             error!("error polling initiator: {}", err);
             ProcessResult::Complete

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -65,7 +65,7 @@ fn actor_process() {
     // Finally create our process.
     let inbox = actor_ref.get_inbox().unwrap();
     let process = ActorProcess::new(pid, NoopSupervisor, new_actor, actor, inbox, waker);
-    let mut process = Box::pinned(process);
+    let mut process = Box::pin(process);
 
     // Actor should return `Poll::Pending`, because no message is ready.
     let mut system_ref = test::system_ref();
@@ -98,7 +98,7 @@ fn erroneous_actor_process() {
     let inbox = actor_ref.get_inbox().unwrap();
     let supervisor = |_err: Error | SupervisorStrategy::Stop;
     let process = ActorProcess::new(pid, supervisor, new_actor, actor, inbox, waker);
-    let mut process = Box::pinned(process);
+    let mut process = Box::pin(process);
 
     // Actor should return Err.
     let mut system_ref = test::system_ref();

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -223,7 +223,7 @@ impl ProcessData {
             id,
             fair_runtime: Duration::from_millis(0),
             priority,
-            process: Box::pinned(process),
+            process: Box::pin(process),
         }
     }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -39,7 +39,7 @@ pub struct DeadlinePassed;
 ///
 /// Using the `select!` macro to add a timeout to receiving a message.
 ///
-/// ```
+/// ```ignore
 /// #![feature(async_await, await_macro, futures_api, pin, never_type)]
 ///
 /// use std::time::Duration;


### PR DESCRIPTION
Also updates to futures preview v0.3 alpha 11.

Disables the examples that use the `select!` macro as it seems broken.

Closes #107.