### PR TITLE
Rename tcp::Actor to tcp::Server

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -4,15 +4,15 @@
 //!
 //! * [Transmission Control Protocol] (TCP) module provides two main types:
 //!   * A [TCP stream] between a local and a remote socket.
-//!   * A [TCP socket server], listening for connections.
-//!   * A [TCP actor], listens for connections and starts a new actor for each.
+//!   * A [TCP listening socket], a socket used to listen for connections.
+//!   * A [TCP server], listens for connections and starts a new actor for each.
 //! * [User Datagram Protocol] (UDP) only provides a single socket type:
 //!   * [`UdpSocket`].
 //!
 //! [Transmission Control Protocol]: crate::net::tcp
 //! [TCP stream]: crate::net::TcpStream
-//! [TCP socket server]: crate::net::TcpListener
-//! [TCP actor]: crate::net::tcp::Actor
+//! [TCP listening socket]: crate::net::TcpListener
+//! [TCP server]: crate::net::tcp::Server
 //! [User Datagram Protocol]: crate::net::udp
 //! [`UdpSocket`]: crate::net::UdpSocket
 
@@ -32,8 +32,6 @@ macro_rules! try_io {
         }
     };
 }
-
-mod tcp_actor;
 
 pub mod tcp;
 pub mod udp;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -4,13 +4,14 @@
 //!
 //!  * [`TcpListener`] listens for incoming connections.
 //!  * [`TcpStream`] represents a single TCP connection.
-//!  * [`tcp::Actor`] is an [`Actor`] that listens for incoming connections and
-//!    starts a new actor for each.
+//!  * [`tcp::Server`] is an [`Actor`] that listens for incoming connections and
+//!    starts a new actor for each. A server can be created by using
+//!    [`setup_server`].
 //!
-//! [`tcp::Actor`]: crate::net::tcp::Actor
+//! [`tcp::Server`]: crate::net::tcp::Server
 //! [`Actor`]: crate::actor::Actor
 //! [`tcp::NewListener`]: crate::net::tcp::NewListener
-//! [`NewActor`]: crate::actor::NewActor
+//! [`setup_server`]: crate::net::tcp::setup_server
 
 use std::future::Future;
 use std::io::{self, Read, Write};
@@ -27,7 +28,9 @@ use gaea::os::RegisterOption;
 
 use crate::actor;
 
-pub use super::tcp_actor::{Actor, ListenerError, Message, NewListener};
+mod server;
+
+pub use self::server::{setup_server, Server, ServerError, ServerMessage, ServerSetup};
 
 /// A TCP socket listener.
 ///


### PR DESCRIPTION
And move the module to be a submodule of the net::tcp module, but still not export it.