### PR TITLE
Fix missing event from short running sync actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Heph
 
-[![Build Status](https://travis-ci.com/Thomasdezeeuw/heph.svg?branch=master)](https://travis-ci.com/Thomasdezeeuw/heph)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Crates.io](https://img.shields.io/crates/v/heph.svg)](https://crates.io/crates/heph)
 [![Docs](https://docs.rs/heph/badge.svg)](https://docs.rs/heph)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
     available_concurrency,
     const_fn,
     const_raw_ptr_to_usize_cast,
+    drain_filter,
     duration_zero,
     is_sorted,
     maybe_uninit_extra,

--- a/src/rt/channel.rs
+++ b/src/rt/channel.rs
@@ -108,4 +108,13 @@ impl<S, R> Handle<S, R> {
             }
         }
     }
+
+    /// Checks if the other side is alive.
+    pub(super) fn is_alive(&mut self) -> bool {
+        match self.send_pipe.write(&[]) {
+            Ok(..) => true,
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => true,
+            Err(..) => false,
+        }
+    }
 }

--- a/src/rt/sync_worker.rs
+++ b/src/rt/sync_worker.rs
@@ -1,6 +1,7 @@
 //! Synchronous actor thread code.
 
-use std::{io, thread};
+use std::io::{self, Write};
+use std::thread;
 
 use inbox::Manager;
 use log::trace;
@@ -54,6 +55,15 @@ impl SyncWorker {
     /// Return the worker's id.
     pub(super) const fn id(&self) -> usize {
         self.id
+    }
+
+    /// Checks if the `SyncWorker` is alive.
+    pub(super) fn is_alive(&mut self) -> bool {
+        match self.sender.write(&[]) {
+            Ok(..) => true,
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => true,
+            Err(..) => false,
+        }
     }
 
     /// See [`thread::JoinHandle::join`].

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -113,6 +113,11 @@ impl<E> Worker<E> {
         self.id
     }
 
+    /// Checks if the `Worker` is alive.
+    pub(super) fn is_alive(&mut self) -> bool {
+        self.channel.is_alive()
+    }
+
     pub(super) fn register(&mut self, registry: &Registry, token: Token) -> io::Result<()> {
         self.channel.register(registry, token)
     }

--- a/tests/message_loss.rs
+++ b/tests/message_loss.rs
@@ -6,6 +6,7 @@
 //! globally.
 
 #![feature(never_type)]
+#![cfg(feature = "test")]
 
 use std::pin::Pin;
 use std::task::Poll;

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -8,4 +8,5 @@
 mod regression {
     mod issue_145;
     mod issue_294;
+    mod issue_323;
 }

--- a/tests/regression/issue_323.rs
+++ b/tests/regression/issue_323.rs
@@ -1,0 +1,31 @@
+//! Short running synchronous threads that are finished before calling
+//! [`Runtime::start`] should be collected, and not run for ever.
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use heph::actor::sync::SyncContext;
+use heph::rt::{Runtime, SyncActorOptions};
+use heph::supervisor::NoSupervisor;
+
+#[test]
+fn issue_323() {
+    let mut runtime = Runtime::new().unwrap();
+
+    let actor = actor as fn(_) -> _;
+    let options = SyncActorOptions::default();
+    runtime
+        .spawn_sync_actor(NoSupervisor, actor, (), options)
+        .unwrap();
+
+    // Let the synchronous actor complete first.
+    sleep(Duration::from_secs(1));
+
+    // This just needs to return and not hang for ever.
+    runtime.start().unwrap();
+}
+
+/// Short running synchronous actor.
+fn actor(_: SyncContext<()>) -> Result<(), !> {
+    Ok(())
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)] // Not all tests use all functions/types.
+#![cfg(feature = "test")]
 
 use std::fmt;
 use std::mem::size_of;


### PR DESCRIPTION
If a sync actor is short running, or the time before calling
Runtime::start takes a while, the thread running the sync actor could be
done before the coordinator had a chance to register it. This causes the
coordinator to never receive an event for it on FreeBSD (it does receive
an event on macOS and Linux) and never remove it from the list of sync
actors, causing the runtime to run for ever.

The fix is fairly simple: after registering check if the sync worker is
still alive by trying to write zero bytes to its pipe.

Fixes #323.