### PR TITLE
Rename ActorOptions::schedule to mark_ready

### DIFF
--- a/examples/1b_hello_world.rs
+++ b/examples/1b_hello_world.rs
@@ -12,12 +12,12 @@ fn main() -> Result<(), RuntimeError> {
 fn add_greeter_actor(mut system_ref: RuntimeRef) -> Result<(), !> {
     // As shown in example 1 actors don't do anything went they are not awoken.
     // In example 1 we send the actor a message to wake it, this example will
-    // use the `schedule` actor option.
-    // The `schedule` actor option will wake (schedule) the actor when it is
+    // use the `mark_ready` actor option.
+    // The `mark_ready` actor option will mark the actor ready to run when it is
     // added to the actor system for the first time. This is useful for actors
-    // that don't have any (initial) external wakers, for example in the case of
-    // our `greeter_actor` below.
-    let options = ActorOptions::default().schedule();
+    // that don't have any (initial) external wake events, for example in the
+    // case of our `greeter_actor` below.
+    let options = ActorOptions::default().mark_ready();
     let actor = greeter_actor as fn(_) -> _;
     system_ref.spawn(NoSupervisor, actor, (), options);
 
@@ -26,7 +26,7 @@ fn add_greeter_actor(mut system_ref: RuntimeRef) -> Result<(), !> {
 
 /// Our greeter actor.
 ///
-/// Note: this needs the `schedule` options when adding it to the actor system.
+/// Note: this needs the `mark_ready` option when adding it to the actor system.
 async fn greeter_actor(_: actor::Context<!>) -> Result<(), !> {
     println!("Hello World");
     Ok(())

--- a/examples/99_stress_memory.rs
+++ b/examples/99_stress_memory.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), RuntimeError> {
                 NoSupervisor,
                 sleepy_actor,
                 (),
-                ActorOptions::default().schedule(),
+                ActorOptions::default().mark_ready(),
             );
 
             info!("Elapsed: {:?}", start.elapsed());

--- a/src/log.rs
+++ b/src/log.rs
@@ -33,7 +33,7 @@
 //!
 //! fn add_greeter_actor(mut system_ref: RuntimeRef) -> Result<(), !> {
 //!     let actor = greeter_actor as fn(_) -> _;
-//!     system_ref.spawn(NoSupervisor, actor, (), ActorOptions::default().schedule());
+//!     system_ref.spawn(NoSupervisor, actor, (), ActorOptions::default().mark_ready());
 //!     Ok(())
 //! }
 //!

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -70,8 +70,8 @@ pub use server::{Server, ServerError, ServerMessage, ServerSetup};
 ///     let address = "127.0.0.1:8000".parse().unwrap();
 ///
 ///     runtime_ref.spawn(supervisor, actor as fn(_, _) -> _, address,
-///         ActorOptions::default().schedule());
-/// #   runtime_ref.spawn(supervisor, client as fn(_, _) -> _, address, ActorOptions::default().schedule());
+///         ActorOptions::default().mark_ready());
+/// #   runtime_ref.spawn(supervisor, client as fn(_, _) -> _, address, ActorOptions::default().mark_ready());
 ///
 ///     Ok(())
 /// }
@@ -139,8 +139,8 @@ pub use server::{Server, ServerError, ServerMessage, ServerSetup};
 ///     let address = "127.0.0.1:8000".parse().unwrap();
 ///
 ///     runtime_ref.spawn(supervisor, actor as fn(_, _) -> _, address,
-///         ActorOptions::default().schedule());
-/// #   runtime_ref.spawn(supervisor, client as fn(_, _) -> _, address, ActorOptions::default().schedule());
+///         ActorOptions::default().mark_ready());
+/// #   runtime_ref.spawn(supervisor, client as fn(_, _) -> _, address, ActorOptions::default().mark_ready());
 ///
 ///     Ok(())
 /// }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -70,11 +70,11 @@ pub enum Connected {}
 ///
 ///     // Add our server actor.
 ///     runtime.spawn(supervisor, echo_server as fn(_, _) -> _, address,
-///         ActorOptions::default().schedule());
+///         ActorOptions::default().mark_ready());
 ///
 ///     // Add our client actor.
 ///     runtime.spawn(supervisor, client as fn(_, _) -> _, address,
-///         ActorOptions::default().schedule());
+///         ActorOptions::default().mark_ready());
 ///
 ///     Ok(())
 /// }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -403,7 +403,7 @@ impl RuntimeRef {
         let ctx = actor::Context::new(pid, runtime_ref, inbox.ctx_inbox(), inbox_ref.clone());
         let actor = new_actor.new(ctx, arg).map_err(AddActorError::NewActor)?;
 
-        if options.should_schedule() {
+        if options.is_ready() {
             waker::new(*waker_id, pid).wake()
         }
 

--- a/src/rt/options.rs
+++ b/src/rt/options.rs
@@ -30,7 +30,7 @@ pub use crate::rt::scheduler::Priority;
 #[derive(Clone, Debug)]
 pub struct ActorOptions {
     priority: Priority,
-    schedule: bool,
+    ready: bool,
 }
 
 impl ActorOptions {
@@ -45,25 +45,24 @@ impl ActorOptions {
         self
     }
 
-    /// Returns `true` if the actor should be scheduled when spawned.
+    /// Returns `true` if the actor is ready to run when spawned.
     ///
-    /// See [`schedule`] for more information.
+    /// See [`mark_ready`] for more information.
     ///
-    /// [`schedule`]: ActorOptions::schedule
-    pub const fn should_schedule(&self) -> bool {
-        self.schedule
+    /// [`mark_ready`]: ActorOptions::mark_ready
+    pub const fn is_ready(&self) -> bool {
+        self.ready
     }
 
-    /// This option will schedule the actor to run when spawned.
+    /// This option will mark the actor as ready to run when spawned.
     ///
     /// By default newly spawned actors will wait for an external event before
-    /// they start running. This can happen for example by a message send to
-    /// them, or a [`TcpStream`] becoming ready to read or write.
+    /// they start running. This external event can for example be a message
+    /// send to them, or a [`TcpStream`] becoming ready to read or write.
     ///
     /// [`TcpStream`]: crate::net::TcpStream
-    pub const fn schedule(mut self) -> Self {
-        // TODO: better name: auto_run, auto_schedule, start_running?
-        self.schedule = true;
+    pub const fn mark_ready(mut self) -> Self {
+        self.ready = true;
         self
     }
 }
@@ -72,7 +71,7 @@ impl Default for ActorOptions {
     fn default() -> ActorOptions {
         ActorOptions {
             priority: Priority::default(),
-            schedule: false,
+            ready: false,
         }
     }
 }

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -66,7 +66,7 @@
 //!     Runtime::new()
 //!         .with_setup(|mut runtime_ref| {
 //!             runtime_ref.spawn(supervisor, bad_actor as fn(_) -> _, (),
-//!                 ActorOptions::default().schedule());
+//!                 ActorOptions::default().mark_ready());
 //!             Ok(())
 //!         })
 //!         .start()
@@ -219,7 +219,7 @@ where
 ///     Runtime::new()
 ///         .with_setup(|mut runtime_ref| {
 ///             runtime_ref.spawn(NoSupervisor, actor as fn(_) -> _, (),
-///                 ActorOptions::default().schedule());
+///                 ActorOptions::default().mark_ready());
 ///             Ok(())
 ///         })
 ///         .start()

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -52,7 +52,7 @@ pub struct DeadlinePassed;
 /// #
 /// # fn setup(mut runtime_ref: RuntimeRef) -> Result<(), !> {
 /// #   let actor = actor as fn(_) -> _;
-/// #   let options = ActorOptions::default().schedule();
+/// #   let options = ActorOptions::default().mark_ready();
 /// #   runtime_ref.spawn(NoSupervisor, actor, (), options);
 /// #   Ok(())
 /// # }
@@ -150,7 +150,7 @@ impl actor::Bound for Timer {
 /// #
 /// # fn setup(mut runtime_ref: RuntimeRef) -> Result<(), !> {
 /// #   let actor = actor as fn(_) -> _;
-/// #   let options = ActorOptions::default().schedule();
+/// #   let options = ActorOptions::default().mark_ready();
 /// #   runtime_ref.spawn(NoSupervisor, actor, (), options);
 /// #   Ok(())
 /// # }
@@ -281,7 +281,7 @@ impl<Fut> actor::Bound for Deadline<Fut> {
 /// #
 /// # fn setup(mut runtime_ref: RuntimeRef) -> Result<(), !> {
 /// #   let actor = actor as fn(_) -> _;
-/// #   let options = ActorOptions::default().schedule();
+/// #   let options = ActorOptions::default().mark_ready();
 /// #   runtime_ref.spawn(NoSupervisor, actor, (), options);
 /// #   Ok(())
 /// # }


### PR DESCRIPTION
To match the terminology used in the scheduler.

Fixes #221.