### PR TITLE
Don't ignore signals if no handler actors are setup

### DIFF
--- a/examples/2_my_ip.rs
+++ b/examples/2_my_ip.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), RuntimeError<io::Error>> {
             let server_ref = runtime_ref.try_spawn(ServerSupervisor, server, (), options)?;
 
             // The server can handle the interrupt, terminate and quit signals,
-            // so it will perform a cleanup shutdown for us.
+            // so it will perform a clean shutdown for us.
             runtime_ref.receive_signals(server_ref.try_map());
 
             Ok(())

--- a/src/rt/signal.rs
+++ b/src/rt/signal.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 /// Process signal.
 ///
 /// Actors can receive signals by calling [`RuntimeRef::receive_signals`]
@@ -44,5 +46,24 @@ impl Signal {
             mio_signals::Signal::Terminate => Signal::Terminate,
             mio_signals::Signal::Quit => Signal::Quit,
         }
+    }
+
+    /// Whether or not the `Signal` is considered a "stopping" signal.
+    pub(super) fn should_stop(self) -> bool {
+        true
+    }
+}
+
+impl fmt::Display for Signal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let alternate = f.alternate();
+        f.write_str(match (self, alternate) {
+            (Signal::Interrupt, false) => "interrupt",
+            (Signal::Interrupt, true) => "interrupt (SIGINT)",
+            (Signal::Terminate, false) => "terminate",
+            (Signal::Terminate, true) => "terminate (SIGTERM)",
+            (Signal::Quit, false) => "quit",
+            (Signal::Quit, true) => "quit (SIGQUIT)",
+        })
     }
 }


### PR DESCRIPTION
Instead we'll return an error in no actors are setup to handle process
signals.

Fixes #258