### PR TITLE
Add associative type Error to the NewActor trait

### DIFF
--- a/examples/1_hello_world.rs
+++ b/examples/1_hello_world.rs
@@ -24,7 +24,10 @@ fn add_greeter_actor(mut system_ref: ActorSystemRef) -> io::Result<()> {
     // Along with the supervisor we'll also supply the argument to start the
     // actor, in our case this is `()` since our actor doesn't accept arguments.
     // We'll use the default actor options here.
-    let mut actor_ref = system_ref.spawn(NoSupervisor, greeter_actor as fn(_) -> _, (), ActorOptions::default());
+    let mut actor_ref = system_ref.spawn(NoSupervisor, greeter_actor as fn(_) -> _, (), ActorOptions::default())
+        // This is safe because asynchronous functions never return an error
+        // when creating the actor.
+        .unwrap();
 
     // By default actors don't do anything when added to the actor system. We
     // need to wake them, for example by sending them a message.

--- a/examples/1b_hello_world.rs
+++ b/examples/1b_hello_world.rs
@@ -23,7 +23,7 @@ fn add_greeter_actor(mut system_ref: ActorSystemRef) -> io::Result<()> {
         ActorOptions {
             schedule: true,
             .. ActorOptions::default()
-        });
+        }).unwrap();
 
     Ok(())
 }

--- a/examples/3_echo_server.rs
+++ b/examples/3_echo_server.rs
@@ -26,7 +26,7 @@ fn add_count_actor(mut system_ref: ActorSystemRef) -> io::Result<()> {
             // Note: this registry is per thread!
             register: true,
             .. Default::default()
-        });
+        }).unwrap();
 
     Ok(())
 }

--- a/src/actor_ref/mod.rs
+++ b/src/actor_ref/mod.rs
@@ -54,7 +54,10 @@
 //!     ActorSystem::new().with_setup(|mut system_ref| {
 //!         // Add the actor to the actor system.
 //!         let new_actor = actor as fn (_) -> _;
-//!         let mut actor_ref = system_ref.spawn(NoSupervisor, new_actor, (), ActorOptions::default());
+//!         let mut actor_ref = system_ref.spawn(NoSupervisor, new_actor, (), ActorOptions::default())
+//!             // This is safe because the `NewActor` implementation for
+//!             // asynchronous functions never returns an error.
+//!             .unwrap();
 //!
 //!         // Now we can use the reference to send the actor a message.
 //!         actor_ref.send("Hello world".to_owned());
@@ -92,7 +95,10 @@
 //! fn main() -> Result<(), RuntimeError> {
 //!      ActorSystem::new().with_setup(|mut system_ref| {
 //!         let new_actor = actor as fn (_) -> _;
-//!         let mut actor_ref = system_ref.spawn(NoSupervisor, new_actor, (), ActorOptions::default());
+//!         let mut actor_ref = system_ref.spawn(NoSupervisor, new_actor, (), ActorOptions::default())
+//!             // This is safe because the `NewActor` implementation for
+//!             // asynchronous functions never returns an error.
+//!             .unwrap();
 //!
 //!         // To create another actor reference we can simply clone the first one.
 //!         let mut second_actor_ref = actor_ref.clone();

