### PR TITLE
Update all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,18 @@ test = []
 
 [dependencies]
 crossbeam-channel    = "0.3.9"
-futures-core-preview = "0.3.0-alpha.18"
-futures-io-preview   = "0.3.0-alpha.18"
-log                  = "0.4.6"
+futures-core-preview = "=0.3.0-alpha.19"
+futures-io-preview   = "=0.3.0-alpha.19"
+log                  = "0.4.8"
 # Replace with Mio v0.7 once released.
 mio                  = { git = "https://github.com/tokio-rs/mio" }
 mio-pipe             = { git = "https://github.com/Thomasdezeeuw/mio-pipe" }
 mio-signals          = { git = "https://github.com/Thomasdezeeuw/mio-signals" }
-num_cpus             = "1.8.0"
-slab                 = "0.4.0"
+num_cpus             = "1.10.1"
+slab                 = "0.4.2"
 std-logger           = "0.3.4"
 
 [dev-dependencies]
-futures-test-preview = "0.3.0-alpha.18"
-futures-util-preview = { version = "0.3.0-alpha.18", features = ["nightly", "async-await", "select-macro"] }
+futures-test-preview = "=0.3.0-alpha.19"
+futures-util-preview = { version = "=0.3.0-alpha.19", features = ["unstable", "select-macro"] }
 lazy_static          = "1.1.0"

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -20,7 +20,7 @@ use std::task::{self, Poll};
 
 use futures_core::future::FusedFuture;
 use futures_core::stream::{FusedStream, Stream};
-use futures_io::{AsyncRead, AsyncWrite, Initializer};
+use futures_io::{AsyncRead, AsyncWrite};
 use mio::{net, Interests};
 
 use crate::actor;
@@ -444,10 +444,6 @@ impl<'a> Future for Peek<'a> {
 }
 
 impl AsyncRead for TcpStream {
-    unsafe fn initializer(&self) -> Initializer {
-        Initializer::nop()
-    }
-
     fn poll_read(
         mut self: Pin<&mut Self>,
         _ctx: &mut task::Context<'_>,


### PR DESCRIPTION
The big one is futures v0.3.0-aplha.19, not major only remove the
initializer API from AsyncRead, which we only used for TcpStream, not a
big problem.