### PR TITLE
Add actor name to logging

### DIFF
--- a/src/actor/tests.rs
+++ b/src/actor/tests.rs
@@ -1,0 +1,54 @@
+use crate::actor;
+
+#[test]
+fn actor_name() {
+    let tests = &[
+        (
+            "core::future::from_generator::GenFuture<1_hello_world::greeter_actor::{{closure}}>",
+            "greeter_actor"
+        ),
+        (
+            "core::future::from_generator::GenFuture<1_hello_world::some::nested::module::greeter::actor::{{closure}}>",
+            "greeter::actor",
+        ),
+        (
+            "core::future::from_generator::GenFuture<3_rpc::ping_actor>",
+            "ping_actor"
+        ),
+        (
+            "core::future::from_generator::GenFuture<2_my_ip::conn_actor::{{closure}}>",
+            "conn_actor"
+        ),
+        // Type implementing `Actor`.
+        (
+            "heph::net::tcp::server::TcpServer<2_my_ip::conn_supervisor, fn(heph::actor::context_priv::Context<!>, heph::net::tcp::stream::TcpStream, std::net::addr::SocketAddr) -> core::future::from_generator::GenFuture<2_my_ip::conn_actor::{{closure}}>, heph::actor::context_priv::ThreadLocal>",
+            "TcpServer",
+        ),
+        // If the module path is removed from `std::any::type_name`.
+        (
+            "GenFuture<1_hello_world::greeter_actor::{{closure}}>",
+            "greeter_actor"
+        ),
+        (
+            "GenFuture<1_hello_world::some::nested::module::greeter::actor::{{closure}}>",
+            "greeter::actor",
+        ),
+        (
+            "TcpServer<2_my_ip::conn_supervisor, fn(heph::actor::context_priv::Context<!>, heph::net::tcp::stream::TcpStream, std::net::addr::SocketAddr) -> core::future::from_generator::GenFuture<2_my_ip::conn_actor::{{closure}}>, heph::actor::context_priv::ThreadLocal>",
+            "TcpServer",
+        ),
+        (
+            "TcpServer<core::future::from_generator::GenFuture<2_my_ip::conn_actor::{{closure}}>>",
+            "TcpServer",
+        ),
+        (
+            "TcpServer<GenFuture<2_my_ip::conn_actor::{{closure}}>>",
+            "TcpServer",
+        ),
+    ];
+
+    for (input, expected) in tests {
+        let got = actor::format_name(input);
+        assert_eq!(got, *expected);
+    }
+}

