### PR TITLE
Pin Rust nightly version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2019-01-09


### PR DESCRIPTION
Futures crate doesn't compile on latest nightly, see https://github.com/rust-lang-nursery/futures-rs/issues/1409.