### PR TITLE
Fix flaky TCP send and try_recv tests on Linux

### DIFF
--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -46,6 +46,11 @@ pub fn any_local_ipv6_address() -> SocketAddr {
     "[::1]:0".parse().unwrap()
 }
 
+/// Returns an address to which the connection will be refused.
+pub fn refused_address() -> SocketAddr {
+    "127.0.0.1:65535".parse().unwrap()
+}
+
 /// Stage of a test actor.
 ///
 /// When testing `Future`s it sometimes hard to tell which futures have and


### PR DESCRIPTION
The `send` and `try_recv` tests on Linux were a bit flaky, often making more progress than expected. Adding more stages to the actor as well as more points to return pending fixes this.

This also adds two tests for the connecting of the `TcpStream`.