--- a/src/rt/process/actor.rs
+++ b/src/rt/process/actor.rs
@@ -103,6 +103,10 @@ where
     NA: NewActor<Context = C>,
     C: ContextKind,
 {
+    fn name(&self) -> &'static str {
+        actor::name::<NA::Actor>()
+    }
+
     fn run(self: Pin<&mut Self>, runtime_ref: &mut RuntimeRef, pid: ProcessId) -> ProcessResult {
         // This is safe because we're not moving the actor.
         let this = unsafe { Pin::get_unchecked_mut(self) };

--- a/src/rt/process/mod.rs
+++ b/src/rt/process/mod.rs
@@ -57,6 +57,9 @@ impl fmt::Display for ProcessId {
 /// This currently has a single implementation:
 /// - `ActorProcess`, which wraps an `Actor` to implement this trait.
 pub(crate) trait Process {
+    /// Return the name of this process, used in logging.
+    fn name(&self) -> &'static str;
+
     /// Run the process.
     ///
     /// Once the process returns `ProcessResult::Complete` it will be removed

--- a/src/rt/scheduler/local/inactive.rs
+++ b/src/rt/scheduler/local/inactive.rs
@@ -329,6 +329,10 @@ mod tests {
     struct TestProcess;
 
     impl Process for TestProcess {
+        fn name(&self) -> &'static str {
+            "TestProcess"
+        }
+
         fn run(self: Pin<&mut Self>, _: &mut RuntimeRef, _: ProcessId) -> ProcessResult {
             unimplemented!()
         }
@@ -418,6 +422,10 @@ mod tests {
         }
 
         impl Process for DropTest {
+            fn name(&self) -> &'static str {
+                "DropTest"
+            }
+
             fn run(self: Pin<&mut Self>, _: &mut RuntimeRef, _: ProcessId) -> ProcessResult {
                 unimplemented!()
             }

--- a/src/rt/scheduler/mod.rs
+++ b/src/rt/scheduler/mod.rs
@@ -58,7 +58,8 @@ impl<P: Process + ?Sized> ProcessData<P> {
     /// Returns the completion state of the process.
     pub(super) fn run(mut self: Pin<&mut Self>, runtime_ref: &mut RuntimeRef) -> ProcessResult {
         let pid = self.as_ref().id();
-        trace!("running process: pid={}", pid);
+        let name = self.process.name();
+        trace!("running process: pid={}, name={}", pid, name);
 
         let start = Instant::now();
         let result = self.process.as_mut().run(runtime_ref, pid);
@@ -67,8 +68,9 @@ impl<P: Process + ?Sized> ProcessData<P> {
         self.fair_runtime += fair_elapsed;
 
         trace!(
-            "finished running process: pid={}, elapsed_time={:?}, result={:?}",
+            "finished running process: pid={}, name={}, elapsed_time={:?}, result={:?}",
             pid,
+            name,
             elapsed,
             result
         );

--- a/src/rt/scheduler/shared/inactive.rs
+++ b/src/rt/scheduler/shared/inactive.rs
@@ -416,6 +416,10 @@ mod tests {
     struct TestProcess;
 
     impl Process for TestProcess {
+        fn name(&self) -> &'static str {
+            "TestProcess"
+        }
+
         fn run(self: Pin<&mut Self>, _: &mut RuntimeRef, _: ProcessId) -> ProcessResult {
             unimplemented!()
         }
@@ -533,6 +537,10 @@ mod tests {
         }
 
         impl Process for DropTest {
+            fn name(&self) -> &'static str {
+                "DropTest"
+            }
+
             fn run(self: Pin<&mut Self>, _: &mut RuntimeRef, _: ProcessId) -> ProcessResult {
                 unimplemented!()
             }

--- a/src/rt/scheduler/shared/runqueue.rs
+++ b/src/rt/scheduler/shared/runqueue.rs
@@ -118,6 +118,10 @@ mod tests {
     struct TestProcess;
 
     impl Process for TestProcess {
+        fn name(&self) -> &'static str {
+            "TestProcess"
+        }
+
         fn run(self: Pin<&mut Self>, _: &mut RuntimeRef, _: ProcessId) -> ProcessResult {
             ProcessResult::Complete
         }

--- a/src/rt/scheduler/tests.rs
+++ b/src/rt/scheduler/tests.rs
@@ -133,6 +133,10 @@ fn process_data_runtime_increase() {
 struct NopTestProcess;
 
 impl Process for NopTestProcess {
+    fn name(&self) -> &'static str {
+        "NopTestProcess"
+    }
+
     fn run(self: Pin<&mut Self>, _: &mut RuntimeRef, _: ProcessId) -> ProcessResult {
         unimplemented!();
     }
@@ -142,6 +146,10 @@ impl Process for NopTestProcess {
 struct SleepyProcess(Duration);
 
 impl Process for SleepyProcess {
+    fn name(&self) -> &'static str {
+        "SleepyProcess"
+    }
+
     fn run(self: Pin<&mut Self>, _runtime_ref: &mut RuntimeRef, _pid: ProcessId) -> ProcessResult {
         sleep(self.0);
         ProcessResult::Pending


### PR DESCRIPTION
Help with debugging, the name is read from the type which is done on a
best effort basis.

Changes the (trace) log output from something like:

```log
2020-11-24T16:54:20.682129Z [DEBUG] heph::rt: spawning thread-local actor: pid=140456139703328
2020-11-24T16:54:20.682294Z [TRACE] heph::rt::scheduler: running process: pid=140456139703328
2020-11-24T16:54:20.682336Z [TRACE] heph::rt::scheduler: finished running process: pid=140456139703328, elapsed_time=16.002µs, result=Complete
```

To

```log
2020-11-24T16:54:20.682129Z [DEBUG] heph::rt: spawning thread-local actor: pid=140456139703328, name=greeter_actor
2020-11-24T16:54:20.682294Z [TRACE] heph::rt::scheduler: running process: pid=140456139703328, name=greeter_actor
2020-11-24T16:54:20.682336Z [TRACE] heph::rt::scheduler: finished running process: pid=140456139703328, name=greeter_actor, elapsed_time=16.002µs, result=Complete
```

Makes it clear that the `greeter_actor` (from example 1) was spawned and run once.