--- a/src/scheduler/process/tests.rs
+++ b/src/scheduler/process/tests.rs
@@ -157,7 +157,7 @@ fn actor_process() {
     // Create our actor.
     #[allow(trivial_casts)]
     let new_actor = ok_actor as fn(_) -> _;
-    let (actor, mut actor_ref) = init_actor(new_actor, ());
+    let (actor, mut actor_ref) = init_actor(new_actor, ()).unwrap();
 
     // Create the waker.
     let pid = ProcessId(0);
@@ -203,7 +203,7 @@ fn erroneous_actor_process() {
     // Create our actor.
     #[allow(trivial_casts)]
     let new_actor = error_actor as fn(_, _) -> _;
-    let (actor, mut actor_ref) = init_actor(new_actor, true);
+    let (actor, mut actor_ref) = init_actor(new_actor, true).unwrap();
 
     // Create the waker.
     let pid = ProcessId(0);
@@ -231,7 +231,7 @@ fn restarting_erroneous_actor_process() {
     // Create our actor.
     #[allow(trivial_casts)]
     let new_actor = error_actor as fn(_, _) -> _;
-    let (actor, mut actor_ref) = init_actor(new_actor, true);
+    let (actor, mut actor_ref) = init_actor(new_actor, true).unwrap();
 
     // Create the waker.
     let pid = ProcessId(0);
@@ -285,7 +285,7 @@ fn actor_process_runtime_increase() {
     // Create our actor.
     #[allow(trivial_casts)]
     let new_actor = sleepy_actor as fn(_, _) -> _;
-    let (actor, mut actor_ref) = init_actor(new_actor, SLEEP_TIME);
+    let (actor, mut actor_ref) = init_actor(new_actor, SLEEP_TIME).unwrap();
 
     // Create the waker.
     let pid = ProcessId(0);
@@ -314,19 +314,20 @@ impl NewActor for TestAssertUnmovedNewActor {
     type Message = ();
     type Argument = ();
     type Actor = AssertUnmoved<Empty<Result<(), !>>>;
+    type Error = !;
 
-    fn new(&mut self, ctx: ActorContext<Self::Message>, _arg: Self::Argument) -> Self::Actor {
+    fn new(&mut self, ctx: ActorContext<Self::Message>, _arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         // In the test we need the access to the inbox, to achieve that we can't
         // drop the context, so we forget about it here leaking the inbox.
         forget(ctx);
-        empty().assert_unmoved()
+        Ok(empty().assert_unmoved())
     }
 }
 
 #[test]
 fn actor_process_assert_actor_unmoved() {
     // Create our actor.
-    let (actor, mut actor_ref) = init_actor(TestAssertUnmovedNewActor , ());
+    let (actor, mut actor_ref) = init_actor(TestAssertUnmovedNewActor , ()).unwrap();
 
     // Create the waker.
     let pid = ProcessId(0);

--- a/src/scheduler/tests.rs
+++ b/src/scheduler/tests.rs
@@ -212,7 +212,7 @@ fn actor_process() {
     // Create our actor.
     #[allow(trivial_casts)]
     let new_actor = actor as fn(_) -> _;
-    let (actor, mut actor_ref) = init_actor(new_actor, ());
+    let (actor, mut actor_ref) = init_actor(new_actor, ()).unwrap();
 
     // Create the waker.
     let pid = ProcessId(0);
@@ -248,12 +248,13 @@ impl NewActor for TestNewActor {
     type Message = ();
     type Argument = ();
     type Actor = AssertUnmoved<Empty<Result<(), !>>>;
+    type Error = !;
 
-    fn new(&mut self, ctx: ActorContext<Self::Message>, _arg: Self::Argument) -> Self::Actor {
+    fn new(&mut self, ctx: ActorContext<Self::Message>, _arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         // In the test we need the access to the inbox, to achieve that we can't
         // drop the context, so we forget about it here leaking the inbox.
         mem::forget(ctx);
-        empty().assert_unmoved()
+        Ok(empty().assert_unmoved())
     }
 }
 
@@ -263,7 +264,7 @@ fn assert_actor_unmoved() {
     let mut system_ref = system_ref();
 
     // Create our actor.
-    let (actor, mut actor_ref) = init_actor(TestNewActor, ());
+    let (actor, mut actor_ref) = init_actor(TestNewActor, ()).unwrap();
 
     // Create the waker.
     let pid = ProcessId(0);

--- a/src/test.rs
+++ b/src/test.rs
@@ -51,7 +51,7 @@ pub fn system_ref() -> ActorSystemRef {
 }
 
 /// Initialise an actor.
-pub fn init_actor<NA>(mut new_actor: NA, arg: NA::Argument) -> (NA::Actor, LocalActorRef<NA::Message>)
+pub fn init_actor<NA>(mut new_actor: NA, arg: NA::Argument) -> Result<(NA::Actor, LocalActorRef<NA::Message>), NA::Error>
     where NA: NewActor,
 {
     let system_ref = system_ref();
@@ -61,9 +61,9 @@ pub fn init_actor<NA>(mut new_actor: NA, arg: NA::Argument) -> (NA::Actor, Local
     let actor_ref = LocalActorRef::new(inbox.downgrade());
 
     let ctx = ActorContext::new(pid, system_ref, inbox);
-    let actor = new_actor.new(ctx, arg);
+    let actor = new_actor.new(ctx, arg)?;
 
-    (actor, actor_ref)
+    Ok((actor, actor_ref))
 }
 
 /// Poll a future.


### PR DESCRIPTION
This also changes the new method to return a Result<Actor, Error>.
Because NewActor.new can now return a result a number of public
functions have also changed. ActorSystem.spawn and test::init_actor were
both changed to return a result.

The implementation of NewActor for asynchronous functions use the never
type (`!`) as error and thus never return an error. This means that a
lot of examples need to unwrap the results from calls to spawn new
actors.

This also changes the implementation of TcpListener and ActorProcess.
In ActorProcess when restarting an actor returns an error it now just
logs it and marks the process as complete, as not much else can be done.
This will needs improvement in the future, see below. The same goes for
TcpListener, it needs better error handling in its Initiator.poll
implementation.

Some things to improve in the future:
 * Better handling of NewActor errors in both ActorProcess and
   TcpListener, both now log and give up.
 * ActorProcess.run needs to be refactored, it's getting too messy.