### PR TITLE
Remove Waker from ActorProcess

### DIFF
--- a/examples/99_stress_memory.rs
+++ b/examples/99_stress_memory.rs
@@ -1,6 +1,6 @@
 //! This is just a memory stress test of the system.
 //!
-//! Currently using 10 million "actors" this test uses 1.89 GB.
+//! Currently using 10 million "actors" this test uses 1.74 GB.
 
 #![feature(async_await, futures_api, never_type)]
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -4,7 +4,6 @@ use std::cell::RefMut;
 use std::collections::BinaryHeap;
 use std::mem;
 use std::pin::Pin;
-use std::task::Waker;
 
 use log::{debug, trace};
 use slab::Slab;
@@ -145,7 +144,6 @@ impl<'s> AddingProcess<'s> {
     /// Add a new inactive actor process to the scheduler.
     pub fn add_actor<S, NA>(self, priority: Priority, supervisor: S,
         new_actor: NA, actor: NA::Actor, mailbox: Shared<MailBox<NA::Message>>,
-        waker: Waker
     )
         where S: Supervisor<<NA::Actor as Actor>::Error, NA::Argument> + 'static,
               NA: NewActor + 'static,
@@ -153,7 +151,7 @@ impl<'s> AddingProcess<'s> {
         let pid = self.pid();
         debug!("adding new actor process: pid={}", pid);
         let process = Box::pin(ActorProcess::new(pid, priority, supervisor,
-            new_actor, actor, mailbox, waker));
+            new_actor, actor, mailbox));
         self.add_process(pid, process)
     }
 

--- a/src/scheduler/process/mod.rs
+++ b/src/scheduler/process/mod.rs
@@ -65,7 +65,7 @@ pub trait Process: fmt::Debug {
 
     /// Run the process.
     ///
-    /// Once the process returns `ProcessResult::Complete` it will be remove
+    /// Once the process returns `ProcessResult::Complete` it will be removed
     /// from the system and no longer run.
     ///
     /// If it returns `ProcessResult::Pending` it will be considered inactive

--- a/src/scheduler/process/tests.rs
+++ b/src/scheduler/process/tests.rs
@@ -16,7 +16,6 @@ use mio_st::event::EventedId;
 
 use crate::actor::{Context, NewActor};
 use crate::scheduler::process::{ActorProcess, Priority, Process, ProcessId, ProcessResult};
-use crate::scheduler::tests::nop_waker;
 use crate::supervisor::{NoSupervisor, SupervisorStrategy};
 use crate::system::ActorSystemRef;
 use crate::test::{init_actor, system_ref};
@@ -159,7 +158,7 @@ fn actor_process() {
     // Create our process.
     let inbox = actor_ref.get_inbox().unwrap();
     let process = ActorProcess::new(ProcessId(0), Priority::NORMAL, NoSupervisor,
-        new_actor, actor, inbox, nop_waker());
+        new_actor, actor, inbox);
     let mut process = Box::pin(process);
 
     assert_eq!(process.id(), ProcessId(0));
@@ -200,7 +199,7 @@ fn erroneous_actor_process() {
     // Create our process.
     let inbox = actor_ref.get_inbox().unwrap();
     let process = ActorProcess::new(ProcessId(0), Priority::NORMAL,
-        |_err| SupervisorStrategy::Stop, new_actor, actor, inbox, nop_waker());
+        |_err| SupervisorStrategy::Stop, new_actor, actor, inbox);
     let mut process = Box::pin(process);
 
     assert_eq!(process.id(), ProcessId(0));
@@ -229,8 +228,8 @@ fn restarting_erroneous_actor_process() {
 
     // Create our process.
     let inbox = actor_ref.get_inbox().unwrap();
-    let process = ActorProcess::new(ProcessId(0), Priority::NORMAL, supervisor, new_actor,
-        actor, inbox, nop_waker());
+    let process = ActorProcess::new(ProcessId(0), Priority::NORMAL, supervisor,
+        new_actor, actor, inbox);
     let mut process: Pin<Box<dyn Process>> = Box::pin(process);
 
     assert_eq!(process.id(), ProcessId(0));
@@ -272,7 +271,7 @@ fn actor_process_runtime_increase() {
     // Create our process.
     let inbox = actor_ref.get_inbox().unwrap();
     let process = ActorProcess::new(ProcessId(0), Priority::NORMAL, NoSupervisor,
-        new_actor, actor, inbox, nop_waker());
+        new_actor, actor, inbox);
     let mut process = Box::pin(process);
 
     assert_eq!(process.id(), ProcessId(0));
@@ -309,7 +308,7 @@ fn actor_process_assert_actor_unmoved() {
     // Create our process.
     let inbox = actor_ref.get_inbox().unwrap();
     let process = ActorProcess::new(ProcessId(0), Priority::NORMAL, NoSupervisor,
-        TestAssertUnmovedNewActor, actor, inbox, nop_waker());
+        TestAssertUnmovedNewActor, actor, inbox);
     let mut process: Pin<Box<dyn Process>> = Box::pin(process);
 
     assert_eq!(process.id(), ProcessId(0));

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -520,14 +520,13 @@ impl ActorSystemRef {
         let ctx = Context::new(pid, system_ref, mailbox.clone());
         let actor = new_actor.new(ctx, arg).map_err(AddActorError::NewActor)?;
 
-        let waker = new_waker(*waker_id, pid);
         if options.schedule {
-            waker.wake()
+            new_waker(*waker_id, pid).wake()
         }
 
         // Add the actor to the scheduler.
         process_entry.add_actor(options.priority, supervisor, new_actor, actor,
-            mailbox, waker);
+            mailbox);
 
         if options.register && registry.borrow_mut().register::<NA>(actor_ref.clone()).is_some() {
             panic!("can't overwrite a previously registered actor in the Actor Registry");

--- a/src/system/waker.rs
+++ b/src/system/waker.rs
@@ -95,6 +95,7 @@ pub fn init_waker(awakener: Awakener, notifications: Sender<ProcessId>) -> Waker
 ///
 /// `init_waker` must be called before calling this function to get a `WakerId`.
 pub fn new_waker(waker_id: WakerId, pid: ProcessId) -> Waker {
+    // TODO: try to remove this check and make it into an unsafe function.
     if pid.0 >= 2_usize.pow(WAKER_DATA_BITS as u32 - THREAD_ID_BITS as u32) {
         panic!("Process id too large for waker");
     }


### PR DESCRIPTION
Reduces the memory usage of the stress memory example by 250 MB.

Updates #90.