### PR TITLE
Ignore test_6_process_signals on Linux 

### DIFF
--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -47,6 +47,10 @@ fn test_4_sync_actor() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "linux",
+    ignore = "multi-threaded process signal handling is broken on Linux; tracked in #325"
+)]
 fn test_6_process_signals() {
     let child = run_example("6_process_signals");
     // Give the process some time to setup signal handling.

--- a/tests/functional/from_message.rs
+++ b/tests/functional/from_message.rs
@@ -1,5 +1,7 @@
 //! Tests for the `from_message!` macro.
 
+#![cfg(feature = "test")]
+
 use std::pin::Pin;
 use std::task::Poll;
 


### PR DESCRIPTION
Updates #325