### PR TITLE
Replace Box with SmallBox in actor_ref::SendValue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ libc              = { version = "0.2.79", default-features = false }
 log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }
 mio-signals       = { version = "0.1.2", default-features = false }
+# FIXME: not sure if we want this as dependency, it's missing issues. For
+# example: https://github.com/andylokandy/smallbox/issues/2.
+smallbox          = { version = "0.8.0", default-features = false, features = ["std", "coerce"] }
 # Enable logging panics via `std-logger` and add timestamps to each log message.
 std-logger        = { version = "0.3.6", default-features = false, features = ["log-panic", "timestamp"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,9 @@
 #![feature(
     array_methods,
     available_concurrency,
+    const_evaluatable_checked,
     const_fn,
+    const_generics,
     const_option,
     const_raw_ptr_to_usize_cast,
     drain_filter,
@@ -78,7 +80,7 @@
     maybe_uninit_extra,
     maybe_uninit_ref,
     maybe_uninit_slice,
-    min_const_generics,
+    //min_const_generics,
     never_type,
     new_uninit,
     vec_spare_capacity,


### PR DESCRIPTION
Not sure if the smallbox crate is a usable dependency however as it's failing the miri test: andylokandy/smallbox#9.

The last commit is another optimisation to reduce the stack size of `SendValue` when using small message types, but it doesn't work yet. Before that commit it defaults to a message size of 128 bytes which is quite large.

Includes #339
Closes  #338