### PR TITLE
Add ActorRef::send

### DIFF
--- a/examples/1_hello_world.rs
+++ b/examples/1_hello_world.rs
@@ -29,7 +29,7 @@ fn add_greeter_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
     // runtime would run forever, without ever making progress (try this by
     // commenting out the send below!). So we'll send our actor a message via an
     // actor reference, which is a reference to the actor inside the runtime.
-    actor_ref.send("World").unwrap();
+    actor_ref.try_send("World").unwrap();
 
     Ok(())
 }

--- a/examples/1_hello_world.rs
+++ b/examples/1_hello_world.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), rt::Error> {
 
 /// The is the setup function used in the runtime.
 fn add_greeter_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
-    // spawn our `greeter_actor` onto the runtime.
+    // Spawn our `greeter_actor` onto the runtime.
     // All actors need supervision, however our actor doesn't return an error
     // (it uses `!`, the never type, as error), because of this we'll use the
     // `NoSupervisor`, which is a supervisor that does nothing and can't be
@@ -28,7 +28,7 @@ fn add_greeter_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
     // for example by sending them a message. If we didn't send this message the
     // runtime would run forever, without ever making progress (try this by
     // commenting out the send below!). So we'll send our actor a message via an
-    // actor reference, which is a reference to the actor inside the runtime.
+    // actor reference.
     actor_ref.try_send("World").unwrap();
 
     Ok(())
@@ -39,7 +39,7 @@ fn add_greeter_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
 /// We'll receive a single message and print it.
 async fn greeter_actor(mut ctx: actor::Context<&'static str>) -> Result<(), !> {
     // All actors have an actor context, which give the actor access to, among
-    // other things, its inbox from which we can receive a message.
+    // other things, its inbox from which it can receive a message.
     let name = ctx.receive_next().await;
     println!("Hello {}", name);
     Ok(())

--- a/examples/4_sync_actor.rs
+++ b/examples/4_sync_actor.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), rt::Error> {
     let actor_ref = runtime.spawn_sync_actor(NoSupervisor, actor, "Bye", options)?;
 
     // Just like with any actor reference we can send the actor a message.
-    actor_ref.send("Hello world".to_string()).unwrap();
+    actor_ref.try_send("Hello world".to_string()).unwrap();
     // We need to drop the reference here to ensure the actor stops.
     // The actor contains a `while` loop receiving messages (see the `actor`
     // function), that only stops iterating once all actor reference to it are

--- a/examples/6_process_signals.rs
+++ b/examples/6_process_signals.rs
@@ -21,14 +21,14 @@ fn main() -> Result<(), rt::Error> {
     let options = SyncActorOptions::default();
     let actor_ref = runtime.spawn_sync_actor(NoSupervisor, sync_actor, (), options)?;
     // Send it message
-    actor_ref.send("Hello sync actor").unwrap();
+    actor_ref.try_send("Hello sync actor").unwrap();
     // Register our actor reference to receive process signals.
     runtime.receive_signals(actor_ref.try_map());
 
     // Thread-safe actor (following the same structure as synchronous actors).
     let thread_safe_actor = thread_safe_actor as fn(_) -> _;
     let actor_ref = runtime.spawn(NoSupervisor, thread_safe_actor, (), ActorOptions::default());
-    actor_ref.send("Hello thread safe actor").unwrap();
+    actor_ref.try_send("Hello thread safe actor").unwrap();
     runtime.receive_signals(actor_ref.try_map());
 
     // Thread-local actor (following the same structure as synchronous actors).
@@ -36,7 +36,7 @@ fn main() -> Result<(), rt::Error> {
         let local_actor = local_actor as fn(_) -> _;
         let actor_ref =
             runtime_ref.spawn_local(NoSupervisor, local_actor, (), ActorOptions::default());
-        actor_ref.send("Hello thread local actor").unwrap();
+        actor_ref.try_send("Hello thread local actor").unwrap();
         runtime_ref.receive_signals(actor_ref.try_map());
 
         Ok(())

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -164,7 +164,7 @@ pub trait NewActor {
     ///             // Now we can use the reference to send the actor a message.
     ///             // We don't have to use `Message` type we can just use
     ///             // `String`, because `Message` implements `From<String>`.
-    ///             actor_ref.send("Hello world".to_owned()).unwrap();
+    ///             actor_ref.try_send("Hello world".to_owned()).unwrap();
     ///             Ok(())
     ///         })
     ///         .start()
@@ -297,7 +297,7 @@ pub trait NewActor {
     ///         ActorOptions::default())?;
     ///     # let actor_ref =
     ///     runtime_ref.try_spawn_local(ServerSupervisor, server, (), ActorOptions::default())?;
-    ///     # actor_ref.send(Terminate).unwrap();
+    ///     # actor_ref.try_send(Terminate).unwrap();
     ///     Ok(())
     /// }
     ///

--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -23,7 +23,7 @@
 //!     let actor_ref = runtime.spawn_sync_actor(NoSupervisor, actor, "Bye", options)?;
 //!
 //!     // Just like with any actor reference we can send the actor a message.
-//!     actor_ref.send("Hello world".to_string()).unwrap();
+//!     actor_ref.try_send("Hello world".to_string()).unwrap();
 //!
 //!     // And now we start the runtime.
 //!     runtime.start()
@@ -96,10 +96,10 @@ use crate::actor::message_select::{MessageSelector, Messages};
 ///     let actor_ref = runtime.spawn_sync_actor(NoSupervisor, actor, (), options)?;
 ///
 ///     // Just like with any actor reference we can send the actor a message.
-///     actor_ref.send("Hello world".to_string()).unwrap();
+///     actor_ref.try_send("Hello world".to_string()).unwrap();
 ///
 ///     # let actor_ref: ActorRef<Signal> = actor_ref.try_map();
-///     # actor_ref.send(Signal::Interrupt).unwrap();
+///     # actor_ref.try_send(Signal::Interrupt).unwrap();
 ///
 ///     // And now we start the runtime.
 ///     runtime.start()

--- a/src/actor/tests.rs
+++ b/src/actor/tests.rs
@@ -38,7 +38,7 @@ fn test_local_actor_context() {
     assert_eq!(test::poll_future(Pin::new(&mut recv_future)), Poll::Pending);
 
     // Send my self a message, and we should be able to retrieve it.
-    actor_ref.send(()).unwrap();
+    actor_ref.try_send(()).unwrap();
     let res = test::poll_future(Pin::new(&mut recv_future));
     assert_eq!(res, Poll::Ready(()));
 }

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -253,8 +253,8 @@ where
 ///         ActorOptions::default());
 ///
 ///     // We'll send our actor two messages.
-///     actor_ref.send("Message 1".to_owned()).unwrap();
-///     actor_ref.send("Message 2".to_owned()).unwrap();
+///     actor_ref.try_send("Message 1".to_owned()).unwrap();
+///     actor_ref.try_send("Message 2".to_owned()).unwrap();
 ///     Ok(())
 /// }
 ///
@@ -302,11 +302,11 @@ impl<M> MessageSelector<M> for First {
 ///         ActorOptions::default());
 ///
 ///     // We'll send our actor two messages, one normal one and a priority one.
-///     actor_ref.send(Message {
+///     actor_ref.try_send(Message {
 ///         priority: 1,
 ///         msg: "Normal message".to_owned(),
 ///     }).unwrap();
-///     actor_ref.send(Message {
+///     actor_ref.try_send(Message {
 ///         priority: 100,
 ///         msg: "Priority message".to_owned(),
 ///     }).unwrap();

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -253,7 +253,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 ///     let options = ActorOptions::default().with_priority(Priority::LOW);
 ///     # let actor_ref =
 ///     runtime_ref.try_spawn_local(ServerSupervisor, server, (), options)?;
-///     # actor_ref.send(Terminate).unwrap();
+///     # actor_ref.try_send(Terminate).unwrap();
 ///
 ///     Ok(())
 /// }
@@ -346,7 +346,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 ///     // Because the server is just another actor we can send it messages.
 ///     // Here we'll send it a terminate message so it will gracefully
 ///     // shutdown.
-///     server_ref.send(Terminate).unwrap();
+///     server_ref.try_send(Terminate).unwrap();
 ///
 ///     Ok(())
 /// }
@@ -428,7 +428,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 ///     let options = ActorOptions::default().with_priority(Priority::LOW);
 ///     # let actor_ref =
 ///     runtime.try_spawn(ServerSupervisor, server, (), options)?;
-///     # actor_ref.send(Terminate).unwrap();
+///     # actor_ref.try_send(Terminate).unwrap();
 ///
 ///     runtime.start().map_err(rt::Error::map_type)
 /// }

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -301,7 +301,7 @@ fn relay_signals<E>(
             worker.send_signal(signal)?;
         }
         for actor_ref in signal_refs.iter() {
-            if let Err(err) = actor_ref.send(signal) {
+            if let Err(err) = actor_ref.try_send(signal) {
                 warn!("failed to send process signal to actor: {}", err);
             }
         }

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -302,6 +302,7 @@ fn relay_signals<E>(
         }
         for actor_ref in signal_refs.iter() {
             if let Err(err) = actor_ref.try_send(signal) {
+                // TODO: try sending again later?
                 warn!("failed to send process signal to actor: {}", err);
             }
         }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -158,7 +158,7 @@ pub(crate) const SYNC_WORKER_ID_END: usize = SYNC_WORKER_ID_START + 10000;
 ///     let actor_ref = runtime_ref.spawn_local(supervisor, actor, arg, ActorOptions::default());
 ///
 ///     // Send a message to the actor we just spawned.
-///     actor_ref.send("World").unwrap();
+///     actor_ref.try_send("World").unwrap();
 ///
 ///     Ok(())
 /// }

--- a/src/rt/process/tests.rs
+++ b/src/rt/process/tests.rs
@@ -62,7 +62,7 @@ fn actor_process() {
     assert_eq!(res, ProcessResult::Pending);
 
     // Send the message and the actor should return Ok.
-    actor_ref.send(()).unwrap();
+    actor_ref.try_send(()).unwrap();
     let res = process.as_mut().run(&mut runtime_ref, ProcessId(0));
     assert_eq!(res, ProcessResult::Complete);
 }
@@ -145,7 +145,7 @@ fn restarting_erroneous_actor_process() {
     assert!(supervisor_called.load(atomic::Ordering::SeqCst));
 
     // Now we send a message to the restarted actor, which should return `Ok`.
-    actor_ref.send(()).unwrap();
+    actor_ref.try_send(()).unwrap();
     let res = process.as_mut().run(&mut runtime_ref, ProcessId(0));
     assert_eq!(res, ProcessResult::Complete);
 }

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -411,7 +411,7 @@ impl RunningRuntime {
 
                     for receiver in receivers.iter_mut() {
                         // Don't care if we succeed in sending the message.
-                        let _ = receiver.send(signal);
+                        let _ = receiver.try_send(signal);
                     }
                 }
                 Wake => { /* Just need to wake up. */ }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -5,6 +5,7 @@
 mod util;
 
 mod functional {
+    mod actor_ref;
     mod bytes;
     mod from_message;
     mod restart_supervisor;

--- a/tests/functional/actor_ref.rs
+++ b/tests/functional/actor_ref.rs
@@ -1,0 +1,106 @@
+//! Tests related to `ActorRef` and `ActorGroup`.
+
+#![cfg(feature = "test")]
+
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::task::Poll;
+
+use heph::test::{init_local_actor, poll_actor};
+use heph::{actor, ActorRef};
+
+const MSGS: &[&str] = &["Hello world", "Hello mars", "Hello moon"];
+
+async fn expect_msgs<M>(mut ctx: actor::Context<M>, expected: Vec<M>) -> Result<(), !>
+where
+    M: Eq + fmt::Debug,
+{
+    for expected in expected {
+        let got = ctx.receive_next().await;
+        assert_eq!(got, expected);
+    }
+    Ok(())
+}
+
+#[test]
+fn try_send() {
+    let expect_msgs = expect_msgs as fn(_, _) -> _;
+    let (actor, actor_ref) = init_local_actor(expect_msgs, MSGS.to_vec()).unwrap();
+    let mut actor = Box::pin(actor);
+
+    for msg in MSGS {
+        actor_ref.try_send(*msg).unwrap();
+    }
+
+    assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
+}
+
+async fn relay_msgs<M>(
+    _: actor::Context<M>,
+    mut relay_ref: ActorRef<M>,
+    msgs: Vec<M>,
+) -> Result<(), !>
+where
+    M: Eq + fmt::Debug + Unpin,
+{
+    for msg in msgs {
+        relay_ref.send(msg).await.unwrap()
+    }
+    Ok(())
+}
+
+#[test]
+fn send() {
+    let expect_msgs = expect_msgs as fn(_, _) -> _;
+    let (actor, actor_ref) = init_local_actor(expect_msgs, MSGS.to_vec()).unwrap();
+    let mut actor = Box::pin(actor);
+
+    let relay_msgs = relay_msgs as fn(_, _, _) -> _;
+    let (relay_actor, _) = init_local_actor(relay_msgs, (actor_ref, MSGS.to_vec())).unwrap();
+    let mut relay_actor = Box::pin(relay_actor);
+
+    assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Pending);
+    assert_eq!(
+        poll_actor(Pin::as_mut(&mut relay_actor)),
+        Poll::Ready(Ok(()))
+    );
+    assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
+}
+
+#[test]
+fn map() {
+    let expect_msgs = expect_msgs as fn(_, _) -> _;
+    let expected = MSGS.iter().map(|s| (*s).to_owned()).collect();
+    let (actor, actor_ref): (_, ActorRef<String>) =
+        init_local_actor(expect_msgs, expected).unwrap();
+    let mut actor = Box::pin(actor);
+
+    let actor_ref: ActorRef<&str> = actor_ref.map();
+    for msg in MSGS {
+        actor_ref.try_send(*msg).unwrap();
+    }
+
+    assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
+}
+
+#[test]
+fn try_map() {
+    let expect_msgs = expect_msgs as fn(_, _) -> _;
+    let expected = vec![
+        NonZeroUsize::new(1).unwrap(),
+        NonZeroUsize::new(2).unwrap(),
+        NonZeroUsize::new(3).unwrap(),
+    ];
+    let (actor, actor_ref): (_, ActorRef<NonZeroUsize>) =
+        init_local_actor(expect_msgs, expected).unwrap();
+    let mut actor = Box::pin(actor);
+
+    let actor_ref: ActorRef<usize> = actor_ref.try_map();
+    assert!(actor_ref.try_send(0usize).is_err());
+    for msg in 1..4usize {
+        actor_ref.try_send(msg).unwrap();
+    }
+
+    assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
+}

--- a/tests/functional/from_message.rs
+++ b/tests/functional/from_message.rs
@@ -34,7 +34,7 @@ fn from_message() {
 }
 
 async fn ping_actor(mut ctx: actor::Context<!>, actor_ref: ActorRef<Message>) -> Result<(), !> {
-    actor_ref.send("Hello!".to_owned()).unwrap();
+    actor_ref.try_send("Hello!".to_owned()).unwrap();
 
     let response = actor_ref
         .rpc(&mut ctx, "Rpc".to_owned())

--- a/tests/functional/tcp/stream.rs
+++ b/tests/functional/tcp/stream.rs
@@ -91,7 +91,7 @@ fn smoke() {
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
 
     let (mut stream, address) = listener.accept().unwrap();
-    let _ = actor_ref.send(address);
+    let _ = actor_ref.try_send(address);
 
     // Now we expect the stream to be connected and ready.
     expect_ready_ok(poll_actor(Pin::as_mut(&mut actor)), ());

--- a/tests/regression/issue_145.rs
+++ b/tests/regression/issue_145.rs
@@ -63,7 +63,7 @@ fn issue_145_tcp_server() {
                 .unwrap()
                 .take()
                 .unwrap()
-                .send(Terminate)
+                .try_send(Terminate)
                 .unwrap();
         }
     });

--- a/tests/regression/issue_294.rs
+++ b/tests/regression/issue_294.rs
@@ -19,7 +19,7 @@ fn issue_294() {
 
     runtime
         .with_setup::<_, !>(move |_| {
-            actor_ref.send(()).unwrap();
+            actor_ref.try_send(()).unwrap();
             Ok(())
         })
         .start()


### PR DESCRIPTION
Renames `{ActorRef,ActorGroup}::send` to `try_send`.

Fixes #277.