### PR TITLE
Rename ActorContext to Context

### DIFF
--- a/examples/1_hello_world.rs
+++ b/examples/1_hello_world.rs
@@ -1,6 +1,6 @@
 #![feature(async_await, await_macro, futures_api, never_type)]
 
-use heph::actor::ActorContext;
+use heph::actor::Context;
 use heph::supervisor::NoSupervisor;
 use heph::system::{ActorOptions, ActorSystem, ActorSystemRef, RuntimeError};
 
@@ -44,7 +44,7 @@ fn add_greeter_actor(mut system_ref: ActorSystemRef) -> Result<(), !> {
 /// Our greeter actor.
 ///
 /// We'll receive a single message and print it.
-async fn greeter_actor(mut ctx: ActorContext<&'static str>) -> Result<(), !> {
+async fn greeter_actor(mut ctx: Context<&'static str>) -> Result<(), !> {
     // All actors have an actor context, which give the actor access to its
     // inbox, from which we can `receive` a message.
     let name = await!(ctx.receive_next());

--- a/examples/1b_hello_world.rs
+++ b/examples/1b_hello_world.rs
@@ -1,6 +1,6 @@
 #![feature(async_await, await_macro, futures_api, never_type)]
 
-use heph::actor::ActorContext;
+use heph::actor::Context;
 use heph::supervisor::NoSupervisor;
 use heph::system::{ActorOptions, ActorSystem, ActorSystemRef, RuntimeError};
 
@@ -32,7 +32,7 @@ fn add_greeter_actor(mut system_ref: ActorSystemRef) -> Result<(), !> {
 /// Our greeter actor.
 ///
 /// Note: this needs the `schedule` options when adding it to the actor system.
-async fn greeter_actor(_: ActorContext<!>) -> Result<(), !> {
+async fn greeter_actor(_: Context<!>) -> Result<(), !> {
     println!("Hello World");
     Ok(())
 }

--- a/examples/2_my_ip.rs
+++ b/examples/2_my_ip.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 
 use futures_util::AsyncWriteExt;
 
-use heph::actor::ActorContext;
+use heph::actor::Context;
 use heph::log::{self, error, info};
 use heph::net::{TcpListener, TcpListenerError, TcpStream};
 use heph::supervisor::SupervisorStrategy;
@@ -77,7 +77,7 @@ fn conn_supervisor(err: io::Error) -> SupervisorStrategy<(TcpStream, SocketAddr)
 ///
 /// This actor will not receive any message and thus uses `!` (the never type)
 /// as message type.
-async fn conn_actor(_: ActorContext<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
+async fn conn_actor(_: Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
     info!("accepted connection: address={}", address);
 
     // This will allocate a new string which isn't the most efficient way to do

--- a/examples/3_actor_registry.rs
+++ b/examples/3_actor_registry.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 
 use futures_util::{AsyncReadExt, TryFutureExt};
 
-use heph::actor::ActorContext;
+use heph::actor::Context;
 use heph::log::{self, error, info};
 use heph::net::{TcpListener, TcpListenerError, TcpStream};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
@@ -67,7 +67,7 @@ struct Add;
 /// that if you run this example it could display a total count of 1 twice. This
 /// means that thread 1 handled the first request and thread 2 handled the
 /// second, be careful of this when implementing a counter this way.
-async fn count_actor(mut ctx: ActorContext<Add>) -> Result<(), !> {
+async fn count_actor(mut ctx: Context<Add>) -> Result<(), !> {
     let mut total = 0;
     loop {
         let _msg = await!(ctx.receive_next());
@@ -84,7 +84,7 @@ fn echo_supervisor(err: io::Error) -> SupervisorStrategy<(TcpStream, SocketAddr)
 }
 
 /// Our actor that handles the incoming TCP connections.
-async fn echo_actor(mut ctx: ActorContext<!>, stream: TcpStream, address: SocketAddr) -> io::Result<()> {
+async fn echo_actor(mut ctx: Context<!>, stream: TcpStream, address: SocketAddr) -> io::Result<()> {
     // Here we use a special request target to mark this log as a request. This
     // will cause it to be printed to standard out, rather then standard error.
     info!(target: log::REQUEST_TARGET, "accepted connection: address={}", address);

--- a/examples/99_stress_memory.rs
+++ b/examples/99_stress_memory.rs
@@ -7,7 +7,7 @@
 use std::thread;
 use std::time::Duration;
 
-use heph::actor::ActorContext;
+use heph::actor::Context;
 use heph::supervisor::NoSupervisor;
 use heph::system::{ActorOptions, ActorSystem, RuntimeError};
 
@@ -27,6 +27,6 @@ fn main() -> Result<(), RuntimeError> {
 }
 
 /// Our "actor", but it doesn't do much.
-async fn actor(_: ActorContext<!>) -> Result<(), !> {
+async fn actor(_: Context<!>) -> Result<(), !> {
     Ok(())
 }

--- a/src/actor/messages.rs
+++ b/src/actor/messages.rs
@@ -19,7 +19,7 @@
 //! #![feature(async_await, futures_api, never_type)]
 //!
 //! use heph::actor::messages::Ack;
-//! use heph::actor::ActorContext;
+//! use heph::actor::Context;
 //!
 //! #[derive(Debug, Eq, PartialEq)]
 //! struct OK;
@@ -55,7 +55,7 @@
 //!     }
 //! }
 //!
-//! async fn coordinator(ctx: ActorContext<Message>) -> Result<(), !> {
+//! async fn coordinator(ctx: Context<Message>) -> Result<(), !> {
 //!     // Do coordinator stuff ...
 //! #   drop(ctx); // Silence dead code warnings.
 //!     # Ok(())

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -13,9 +13,9 @@
 //! ```
 //! #![feature(async_await, futures_api)]
 //!
-//! use heph::actor::{ActorContext, NewActor};
+//! use heph::actor::{Context, NewActor};
 //!
-//! async fn actor(ctx: ActorContext<()>) -> Result<(), ()> {
+//! async fn actor(ctx: Context<()>) -> Result<(), ()> {
 //! #   drop(ctx); // Use `ctx` to silence dead code warnings.
 //!     println!("Actor is running!");
 //!     Ok(())
@@ -51,7 +51,7 @@ pub mod message_select {
 }
 
 #[doc(inline)]
-pub use self::context::{ActorContext, ReceiveMessage};
+pub use self::context::{Context, ReceiveMessage};
 
 /// The trait that defines how to create a new [`Actor`].
 ///
@@ -71,7 +71,7 @@ pub trait NewActor {
     /// ```
     /// #![feature(async_await, await_macro, futures_api, never_type)]
     ///
-    /// use heph::actor::ActorContext;
+    /// use heph::actor::Context;
     /// use heph::supervisor::NoSupervisor;
     /// use heph::system::{ActorOptions, ActorSystem, RuntimeError};
     ///
@@ -110,7 +110,7 @@ pub trait NewActor {
     /// }
     ///
     /// /// Our actor implementation that prints all messages it receives.
-    /// async fn actor(mut ctx: ActorContext<Message>) -> Result<(), !> {
+    /// async fn actor(mut ctx: Context<Message>) -> Result<(), !> {
     ///     let msg = await!(ctx.receive_next());
     ///     println!("received message: {:?}", msg);
     ///     Ok(())
@@ -127,7 +127,7 @@ pub trait NewActor {
     /// `(TcpStream, SocketAddr)`.
     ///
     /// An empty tuple can be used for actors that don't accept any arguments
-    /// (except for the `ActorContext`, see [`new`] below).
+    /// (except for the `Context`, see [`new`] below).
     ///
     /// When using asynchronous functions arguments are passed regularly, i.e.
     /// not in the form of a tuple, however they do have be passed as a tuple to
@@ -155,77 +155,77 @@ pub trait NewActor {
     type Error: fmt::Display;
 
     /// Create a new [`Actor`](Actor).
-    fn new(&mut self, ctx: ActorContext<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error>;
+    fn new(&mut self, ctx: Context<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error>;
 }
 
-impl<M, A> NewActor for fn(ctx: ActorContext<M>) -> A
+impl<M, A> NewActor for fn(ctx: Context<M>) -> A
     where A: Actor,
 {
     type Message = M;
     type Argument = ();
     type Actor = A;
     type Error = !;
-    fn new(&mut self, ctx: ActorContext<Self::Message>, _arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, ctx: Context<Self::Message>, _arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         Ok((self)(ctx))
     }
 }
 
-impl<M, Arg, A> NewActor for fn(ctx: ActorContext<M>, arg: Arg) -> A
+impl<M, Arg, A> NewActor for fn(ctx: Context<M>, arg: Arg) -> A
     where A: Actor,
 {
     type Message = M;
     type Argument = Arg;
     type Actor = A;
     type Error = !;
-    fn new(&mut self, ctx: ActorContext<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, ctx: Context<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         Ok((self)(ctx, arg))
     }
 }
 
-impl<M, Arg1, Arg2, A> NewActor for fn(ctx: ActorContext<M>, arg1: Arg1, arg2: Arg2) -> A
+impl<M, Arg1, Arg2, A> NewActor for fn(ctx: Context<M>, arg1: Arg1, arg2: Arg2) -> A
     where A: Actor,
 {
     type Message = M;
     type Argument = (Arg1, Arg2);
     type Actor = A;
     type Error = !;
-    fn new(&mut self, ctx: ActorContext<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, ctx: Context<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         Ok((self)(ctx, arg.0, arg.1))
     }
 }
 
-impl<M, Arg1, Arg2, Arg3, A> NewActor for fn(ctx: ActorContext<M>, arg1: Arg1, arg2: Arg2, arg3: Arg3) -> A
+impl<M, Arg1, Arg2, Arg3, A> NewActor for fn(ctx: Context<M>, arg1: Arg1, arg2: Arg2, arg3: Arg3) -> A
     where A: Actor,
 {
     type Message = M;
     type Argument = (Arg1, Arg2, Arg3);
     type Actor = A;
     type Error = !;
-    fn new(&mut self, ctx: ActorContext<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, ctx: Context<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         Ok((self)(ctx, arg.0, arg.1, arg.2))
     }
 }
 
-impl<M, Arg1, Arg2, Arg3, Arg4, A> NewActor for fn(ctx: ActorContext<M>, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) -> A
+impl<M, Arg1, Arg2, Arg3, Arg4, A> NewActor for fn(ctx: Context<M>, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) -> A
     where A: Actor,
 {
     type Message = M;
     type Argument = (Arg1, Arg2, Arg3, Arg4);
     type Actor = A;
     type Error = !;
-    fn new(&mut self, ctx: ActorContext<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, ctx: Context<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         Ok((self)(ctx, arg.0, arg.1, arg.2, arg.3))
     }
 }
 
-impl<M, Arg1, Arg2, Arg3, Arg4, Arg5, A> NewActor for fn(ctx: ActorContext<M>, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) -> A
+impl<M, Arg1, Arg2, Arg3, Arg4, Arg5, A> NewActor for fn(ctx: Context<M>, arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4, arg5: Arg5) -> A
     where A: Actor,
 {
     type Message = M;
     type Argument = (Arg1, Arg2, Arg3, Arg4, Arg5);
     type Actor = A;
     type Error = !;
-    fn new(&mut self, ctx: ActorContext<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, ctx: Context<Self::Message>, arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         Ok((self)(ctx, arg.0, arg.1, arg.2, arg.3, arg.4))
     }
 }

--- a/src/actor/tests.rs
+++ b/src/actor/tests.rs
@@ -3,7 +3,7 @@
 use std::pin::Pin;
 use std::task::Poll;
 
-use crate::actor::ActorContext;
+use crate::actor::Context;
 use crate::mailbox::MailBox;
 use crate::scheduler::ProcessId;
 use crate::test;
@@ -14,7 +14,7 @@ fn test_actor_context() {
     let pid = ProcessId(0);
     let system_ref = test::system_ref();
     let inbox = Shared::new(MailBox::new(pid, system_ref.clone()));
-    let mut ctx = ActorContext::new(pid, system_ref, inbox);
+    let mut ctx = Context::new(pid, system_ref, inbox);
 
     assert_eq!(ctx.pid(), pid);
     let mut actor_ref = ctx.actor_ref();

--- a/src/actor_ref/mod.rs
+++ b/src/actor_ref/mod.rs
@@ -44,7 +44,7 @@
 //! ```
 //! #![feature(async_await, await_macro, futures_api, never_type)]
 //!
-//! use heph::actor::ActorContext;
+//! use heph::actor::Context;
 //! use heph::supervisor::NoSupervisor;
 //! use heph::system::{ActorOptions, ActorSystem, RuntimeError};
 //!
@@ -65,7 +65,7 @@
 //! }
 //!
 //! /// Our actor.
-//! async fn actor(mut ctx: ActorContext<String>) -> Result<(), !> {
+//! async fn actor(mut ctx: Context<String>) -> Result<(), !> {
 //!     let msg = await!(ctx.receive_next());
 //!     println!("got message: {}", msg);
 //!     Ok(())
@@ -82,7 +82,7 @@
 //! ```
 //! #![feature(async_await, await_macro, futures_api, never_type)]
 //!
-//! use heph::actor::ActorContext;
+//! use heph::actor::Context;
 //! use heph::supervisor::NoSupervisor;
 //! use heph::system::{ActorOptions, ActorSystem, RuntimeError};
 //!
@@ -104,7 +104,7 @@
 //! }
 //!
 //! /// Our actor.
-//! async fn actor(mut ctx: ActorContext<String>) -> Result<(), !> {
+//! async fn actor(mut ctx: Context<String>) -> Result<(), !> {
 //!     let msg = await!(ctx.receive_next());
 //!     println!("First message: {}", msg);
 //!

--- a/src/channel/oneshot.rs
+++ b/src/channel/oneshot.rs
@@ -11,7 +11,7 @@
 //! ```
 //! #![feature(async_await, await_macro, futures_api, never_type)]
 //!
-//! use heph::actor::ActorContext;
+//! use heph::actor::Context;
 //! use heph::actor_ref::ActorRef;
 //! use heph::channel::oneshot;
 //!
@@ -32,7 +32,7 @@
 //! }
 //!
 //! /// Actor that manages a pool of database connections.
-//! async fn db_manager(mut ctx: ActorContext<DbConnMsg>, mut pool: Vec<DbConn>) -> Result<(), !> {
+//! async fn db_manager(mut ctx: Context<DbConnMsg>, mut pool: Vec<DbConn>) -> Result<(), !> {
 //!     loop {
 //! #       #[allow(unreachable_patterns)]
 //!         match await!(ctx.receive_next()) {
@@ -54,7 +54,7 @@
 //! }
 //!
 //! /// Our actor that uses a database connection.
-//! async fn actor(ctx: ActorContext<()>, mut db_manager: ActorRef<DbConnMsg>) -> Result<(), ()> {
+//! async fn actor(ctx: Context<()>, mut db_manager: ActorRef<DbConnMsg>) -> Result<(), ()> {
 //!     // Create a new one shot channel.
 //!     let (sender, receiver) = oneshot();
 //!     // Send a get request to the database connection actor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,9 @@
 //! ```
 //! # #![feature(async_await, await_macro, futures_api, never_type)]
 //! #
-//! # use heph::actor::ActorContext;
+//! # use heph::actor::Context;
 //! #
-//! async fn actor(mut ctx: ActorContext<String>) -> Result<(), !> {
+//! async fn actor(mut ctx: Context<String>) -> Result<(), !> {
 //!     // Receive a message.
 //!     let msg = await!(ctx.receive_next());
 //!     // Print the message.
@@ -113,7 +113,7 @@ mod util;
 mod waker;
 
 #[doc(no_inline)]
-pub use crate::actor::{Actor, ActorContext, NewActor};
+pub use crate::actor::{Actor, Context, NewActor};
 #[doc(no_inline)]
 pub use crate::actor_ref::ActorRef;
 #[doc(no_inline)]

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -199,9 +199,9 @@ impl<F, M> MessageSelector<M> for F
 
 /// A [`MessageSelector`] implementation that selects the first message.
 ///
-/// Used by [`ActorContext::receive_next`].
+/// Used by [`Context::receive_next`].
 ///
-/// [`ActorContext::receive_next`]: crate::actor::ActorContext::receive_next
+/// [`Context::receive_next`]: crate::actor::Context::receive_next
 #[derive(Debug)]
 pub struct First;
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -13,7 +13,7 @@ use mio_st::net::{TcpListener as MioTcpListener, TcpStream as MioTcpStream};
 use mio_st::poll::PollOption;
 
 use crate::actor::messages::Terminate;
-use crate::actor::{Actor, ActorContext, NewActor};
+use crate::actor::{Actor, Context, NewActor};
 use crate::mailbox::MailBox;
 use crate::net::{interrupted, would_block};
 use crate::supervisor::Supervisor;
@@ -46,7 +46,7 @@ use crate::util::Shared;
 ///
 /// use futures_util::AsyncWriteExt;
 ///
-/// use heph::actor::ActorContext;
+/// use heph::actor::Context;
 /// use heph::log::error;
 /// use heph::net::{TcpListener, TcpListenerError, TcpStream};
 /// use heph::supervisor::SupervisorStrategy;
@@ -94,7 +94,7 @@ use crate::util::Shared;
 /// }
 ///
 /// /// The actor responsible for a single TCP stream.
-/// async fn conn_actor(_ctx: ActorContext<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
+/// async fn conn_actor(_ctx: Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
 /// #   drop(address); // Silence dead code warnings.
 ///     await!(stream.write_all(b"Hello World"))
 /// }
@@ -111,7 +111,7 @@ use crate::util::Shared;
 ///
 /// use futures_util::AsyncWriteExt;
 ///
-/// use heph::actor::ActorContext;
+/// use heph::actor::Context;
 /// use heph::actor::messages::Terminate;
 /// use heph::log::error;
 /// use heph::net::{TcpListener, TcpListenerError, TcpStream};
@@ -156,7 +156,7 @@ use crate::util::Shared;
 /// }
 ///
 /// /// The actor responsible for a single TCP stream.
-/// async fn conn_actor(_ctx: ActorContext<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
+/// async fn conn_actor(_ctx: Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
 /// #   drop(address); // Silence dead code warnings.
 ///     await!(stream.write_all(b"Hello World"))
 /// }
@@ -348,7 +348,7 @@ impl<S, NA> NewActor for NewTcpListener<S, NA>
     type Actor = TcpListener<S, NA>;
     type Error = io::Error;
 
-    fn new(&mut self, mut ctx: ActorContext<Self::Message>, address: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, mut ctx: Context<Self::Message>, address: Self::Argument) -> Result<Self::Actor, Self::Error> {
         let mut system_ref = ctx.system_ref().clone();
         let mut listener = MioTcpListener::bind(address)?;
         system_ref.poller_register(&mut listener, ctx.pid().into(), MioTcpListener::INTERESTS, PollOption::Edge)?;
@@ -389,7 +389,7 @@ macro_rules! try_io {
 impl TcpStream {
     /// Create a new TCP stream and issue a non-blocking connect to the
     /// specified `address`.
-    pub fn connect<M>(ctx: &mut ActorContext<M>, address: SocketAddr) -> io::Result<TcpStream> {
+    pub fn connect<M>(ctx: &mut Context<M>, address: SocketAddr) -> io::Result<TcpStream> {
         let mut stream = MioTcpStream::connect(address)?;
         let pid = ctx.pid();
         ctx.system_ref().poller_register(&mut stream, pid.into(),

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -7,7 +7,7 @@ use std::task::{LocalWaker, Poll};
 use mio_st::net::{ConnectedUdpSocket as MioConnectedUdpSocket, UdpSocket as MioUdpSocket};
 use mio_st::poll::PollOption;
 
-use crate::actor::ActorContext;
+use crate::actor::Context;
 use crate::net::{interrupted, would_block};
 
 /// A macro to try an I/O function.
@@ -42,7 +42,7 @@ impl ConnectedUdpSocket {
     ///
     /// This method first binds a UDP socket to the `local` address, then
     /// connects that socket to `remote` address.
-    pub fn connect<M>(ctx: &mut ActorContext<M>, local: SocketAddr, remote: SocketAddr) -> io::Result<ConnectedUdpSocket> {
+    pub fn connect<M>(ctx: &mut Context<M>, local: SocketAddr, remote: SocketAddr) -> io::Result<ConnectedUdpSocket> {
         let mut socket = MioConnectedUdpSocket::connect(local, remote)?;
         let pid = ctx.pid();
         ctx.system_ref().poller_register(&mut socket, pid.into(),
@@ -97,7 +97,7 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     /// Create a UDP socket binding to the `address`.
-    pub fn bind<M>(ctx: &mut ActorContext<M>, address: SocketAddr) -> io::Result<UdpSocket> {
+    pub fn bind<M>(ctx: &mut Context<M>, address: SocketAddr) -> io::Result<UdpSocket> {
         let mut socket = MioUdpSocket::bind(address)?;
         let pid = ctx.pid();
         ctx.system_ref().poller_register(&mut socket, pid.into(),

--- a/src/scheduler/process/actor.rs
+++ b/src/scheduler/process/actor.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use log::{error, trace};
 
-use crate::actor::{Actor, ActorContext, NewActor};
+use crate::actor::{Actor, Context, NewActor};
 use crate::mailbox::MailBox;
 use crate::scheduler::process::{Priority, Process, ProcessId, ProcessResult};
 use crate::supervisor::{Supervisor, SupervisorStrategy};
@@ -24,7 +24,7 @@ pub struct ActorProcess<S, NA: NewActor> {
     supervisor: S,
     new_actor: NA,
     actor: NA::Actor,
-    /// The inbox of the actor, used in create a new `ActorContext` if the actor
+    /// The inbox of the actor, used in create a new `Context` if the actor
     /// is restarted.
     inbox: Shared<MailBox<NA::Message>>,
     /// Waker used in the futures context.
@@ -82,7 +82,7 @@ impl<S, NA> Process for ActorProcess<S, NA>
                 match this.supervisor.decide(err) {
                     SupervisorStrategy::Restart(arg) => {
                         // Create a new actor.
-                        let ctx = ActorContext::new(this.id, system_ref.clone(), this.inbox.clone());
+                        let ctx = Context::new(this.id, system_ref.clone(), this.inbox.clone());
                         match this.new_actor.new(ctx, arg) {
                             Ok(actor) => {
                                 pinned_actor.set(actor);

--- a/src/scheduler/process/tests.rs
+++ b/src/scheduler/process/tests.rs
@@ -15,7 +15,7 @@ use futures_test::future::{AssertUnmoved, FutureTestExt};
 use futures_util::future::{empty, Empty};
 use mio_st::event::EventedId;
 
-use crate::actor::{ActorContext, NewActor};
+use crate::actor::{Context, NewActor};
 use crate::scheduler::process::{ActorProcess, Priority, Process, ProcessId, ProcessResult};
 use crate::supervisor::{NoSupervisor, SupervisorStrategy};
 use crate::system::ActorSystemRef;
@@ -145,7 +145,7 @@ fn process_ordering() {
     assert_eq!(process2.cmp(process3), Ordering::Less);
 }
 
-async fn ok_actor(mut ctx: ActorContext<()>) -> Result<(), !> {
+async fn ok_actor(mut ctx: Context<()>) -> Result<(), !> {
     let _msg = await!(ctx.receive_next());
     Ok(())
 }
@@ -187,7 +187,7 @@ fn actor_process() {
     assert!(process.runtime() > runtime_after_1_run);
 }
 
-async fn error_actor(mut ctx: ActorContext<()>, fail: bool) -> Result<(), ()> {
+async fn error_actor(mut ctx: Context<()>, fail: bool) -> Result<(), ()> {
     if !fail {
         let _msg = await!(ctx.receive_next());
         Ok(())
@@ -270,7 +270,7 @@ fn restarting_erroneous_actor_process() {
     assert!(process.runtime() > runtime_after_1_run);
 }
 
-async fn sleepy_actor(ctx: ActorContext<()>, sleep_time: Duration) -> Result<(), !> {
+async fn sleepy_actor(ctx: Context<()>, sleep_time: Duration) -> Result<(), !> {
     sleep(sleep_time);
     drop(ctx);
     Ok(())
@@ -314,7 +314,7 @@ impl NewActor for TestAssertUnmovedNewActor {
     type Actor = AssertUnmoved<Empty<Result<(), !>>>;
     type Error = !;
 
-    fn new(&mut self, ctx: ActorContext<Self::Message>, _arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, ctx: Context<Self::Message>, _arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         // In the test we need the access to the inbox, to achieve that we can't
         // drop the context, so we forget about it here leaking the inbox.
         forget(ctx);

--- a/src/scheduler/tests.rs
+++ b/src/scheduler/tests.rs
@@ -8,7 +8,7 @@ use crossbeam_channel as channel;
 use futures_test::future::{AssertUnmoved, FutureTestExt};
 use futures_util::future::{empty, Empty};
 
-use crate::actor::{ActorContext, NewActor};
+use crate::actor::{Context, NewActor};
 use crate::scheduler::process::{Process, ProcessId, ProcessResult};
 use crate::scheduler::{Priority, ProcessState, Scheduler};
 use crate::supervisor::NoSupervisor;
@@ -191,7 +191,7 @@ fn scheduler_run_order() {
     assert_eq!(*run_order.borrow(), vec![2, 1, 0]);
 }
 
-async fn actor(mut ctx: ActorContext<()>) -> Result<(), !> {
+async fn actor(mut ctx: Context<()>) -> Result<(), !> {
     let _msg = await!(ctx.receive_next());
     Ok(())
 }
@@ -243,7 +243,7 @@ impl NewActor for TestNewActor {
     type Actor = AssertUnmoved<Empty<Result<(), !>>>;
     type Error = !;
 
-    fn new(&mut self, ctx: ActorContext<Self::Message>, _arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
+    fn new(&mut self, ctx: Context<Self::Message>, _arg: Self::Argument) -> Result<Self::Actor, Self::Error> {
         // In the test we need the access to the inbox, to achieve that we can't
         // drop the context, so we forget about it here leaking the inbox.
         mem::forget(ctx);

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -36,7 +36,7 @@
 //! ```
 //! #![feature(async_await, await_macro, futures_api, never_type)]
 //!
-//! use heph::actor::ActorContext;
+//! use heph::actor::Context;
 //! use heph::log::{self, error};
 //! use heph::supervisor::SupervisorStrategy;
 //! use heph::system::{ActorOptions, ActorSystem, RuntimeError};
@@ -66,7 +66,7 @@
 //! }
 //!
 //! /// Our badly behaving actor.
-//! async fn bad_actor(_ctx: ActorContext<!>) -> Result<(), Error> {
+//! async fn bad_actor(_ctx: Context<!>) -> Result<(), Error> {
 //!     Err(Error)
 //! }
 //! ```
@@ -124,7 +124,7 @@ impl<F, E, Arg> Supervisor<E, Arg> for F
 /// ```
 /// #![feature(async_await, await_macro, futures_api, never_type)]
 ///
-/// use heph::actor::ActorContext;
+/// use heph::actor::Context;
 /// use heph::supervisor::NoSupervisor;
 /// use heph::system::{ActorOptions, ActorSystem, RuntimeError};
 ///
@@ -140,7 +140,7 @@ impl<F, E, Arg> Supervisor<E, Arg> for F
 /// }
 ///
 /// /// Our actor that never returns an error.
-/// async fn actor(ctx: ActorContext<&'static str>) -> Result<(), !> {
+/// async fn actor(ctx: Context<&'static str>) -> Result<(), !> {
 /// #   drop(ctx); // Silence dead code warnings.
 ///     Ok(())
 /// }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - [`ActorSystem`]: is the actor system, used to run all actors.
 //! - [`ActorSystemRef`]: is a reference to the actor system, used to get access
-//!   to the actor system's internals, often via the [`ActorContext`], e.g. see
+//!   to the actor system's internals, often via the [`Context`], e.g. see
 //!   [`TcpStream.connect`].
 //!
 //! See [`ActorSystem`] for documentation on how to run an actor system. For
@@ -12,7 +12,7 @@
 //!
 //! [`ActorSystem`]: struct.ActorSystem.html
 //! [`ActorSystemRef`]: struct.ActorSystemRef.html
-//! [`ActorContext`]: ../actor/struct.ActorContext.html
+//! [`Context`]: ../actor/struct.Context.html
 //! [`TcpStream.connect`]: ../net/struct.TcpStream.html#method.connect
 //!
 //! # Actor Registry
@@ -64,7 +64,7 @@ use mio_st::event::{Evented, EventedId, Events, Ready};
 use mio_st::poll::{Interests, PollOption, Poller};
 use num_cpus;
 
-use crate::actor::{Actor, ActorContext, NewActor};
+use crate::actor::{Actor, Context, NewActor};
 use crate::actor_ref::{ActorRef, Local};
 use crate::mailbox::MailBox;
 use crate::scheduler::{ProcessId, Scheduler, SchedulerRef};
@@ -123,7 +123,7 @@ pub use self::options::ActorOptions;
 /// ```
 /// #![feature(async_await, await_macro, futures_api, never_type)]
 ///
-/// use heph::actor::ActorContext;
+/// use heph::actor::Context;
 /// use heph::supervisor::NoSupervisor;
 /// use heph::system::{ActorOptions, ActorSystem, ActorSystemRef, RuntimeError};
 ///
@@ -151,7 +151,7 @@ pub use self::options::ActorOptions;
 /// }
 ///
 /// /// Our actor that greets people.
-/// async fn greeter_actor(mut ctx: ActorContext<&'static str>, message: &'static str) -> Result<(), !> {
+/// async fn greeter_actor(mut ctx: Context<&'static str>, message: &'static str) -> Result<(), !> {
 ///     let name = await!(ctx.receive_next());
 ///     println!("{} {}", message, name);
 ///     Ok(())
@@ -505,7 +505,7 @@ impl ActorSystemRef {
         // Create our actor context and our actor with it.
         let mailbox = Shared::new(MailBox::new(pid, self.clone()));
         let actor_ref = ActorRef::<NA::Message, Local>::new(mailbox.downgrade());
-        let ctx = ActorContext::new(pid, system_ref, mailbox.clone());
+        let ctx = Context::new(pid, system_ref, mailbox.clone());
         let actor = new_actor.new(ctx, arg).map_err(AddActorError::NewActor)?;
 
         // Add the actor to the scheduler.
@@ -566,7 +566,7 @@ impl ActorSystemRef {
     /// ```
     /// #![feature(async_await, await_macro, futures_api, never_type)]
     ///
-    /// use heph::actor::ActorContext;
+    /// use heph::actor::Context;
     /// use heph::supervisor::NoSupervisor;
     /// use heph::system::{ActorOptions, ActorSystem, ActorSystemRef, RuntimeError};
     ///
@@ -598,7 +598,7 @@ impl ActorSystemRef {
     /// }
     ///
     /// /// Our actor implemented as an asynchronous function.
-    /// async fn actor(ctx: ActorContext<()>) -> Result<(), !> {
+    /// async fn actor(ctx: Context<()>) -> Result<(), !> {
     ///     // ...
     /// #   drop(ctx); // Silence dead code warnings.
     /// #   Ok(())

--- a/src/test.rs
+++ b/src/test.rs
@@ -23,7 +23,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{LocalWaker, Poll};
 
-use crate::actor::{Actor, ActorContext, NewActor};
+use crate::actor::{Actor, Context, NewActor};
 use crate::actor_ref::{ActorRef, Local};
 use crate::mailbox::MailBox;
 use crate::scheduler::ProcessId;
@@ -52,7 +52,7 @@ pub fn init_actor<NA>(mut new_actor: NA, arg: NA::Argument) -> Result<(NA::Actor
     let inbox = Shared::new(MailBox::new(pid, system_ref.clone()));
     let actor_ref = ActorRef::<NA::Message, Local>::new(inbox.downgrade());
 
-    let ctx = ActorContext::new(pid, system_ref, inbox);
+    let ctx = Context::new(pid, system_ref, inbox);
     let actor = new_actor.new(ctx, arg)?;
 
     Ok((actor, actor_ref))


### PR DESCRIPTION
Because it's shorter to type. If the name is not clear enough `actor::Context` can be used by using `heph::actor`.