### PR TITLE
Add basic trace infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target/
+target/
 **/*.rs.bk
 Cargo.lock

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 # NOTE: when using this command you might want to change the `test` target to
 # only run a subset of the tests you're actively working on.
 dev:
-	find src/ tests/ Makefile Cargo.toml | entr -d -c $(MAKE) test
+	find src/ tests/ examples/ Makefile Cargo.toml | entr -d -c $(MAKE) test
 
 clippy: lint
 lint:

--- a/doc/Trace Format.md
+++ b/doc/Trace Format.md
@@ -1,0 +1,238 @@
+# Trace Format
+
+###### Version 0.1.0.
+
+This design document describes the format used by Heph's trace system.
+
+It's inspired by the Common Trace Format (v1.8.3), available here:
+<https://diamon.org/ctf>.
+
+## Overview
+
+A single trace is split into multiple packets, which allows them to be easily
+send using packet based protocols, such as UDP, and stream based protocols, such
+as TCP, or for writing to disk. There are two kinds of packets:
+
+ * Metadata packets, used for setting options.
+ * Event packets, which contains information about a single event.
+
+A trace is conceptually split into multiple streams. A stream represents a
+sequence of events (not metadata), from the same thread of execution. For
+example events that happen on the same thread. Each stream has a 32 bit
+identifier (id) unique in the trace, which is used to coalesce events.
+
+The format always uses big-endian for integers.
+
+## Metadata Packet
+
+Metadata packets can set a certain option for the entire trace, i.e. it involves
+all other packets. They may be present in the trace at any point, but are
+usually at the start of it. Metadata packets have to following layout:
+
+```
+Bits		Description.
+[ 0..31]	Magic constant (0x75D11D4D) to indicate a metadata packet.
+[31..63]	Size of the packet in bytes.
+[64..79]	Option name length, unsigned 16 bit integer.
+[80..$n]	Option name in UTF-8, length defined by the option length.
+[$n+1..]	Option value, layout depends on the option.
+```
+
+The packet starts with a 32 bit magic constant `0x75D11D4D`[^1], allowing the
+packet to be differentiated from event packets (see below). The next 32 bits are
+the size of the packet in bytes (including itself and the magic constant) as a
+unsigned 32 bit integer (in big-endian, same as all integers).
+
+A single metadata packet can only specify a single option. This is done by
+giving the option name as a string: 16 unsigned bits to indicate the length of
+the string, followed by that many bytes in UTF-8. Finally the value for the
+option is supplied, the layout of which depends on the option itself.
+
+The layout would something like the following as a structure in Rust:
+
+```
+struct Metadata<Option> {
+	magic: u32,
+	size:  u32,
+	option_name_length: u16,
+	option_name:       [u8],
+	option_value:    Option, // Layout depends on the option.
+}
+```
+
+### Options
+
+Currently the following options are supported:
+
+ * `epoch`: Sets the epoch (zero time) used in event packets. The value must
+   specified as the number of nanoseconds since the Unix epoch as unsigned 64
+   bit integer. This will be used as wall-clock based epoch, while the timings
+   in the events can be based on monotonic clocks (which often don't have a
+   relation to the wall-clocks).
+
+Note that no options are required to be set on the trace, meaning a trace
+without any metadata packets is valid.
+
+### Example
+
+The following example shows the layout for a metadata packet setting the `epoch`
+option.
+
+```
+Bits		Value		Description.
+[ 0..31]	0x75D11D4D	Magic constant to indicate a metadata packet.
+[31..63]	23  		Size of the packet: 4 (magic) + 4 (packet size) +
+                		2 (option name length) + 5 (option name) + 8 (option value) = 23 bytes.
+[64..79]	5   		Option length: "epoch" is 5 bytes.
+[80..$n]	"epoch"		Option name.
+[$n+1..]	1610113734118010000	Option value: 08 Jan 2021.
+```
+
+## Event Packet
+
+An event packet describes a single event. The layout is the following:
+
+```
+Bits		Description.
+[  0.. 31]	Magic constant (0xC1FC1FB7) to indicate an event packet.
+[ 31.. 63]	Size of the packet in bytes.
+[ 64.. 95]	Stream identifier (id).
+[ 96..127]	Stream event counter.
+[128..191]	Start time in nanoseconds, relative to trace's epoch.
+[192..255]	End time in nanoseconds, relative to trace's epoch.
+[256..271]	Desciption length, unsigned 16 bit integer.
+[272.. $n]	Description in UTF-8, length defined by the description length.
+
+[$n+1..$k]	Attributes, optional, see below.
+```
+
+An event packet also starts with a 32 bit magic constant `0xC1FC1FB7` [^2] and
+the size of the packet in bytes as 32 bit unsigned integer.
+
+Next are 32 bits for the stream id, interrupted as an 32 bit usigned integer.
+This stream id can be used to coalesce events. For example if we have two
+events with the same stream id, where event A start at time 10 and ends at time
+20 and an event B start starts at the time 5 (i.e. earlier than event A) and
+ends at time 15 (i.e. later than event B) we have an implicit parent-child
+relation between the two events, event B caused event A. This allows us to
+create a call-stack like image of the events, with the code needed to know
+anything about it's caller/parent (i.e. we don't have to carry a `Span` like
+strucutre around in the code).
+
+The fourth field is the stream event counter. This simply an 32 bit usigned
+integer which count the events in the stream. This can be used in packet based
+protcols to detect if an event was missed. The counter may wrap-around on
+overflow, i.e. after `2 ^ 32` comes `0`. Note however this is optional and may
+be ignore by consumers of the trace.
+
+The next two fields are the start and end timestamps of the event. Both are 64
+bit unsigned integers representing the number of nanoseconds since the epoch of
+the trace. Also see the `epoch` option of the metadata packet.
+
+Next comes a description in string format: 16 unsigned bits to indicate the
+length and that many bytes in UTF-8.
+
+The above fields are all required, the following attributes however are not. An
+event with zero attributes is valid.
+
+The attributes are key-value pairs with additional information about the event.
+The following describes the layout of the attributes. **Note** that the bits
+below start at zero, but are actually after the other event field (see above).
+
+```
+Bits			Description.
+[   0..  15]	Attribute name length, unsigned 16 bit integer.
+[  16..  $n]	Attribute name in UTF-8, length defined by the attribute name length.
+[$n+1..$n+8]	Attribute value type, a byte to indicate the type of the attribute value.
+[$n+9..$k  ]	Attribute value, layout depends on the type of the value.
+```
+
+Each attribute is a key-value pair, so it start with the name of the attribute
+as a string. A string, like the event description, is 16 unsigned bits followed
+by that many bytes in UTF-8 that make up the attribute name. Next is the
+attribute value.
+
+The attribute value can one of the following types.
+
+```
+Byte layout	Type
+0b0000_0001	Unsigned 64 bit integer.
+0b0000_0010	Signed 64 bit integer.
+0b0000_0011	64 bit floating point.
+0b0000_0100	String: 16 bit unsigned integer as length, followed by that many bytes.
+
+0b1000_0000	Array marker: 16 bit unsigned integer to indicate the length, followed
+           	by that many value laid out a definied by the value type above.
+```
+
+The unsigned integer, signed integer and floating point values are always 64
+bits and in big-endian format.
+
+The string type we've already seen previous: 16 bit unsigned integer to indicate
+the length, followed by that many bytes in UTF-8 which is the string content.
+
+Finally dynamically sized arrays are supported. Within the array only a single
+type is support, i.e. it's not supported to use different types within the same
+array. The format of the array is an 16 unsigned bit integer to indicate the
+length followed by that many values. The layout of the values is determined by
+the type of the value.
+
+It's not valid to have an untyped array, an array must always be combined with a
+value type. For example `0b0000_0100 | 0b1000_0000` indicates an array of
+strings. **The array type on it's own, i.e.** `0b1000_0000`**, is invalid**.
+
+The layout would something like the following as a structure in Rust:
+
+```
+struct Event<Attributes> {
+	magic: u32,
+	size:  u32,
+	description_length: u16,
+	description:       [u8],
+	attributes: Attributes, // Layout differs per event.
+}
+
+// NOTE: the integers and floats have the same layout as `u64`/`i64`/`f64` from
+// big-endian bytes.
+
+struct StringAttribute {
+	length: u16,
+	value: [u8],
+}
+
+struct ArrayAttribute<A> {
+	length: u16,
+	values: [A],
+}
+```
+
+### Example
+
+The following example shows the layout for an event packet.
+
+```
+Bits		Value		Description.
+[  0.. 31]	0xC1FC1FB7	Magic constant to indicate an event packet.
+[ 31.. 63]	67  		Size of the packet (536 / 8).
+[ 64.. 95]	0   		Stream identifier (id).
+[ 96..127]	0   		Stream event counter.
+[128..191]	100 		Start time.
+[192..255]	200 		End time.
+[256..271]	8   		Desciption length.
+[272..335]	"My event"	Description.
+[336..351]	4  		Attribute name length.
+[352..383]	"Test"		Attribute name.
+[384..391]	0b0000_0001	Attribute value type: unsigned 64 bit integer.
+[392..455]	123 		Attribute value.
+[456..471]	5   		Attribute name length.
+[472..511]	"Test2"		Attribute name.
+[512..391]	0b1000_0011	Attribute value type: array of 64 floats.
+[392..407]	2   		Array length.
+[408..471]	123.456		Array[0].
+[472..535]	789.0		Array[1].
+```
+
+
+[^1]: The value is `0x75D11D57` minus 10.
+
+[^2]: The value is `0xC1FC1FC1` minus 10.

--- a/examples/8_tracing.rs
+++ b/examples/8_tracing.rs
@@ -1,0 +1,81 @@
+#![feature(never_type)]
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use log::warn;
+
+use heph::actor_ref::{ActorRef, SendError};
+use heph::supervisor::{NoSupervisor, SupervisorStrategy};
+use heph::{actor, rt, ActorOptions, Runtime, RuntimeRef};
+
+fn main() -> Result<(), rt::Error> {
+    let mut runtime = Runtime::new()?.with_setup(setup);
+
+    // Enable tracing of the runtime.
+    runtime.enable_tracing("heph_tracing_example.bin.log")?;
+
+    runtime.start()
+}
+
+const CHAIN_SIZE: usize = 5;
+
+/// Setup function will start a chain of `relay_actors` and a final
+/// `print_actor`, just to create some activity for the trace.
+fn setup(mut runtime_ref: RuntimeRef) -> Result<(), !> {
+    let print_actor = print_actor as fn(_) -> _;
+    let relay_actor = relay_actor as fn(_, _) -> _;
+
+    // Spawn our printing actor.
+    let actor_ref = runtime_ref.spawn_local(NoSupervisor, print_actor, (), ActorOptions::default());
+
+    // Create a chain of relay actors that will relay messages to the next
+    // actor.
+    let mut next_actor_ref = actor_ref;
+    for _ in 0..CHAIN_SIZE {
+        next_actor_ref = runtime_ref.spawn_local(
+            |err| {
+                warn!("error running actor: {}", err);
+                SupervisorStrategy::Stop
+            },
+            relay_actor,
+            next_actor_ref,
+            ActorOptions::default(),
+        );
+    }
+
+    // Send the messages down the chain of actors.
+    let msgs = &[
+        "First message: Hello World!",
+        "Hello Mars!",
+        "End of transmission.",
+    ];
+    for msg in msgs {
+        next_actor_ref.try_send(*msg).unwrap();
+    }
+
+    Ok(())
+}
+
+/// Actor that relays all messages it receives to actor behind `relay`.
+async fn relay_actor(
+    mut ctx: actor::Context<&'static str>,
+    relay: ActorRef<&'static str>,
+) -> Result<(), SendError> {
+    while let Ok(msg) = ctx.receive_next().await {
+        // Sleep to extend the duration of the trace.
+        sleep(Duration::from_millis(5));
+        relay.send(msg).await?;
+    }
+    Ok(())
+}
+
+/// Actor that prints all messages it receives.
+async fn print_actor(mut ctx: actor::Context<&'static str>) -> Result<(), !> {
+    while let Ok(msg) = ctx.receive_next().await {
+        // Sleep to extend the duration of the trace.
+        sleep(Duration::from_millis(5));
+        println!("Received message: {}", msg);
+    }
+    Ok(())
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,3 +48,24 @@ can be used to cleanly shutdown your application.
 The code can be found in `6_process_signals.rs` and run with `cargo run
 --example 6_process_signals`, pressing ctrl-c (sending it an interrupt signal
 `SIGINT`) should shutdown the example cleanly.
+
+
+## 8. Runtime tracing
+
+Heph supports generating trace files in its own custom format, described in the
+[Trace Format design document]. This format can be converted into [Chrome's
+Trace Event Format] so it can be opened by [Catapult trace view].
+
+```bash
+ $ cargo run --example 8_tracing       # Run the example, to generate the trace.
+ $ cd tools                            # Got into the tools directory.
+                                       # Convert the trace to Chrome's format.
+ $ cargo run --bin convert_trace ../heph_tracing_example.bin.log heph_tracing_example.json
+                                       # Make the trace viewable in HTML.
+ $ $(CAPAPULT_REPO)/tracing/bin/trace2html heph_tracing_example.json
+ $ open heph_tracing_example.json      # Finally open the trace in your browser.
+```
+
+[Trace Format design document]: ../doc/Trace%20Format.md
+[Chrome's Trace Event Format]: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+[Catapult trace view]: https://chromium.googlesource.com/catapult/+/refs/heads/master/tracing/README.md

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ The code can be found in `1_hello_world.rs` and run with `cargo run --example
 1_hello_world`, and it should print "Hello World".
 
 
-## 2. Ip server
+## 2. IP Server
 
 The second example is a simple TCP server that writes the ip of the connection
 to the connection.
@@ -28,19 +28,19 @@ address, e.g. "127.0.0.1".
 Example three shows how Heph makes Remote Procedure Calls (RPC) easy.
 
 
-## 4. Synchronous actor
+## 4. Synchronous Actor
 
 The fourth example how to use synchronous actors. These are actors that have the
 thread all to themselves, which means that can do heavy computation and blocking
 I/O without stalling other actors.
 
 
-## 5. Remote actor references
+## 5. Remote Actor References
 
 TODO: reimplement this.
 
 
-## 6. Process signal handling
+## 6. Process Signal Handling
 
 Heph has build-in support for handling process signals. This example shows this
 can be used to cleanly shutdown your application.
@@ -50,7 +50,14 @@ The code can be found in `6_process_signals.rs` and run with `cargo run
 `SIGINT`) should shutdown the example cleanly.
 
 
-## 8. Runtime tracing
+## 7. Restart Supervisor Macro
+
+Example seven shows how the `restart_supervisor!` macro can be used to easily
+create a new `Supervisor` implementation that attempts to restart the actor with
+cloned arguments.
+
+
+## 8. Runtime Tracing
 
 Heph supports generating trace files in its own custom format, described in the
 [Trace Format design document]. This format can be converted into [Chrome's

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -24,6 +24,9 @@ const SIGNAL: Token = Token(usize::max_value());
 /// Token used to wake-up the coordinator thread.
 pub(super) const WAKER: Token = Token(usize::max_value() - 1);
 
+/// Stream id for the coordinator.
+pub(super) const TRACE_ID: u32 = 0;
+
 pub(super) struct Coordinator {
     /// OS poll, used to poll the status of the (sync) worker threads and
     /// process signals.

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -231,7 +231,9 @@ impl Coordinator {
                 rt::trace::finish(
                     &mut trace_log,
                     timing,
-                    event!("Waking worker threads", { amount: usize = wake_workers }),
+                    event!("Waking worker threads", attributes: {
+                        amount: usize = wake_workers,
+                    }),
                 );
             }
 

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -413,7 +413,9 @@ where
         trace::finish(
             &mut self.trace_log,
             timing,
-            event!("Creating worker threads", { amount: usize = self.threads }),
+            event!("Creating worker threads", attributes: {
+                amount: usize = self.threads,
+            }),
         );
 
         // Drop stuff we don't need anymore. For the setup function this is

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -269,16 +269,6 @@ impl<S> Runtime<S> {
         self.threads
     }
 
-    /// Generate a trace of the runtime, writing it to the file specified by
-    /// `path`.
-    ///
-    /// TODO: document the trace format. It's currently a sort-of JSON.
-    pub fn enable_tracing<P: AsRef<Path>>(&mut self, path: P) -> io::Result<()> {
-        let trace_log = trace::Log::open(path.as_ref(), coordinator::TRACE_ID)?;
-        self.trace_log = Some(trace_log);
-        Ok(())
-    }
-
     /// Attempt to spawn a new thead-safe actor.
     ///
     /// See the [`Spawn`] trait for more information.
@@ -368,6 +358,27 @@ impl<S> Runtime<S>
 where
     S: SetupFn,
 {
+    /// Generate a trace of the runtime, writing it to the file specified by
+    /// `path`.
+    ///
+    /// The [Trace Format] design document describes the layout of the trace,
+    /// found in the `doc` directory of the repository. It can be converted into
+    /// [Chrome's Trace Event Format] use the convertion tool found in the
+    /// `tools` directory. Also see example 8 Runtime Tracing in
+    /// examples/README.md which shows a complete example.
+    ///
+    /// [Trace Format]:  https://github.com/Thomasdezeeuw/heph/blob/master/doc/Trace%20Format.md
+    /// [Chrome's Trace Event Format]: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+    pub fn enable_tracing<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error<S::Error>> {
+        match trace::Log::open(path.as_ref(), coordinator::TRACE_ID) {
+            Ok(trace_log) => {
+                self.trace_log = Some(trace_log);
+                Ok(())
+            }
+            Err(err) => Err(Error::setup_trace(err)),
+        }
+    }
+
     /// Run the runtime.
     ///
     /// This will spawn a number of worker threads (see

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -69,7 +69,7 @@ use sync_worker::SyncWorker;
 use waker::{WakerId, MAX_THREADS};
 use worker::Worker;
 
-pub(crate) const SYNC_WORKER_ID_START: usize = MAX_THREADS + 1;
+pub(crate) const SYNC_WORKER_ID_START: usize = MAX_THREADS + 1 + 1; // Worker ids start at 1.
 pub(crate) const SYNC_WORKER_ID_END: usize = SYNC_WORKER_ID_START + 10000;
 
 /// The runtime that runs all actors.
@@ -368,7 +368,7 @@ where
         );
 
         // Start our worker threads.
-        let handles = (0..self.threads)
+        let handles = (1..=self.threads)
             .map(|id| {
                 let setup = self.setup.clone();
                 Worker::start(id, setup, self.shared.clone())

--- a/src/rt/scheduler/mod.rs
+++ b/src/rt/scheduler/mod.rs
@@ -42,7 +42,7 @@ pub(super) struct ProcessData<P: ?Sized> {
 
 impl<P: ?Sized> ProcessData<P> {
     /// Returns the process identifier, or pid for short.
-    fn id(self: Pin<&Self>) -> ProcessId {
+    pub(super) fn id(self: Pin<&Self>) -> ProcessId {
         // Since the pid only job is to be unique we just use the pointer to
         // this structure as pid. This way we don't have to store any additional
         // pid in the structure itself or in the scheduler.
@@ -53,6 +53,11 @@ impl<P: ?Sized> ProcessData<P> {
 }
 
 impl<P: Process + ?Sized> ProcessData<P> {
+    /// Returns the name of the process.
+    pub(super) fn name(self: Pin<&Self>) -> &'static str {
+        self.process.name()
+    }
+
     /// Run the process.
     ///
     /// Returns the completion state of the process.

--- a/src/rt/trace.rs
+++ b/src/rt/trace.rs
@@ -1,0 +1,268 @@
+//! Tracing utilities.
+
+#![allow(dead_code, unused_imports, missing_docs, missing_debug_implementations)]
+
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::mem::size_of;
+use std::path::Path;
+use std::time::{Duration, Instant, SystemTime};
+
+use log::warn;
+
+use crate::rt::ProcessId;
+
+/// Default buffer size of `Log`.
+const BUF_SIZE: usize = 512;
+
+/// Trace log.
+#[derive(Debug)]
+pub(crate) struct Log {
+    /// File to write the trace to.
+    ///
+    /// This file is shared between one or more thread, thus writes to it should
+    /// be atomic, e.g. no partial writes. Most OSs support atomic writes up to
+    /// a page size (usally 4kB).
+    file: File,
+    /// Used to buffer writes for a single event.
+    buf: Vec<u8>,
+    /// Id of the stream, used in writing events.
+    stream_id: u32,
+}
+
+impl Log {
+    /// Open a new trace `Log`.
+    pub(super) fn open(path: &Path, stream_id: u32) -> io::Result<Log> {
+        OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(path)
+            .map(|file| Log {
+                file,
+                stream_id,
+                buf: Vec::with_capacity(BUF_SIZE),
+            })
+    }
+
+    /// Create a new stream with `stream_id`, writing to the same (duplicated)
+    /// file.
+    pub(super) fn new_stream(&self, stream_id: u32) -> io::Result<Log> {
+        self.file.try_clone().map(|file| Log {
+            file,
+            stream_id,
+            buf: Vec::with_capacity(BUF_SIZE),
+        })
+    }
+
+    /// Append `event` to trace `Log`.
+    pub(crate) fn append<E>(&mut self, event: &Metadata<E>) -> io::Result<()>
+    where
+        E: Event,
+    {
+        self.buf.clear();
+        // TODO: use a better format than butchered JSON.
+        write!(
+            &mut self.buf,
+            "{{\
+                \"stream_id\":{},\
+                \"description\":\"{}\",\
+                \"start\":{},\
+                \"elapsed\":\"{:?}\",\
+                \"attributes\":",
+            self.stream_id,
+            E::DESCRIPTION,
+            nanos_since_unix_epoch(event.start),
+            event.elapsed,
+        )
+        .unwrap_or_else(|_| unreachable!());
+        event.event.write_attributes(&mut self.buf);
+        self.buf.extend_from_slice(b"}\n");
+        write_once(&self.file, &self.buf)
+    }
+}
+
+/// Start timing for an event (using [`EventTiming`]) if we're tracing, i.e. if
+/// `log` is `Some`.
+pub(crate) fn start(log: &Option<Log>) -> Option<EventTiming> {
+    if log.is_some() {
+        Some(EventTiming::start())
+    } else {
+        None
+    }
+}
+
+/// Finish a trace, partner function to [`start`].
+///
+/// If `log` is `Some` `timing` must also be `Some.
+#[track_caller]
+pub(crate) fn finish<E>(log: &mut Option<Log>, timing: Option<EventTiming>, event: E)
+where
+    E: Event,
+{
+    if let Some(log) = log.as_mut() {
+        let timing = timing.unwrap();
+        let event = timing.finish(event);
+        if let Err(err) = log.append(&event) {
+            warn!("error writing trace data: {}", err);
+        }
+    }
+}
+
+/// Returns the number of nanoseconds since Unix epoch.
+///
+/// (2 ^ 64) / 1000000000 / (365 * 24 * 60 * 60) ~= 584 years are supported.
+/// Thus in the year 2554 we should start thinking about fixing this problem...
+/// You know in a timely manner (without panicking) like always.
+#[track_caller]
+fn nanos_since_unix_epoch(time: SystemTime) -> u64 {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
+/// Write the entire `buf`fer into the `output` or return an error.
+#[inline(always)]
+fn write_once<W>(mut output: W, buf: &[u8]) -> io::Result<()>
+where
+    W: Write,
+{
+    output.write(buf).and_then(|written| {
+        if written != buf.len() {
+            // Not completely correct when going by the name alone, but it's the
+            // closest we can get to a descriptive error.
+            Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "failed to write entire trace event",
+            ))
+        } else {
+            Ok(())
+        }
+    })
+}
+
+/// Metadata wrapping an [`Event`].
+#[derive(Debug)]
+pub(crate) struct Metadata<E> {
+    start: SystemTime,
+    elapsed: Duration,
+    event: E,
+}
+
+/// Time an [`Event`].
+#[derive(Debug)]
+pub(crate) struct EventTiming {
+    /// Real time the event was started.
+    start: SystemTime,
+    /// Timestamp used to determine the duration of the event as real-clocks can
+    /// go backwards.
+    timing: Instant,
+}
+
+impl EventTiming {
+    /// Start timing.
+    pub(crate) fn start() -> EventTiming {
+        let start = SystemTime::now();
+        let timing = Instant::now();
+        EventTiming { start, timing }
+    }
+
+    /// Finish timing `event`.
+    pub(crate) fn finish<E>(self, event: E) -> Metadata<E> {
+        let elapsed = self.timing.elapsed();
+        Metadata {
+            start: self.start,
+            elapsed,
+            event,
+        }
+    }
+}
+
+/// Trait that defines an event.
+///
+/// An event is simple, it has a human-readable description and optional
+/// attributes. To create an event type use the [`event!`] macro.
+pub(crate) trait Event {
+    /// Description of the event in human-readable text, e.g. `run process`.
+    const DESCRIPTION: &'static str;
+
+    /// Write attributes related to this event to the `buf`fer.
+    ///
+    /// For example if we're running a process we would write the process id as
+    /// a possible attribute.
+    fn write_attributes(&self, buf: &mut Vec<u8>);
+
+    /// Use the [`event!`] macro instead.
+    #[doc(hidden)]
+    fn _do_not_manually_implement_this_it_wont_work();
+}
+
+/// Macro to create a new [`Event`] type.
+macro_rules! event {
+    ($msg: expr) => {{
+        #[derive(Copy, Clone)]
+        #[allow(missing_docs)]
+        struct Event;
+
+        impl $crate::rt::trace::Event for Event {
+            const DESCRIPTION: &'static str = $msg;
+
+            fn write_attributes(&self, buf: &mut Vec<u8>) {
+                buf.extend_from_slice(b"{}");
+            }
+
+            fn _do_not_manually_implement_this_it_wont_work() {}
+        }
+
+        impl std::fmt::Debug for Event {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                use $crate::rt::trace::Event;
+                f.debug_struct("Event")
+                    .field("description", &Self::DESCRIPTION)
+                    .finish()
+            }
+        }
+
+        Event
+    }};
+    ($msg: expr, {
+        $( $attribute_key: ident : $attribute_type: ty = $attribute_value: expr),+ $(,)*
+    }) => {{
+        #[derive(Copy, Clone)]
+        #[allow(missing_docs)]
+        struct Event {
+            $( $attribute_key : $attribute_type ),+
+        }
+
+        impl $crate::rt::trace::Event for Event {
+            const DESCRIPTION: &'static str = $msg;
+
+            fn write_attributes(&self, buf: &mut Vec<u8>) {
+                use std::io::Write;
+                // TODO: don't write integers in quotes.
+                write!(buf,
+                    concat!("{{", $( "\"", stringify!($attribute_key), "\":\"{}\"," ),+ ),
+                    $( &self.$attribute_key ),+
+                ).unwrap_or_else(|_| unreachable!());
+                let _ = buf.pop(); // Remove last `,` not allowed in JSON.
+                buf.extend_from_slice(b"}");
+            }
+
+            fn _do_not_manually_implement_this_it_wont_work() {}
+        }
+
+        impl std::fmt::Debug for Event {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                use $crate::rt::trace::Event;
+                f.debug_struct("Event")
+                    .field("description", &Self::DESCRIPTION)
+                    $( .field(stringify!($attribute_key), &self.$attribute_key) )+
+                    .finish()
+            }
+        }
+
+        Event {
+            $( $attribute_key : $attribute_value ),+
+        }
+    }};
+}

--- a/src/rt/trace.rs
+++ b/src/rt/trace.rs
@@ -53,7 +53,7 @@ impl Log {
         // Write the metadata for the trace log, currently that's only the time
         // at which it's recorded.
         // TODO: use a better format.
-        write!(&mut log.buf, "{{\"timestamp\":\"{:?}\"}}\n", timestamp)
+        writeln!(&mut log.buf, "{{\"timestamp\":\"{:?}\"}}", timestamp)
             .unwrap_or_else(|_| unreachable!());
         write_once(&log.file, &log.buf)?;
 
@@ -269,7 +269,9 @@ macro_rules! event {
             }
         }
 
+        #[allow(clippy::redundant_field_names)]
         Event {
+
             $( $attribute_key : $attribute_value ),+
         }
     }};

--- a/src/rt/trace.rs
+++ b/src/rt/trace.rs
@@ -14,7 +14,7 @@ use log::warn;
 use crate::rt::ProcessId;
 
 /// Default buffer size of `Log`.
-const BUF_SIZE: usize = 512;
+const BUF_SIZE: usize = 128;
 
 /// Trace log.
 #[derive(Debug)]
@@ -29,6 +29,8 @@ pub(crate) struct Log {
     buf: Vec<u8>,
     /// Id of the stream, used in writing events.
     stream_id: u32,
+    /// Count for the events we're writing to this stream.
+    stream_counter: u32,
     /// Time which we use as zero, or epoch, time for all events.
     epoch: Instant,
 }
@@ -36,28 +38,27 @@ pub(crate) struct Log {
 impl Log {
     /// Open a new trace `Log`.
     pub(super) fn open(path: &Path, stream_id: u32) -> io::Result<Log> {
+        // Start with getting the "real" time, using the wall-clock.
         let timestamp = SystemTime::now();
+        // Hopefully quickly after get a monotonic time we use as zero-point
+        // (i.e. the epoch for this trace).
         let epoch = Instant::now();
 
-        let mut log = OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(path)
-            .map(|file| Log {
-                file,
-                stream_id,
-                buf: Vec::with_capacity(BUF_SIZE),
-                epoch,
-            })?;
+        let file = OpenOptions::new().append(true).create(true).open(path)?;
 
-        // Write the metadata for the trace log, currently that's only the time
-        // at which it's recorded.
-        // TODO: use a better format.
-        writeln!(&mut log.buf, "{{\"timestamp\":\"{:?}\"}}", timestamp)
-            .unwrap_or_else(|_| unreachable!());
-        write_once(&log.file, &log.buf)?;
+        // Write the metadata for the trace log, currently it only sets the
+        // epoch time.
+        let mut buf = Vec::with_capacity(BUF_SIZE);
+        write_epoch_metadata(&mut buf, timestamp);
+        write_once(&file, &buf)?;
 
-        Ok(log)
+        Ok(Log {
+            file,
+            stream_id,
+            stream_counter: 0,
+            buf,
+            epoch,
+        })
     }
 
     /// Create a new stream with `stream_id`, writing to the same (duplicated)
@@ -66,6 +67,7 @@ impl Log {
         self.file.try_clone().map(|file| Log {
             file,
             stream_id,
+            stream_counter: 0,
             buf: Vec::with_capacity(BUF_SIZE),
             epoch: self.epoch,
         })
@@ -76,26 +78,66 @@ impl Log {
     where
         E: Event,
     {
+        const MAGIC: u32 = 0xC1FC1FB7;
+
+        let stream_count: u32 = self.next_stream_count();
+        let start_nanos: u64 = self.nanos_since_epoch(event.start);
+        let end_nanos: u64 = self.nanos_since_epoch(event.end);
+        let description: &[u8] = E::DESCRIPTION.as_bytes();
+        let description_len: u16 = description.len() as u16;
+
         self.buf.clear();
-        // TODO: use a better format than butchered JSON.
-        write!(
-            &mut self.buf,
-            "{{\
-                \"stream_id\":{},\
-                \"description\":\"{}\",\
-                \"start\":{},\
-                \"end\":{},\
-                \"attributes\":",
-            self.stream_id,
-            E::DESCRIPTION,
-            nanos_since_epoch(self.epoch, event.start),
-            nanos_since_epoch(self.epoch, event.end),
-        )
-        .unwrap_or_else(|_| unreachable!());
+        self.buf.extend_from_slice(&MAGIC.to_be_bytes());
+        self.buf.extend_from_slice(&0u32.to_be_bytes()); // Written later.
+        self.buf.extend_from_slice(&self.stream_id.to_be_bytes());
+        self.buf.extend_from_slice(&stream_count.to_be_bytes());
+        self.buf.extend_from_slice(&start_nanos.to_be_bytes());
+        self.buf.extend_from_slice(&end_nanos.to_be_bytes());
+        self.buf.extend_from_slice(&description_len.to_be_bytes());
+        self.buf.extend_from_slice(description);
         event.event.write_attributes(&mut self.buf);
-        self.buf.extend_from_slice(b"}\n");
+        let packet_size = self.buf.len() as u32;
+        self.buf[4..8].copy_from_slice(&packet_size.to_be_bytes());
+
+        // TODO: buffer events? If buf.len() + packet_size >= 4k -> write first?
         write_once(&self.file, &self.buf)
     }
+
+    /// Returns the number of nanoseconds since the trace's epoch.
+    ///
+    /// (2 ^ 64) / 1000000000 / (365 * 24 * 60 * 60) ~= 584 years.
+    /// So restart the application once every 500 years and you're good.
+    #[track_caller]
+    fn nanos_since_epoch(&self, time: Instant) -> u64 {
+        time.duration_since(self.epoch).as_nanos() as u64
+    }
+
+    /// Returns the next stream counter.
+    fn next_stream_count(&mut self) -> u32 {
+        let count = self.stream_counter;
+        self.stream_counter = self.stream_counter.wrapping_add(1);
+        count
+    }
+}
+
+/// Write an epoch metadata packet to `buf`.
+fn write_epoch_metadata(buf: &mut Vec<u8>, time: SystemTime) {
+    const MAGIC: u32 = 0x75D11D4D;
+    const PACKET_SIZE: u32 = 23;
+    const OPTION_LENGTH: u16 = OPTION.len() as u16;
+    const OPTION: &[u8] = b"epoch";
+
+    // Number of nanoseconds since Unix epoch as u64.
+    let nanos_since_unix = time
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
+
+    buf.extend_from_slice(&MAGIC.to_be_bytes());
+    buf.extend_from_slice(&PACKET_SIZE.to_be_bytes());
+    buf.extend_from_slice(&OPTION_LENGTH.to_be_bytes());
+    buf.extend_from_slice(OPTION);
+    buf.extend_from_slice(&nanos_since_unix.to_be_bytes());
 }
 
 /// Returns the number of nanoseconds since `epoch`.
@@ -198,6 +240,8 @@ pub(crate) trait Event {
     ///
     /// For example if we're running a process we would write the process id as
     /// a possible attribute.
+    ///
+    /// Use the [`WriteAttribute`] trait for this.
     fn write_attributes(&self, buf: &mut Vec<u8>);
 
     /// Use the [`event!`] macro instead.
@@ -205,19 +249,115 @@ pub(crate) trait Event {
     fn _do_not_manually_implement_this_it_wont_work();
 }
 
+/// The [`WriteAttribute::TYPE_BYTE`] constants.
+const UNSIGNED_INTEGER_BYTE: u8 = 0b001;
+const SIGNED_INTEGER_BYTE: u8 = 0b010;
+const FLOAT_BYTE: u8 = 0b011;
+pub(crate) const STRING_BYTE: u8 = 0b100; // Used in `event!` macro.
+
+// Use in `event!` macro.
+pub(crate) trait WriteAttribute {
+    /// The type byte for this attribute.
+    const TYPE_BYTE: u8;
+
+    /// Must return [`Self::TYPE_BYTE`].
+    fn type_byte(&self) -> u8 {
+        Self::TYPE_BYTE
+    }
+
+    /// Write the contents of the attribute, without type byte.
+    fn write_attribute(&self, buf: &mut Vec<u8>);
+}
+
+macro_rules! impl_write_attribute {
+    ($ty: ty as $f_ty: ty, $type_byte: expr) => {
+        impl WriteAttribute for $ty {
+            const TYPE_BYTE: u8 = $type_byte;
+
+            fn write_attribute(&self, buf: &mut Vec<u8>) {
+                #[allow(trivial_numeric_casts)] // for `u64 as u64`.
+                let value = *self as $f_ty;
+                buf.extend_from_slice(&value.to_be_bytes());
+            }
+        }
+    };
+}
+
+impl_write_attribute!(u8 as u64, UNSIGNED_INTEGER_BYTE);
+impl_write_attribute!(u16 as u64, UNSIGNED_INTEGER_BYTE);
+impl_write_attribute!(u32 as u64, UNSIGNED_INTEGER_BYTE);
+impl_write_attribute!(u64 as u64, UNSIGNED_INTEGER_BYTE);
+impl_write_attribute!(usize as u64, UNSIGNED_INTEGER_BYTE);
+
+impl_write_attribute!(i8 as i64, SIGNED_INTEGER_BYTE);
+impl_write_attribute!(i16 as i64, SIGNED_INTEGER_BYTE);
+impl_write_attribute!(i32 as i64, SIGNED_INTEGER_BYTE);
+impl_write_attribute!(i64 as i64, SIGNED_INTEGER_BYTE);
+impl_write_attribute!(isize as i64, SIGNED_INTEGER_BYTE);
+
+impl_write_attribute!(f32 as f64, FLOAT_BYTE);
+impl_write_attribute!(f64 as f64, FLOAT_BYTE);
+
+impl WriteAttribute for str {
+    const TYPE_BYTE: u8 = STRING_BYTE;
+
+    fn write_attribute(&self, buf: &mut Vec<u8>) {
+        let bytes = self.as_bytes();
+        let length = bytes.len() as u16;
+        buf.extend_from_slice(&length.to_be_bytes());
+        buf.extend_from_slice(bytes);
+    }
+}
+
+impl WriteAttribute for String {
+    const TYPE_BYTE: u8 = STRING_BYTE;
+
+    fn write_attribute(&self, buf: &mut Vec<u8>) {
+        (&**self).write_attribute(buf)
+    }
+}
+
+impl<T> WriteAttribute for [T]
+where
+    T: WriteAttribute,
+{
+    const TYPE_BYTE: u8 = T::TYPE_BYTE | (1 << 7); // Mark for array.
+
+    fn write_attribute(&self, buf: &mut Vec<u8>) {
+        let length = self.len() as u16;
+        buf.extend_from_slice(&length.to_be_bytes());
+
+        for attribute in self.iter() {
+            attribute.write_attribute(buf)
+        }
+    }
+}
+
+impl<T, const N: usize> WriteAttribute for [T; N]
+where
+    T: WriteAttribute,
+{
+    const TYPE_BYTE: u8 = T::TYPE_BYTE | (1 << 7); // Mark for array.
+
+    fn write_attribute(&self, buf: &mut Vec<u8>) {
+        (&self[..]).write_attribute(buf)
+    }
+}
+
 /// Macro to create a new [`Event`] type.
+///
+/// The attributes supported are currently limited to any sized (un)signed
+/// integer (e.g. `u64`, `usize`, `i64` etc), floats (`f32` and `f64`), strings
+/// (`str` and `String`) and slices (and arrays).
 macro_rules! event {
     ($msg: expr) => {{
-        #[derive(Copy, Clone)]
         #[allow(missing_docs)]
         struct Event;
 
         impl $crate::rt::trace::Event for Event {
             const DESCRIPTION: &'static str = $msg;
 
-            fn write_attributes(&self, buf: &mut Vec<u8>) {
-                buf.extend_from_slice(b"{}");
-            }
+            fn write_attributes(&self, _: &mut Vec<u8>) { /* Do nothing. */ }
 
             fn _do_not_manually_implement_this_it_wont_work() {}
         }
@@ -234,26 +374,25 @@ macro_rules! event {
         Event
     }};
     ($msg: expr, {
-        $( $attribute_key: ident : $attribute_type: ty = $attribute_value: expr),+ $(,)*
+        $( $attribute_name: ident : $attribute_type: ty = $attribute_value: expr),+ $(,)*
     }) => {{
-        #[derive(Copy, Clone)]
         #[allow(missing_docs)]
         struct Event {
-            $( $attribute_key : $attribute_type ),+
+            $( $attribute_name : $attribute_type ),+
         }
 
         impl $crate::rt::trace::Event for Event {
             const DESCRIPTION: &'static str = $msg;
 
             fn write_attributes(&self, buf: &mut Vec<u8>) {
-                use std::io::Write;
-                // TODO: don't write integers in quotes.
-                write!(buf,
-                    concat!("{{", $( "\"", stringify!($attribute_key), "\":\"{}\"," ),+ ),
-                    $( &self.$attribute_key ),+
-                ).unwrap_or_else(|_| unreachable!());
-                let _ = buf.pop(); // Remove last `,` not allowed in JSON.
-                buf.extend_from_slice(b"}");
+                use $crate::rt::trace::WriteAttribute;
+                $(
+                    // Write the attribute name.
+                    stringify!($attribute_name).write_attribute(buf);
+                    // Write the attribute value.
+                    buf.push(self.$attribute_name.type_byte());
+                    self.$attribute_name.write_attribute(buf);
+                )+
             }
 
             fn _do_not_manually_implement_this_it_wont_work() {}
@@ -264,15 +403,14 @@ macro_rules! event {
                 use $crate::rt::trace::Event;
                 f.debug_struct("Event")
                     .field("description", &Self::DESCRIPTION)
-                    $( .field(stringify!($attribute_key), &self.$attribute_key) )+
+                    $( .field(stringify!($attribute_name), &self.$attribute_name) )+
                     .finish()
             }
         }
 
         #[allow(clippy::redundant_field_names)]
         Event {
-
-            $( $attribute_key : $attribute_value ),+
+            $( $attribute_name : $attribute_value ),+
         }
     }};
 }

--- a/src/rt/trace.rs
+++ b/src/rt/trace.rs
@@ -44,7 +44,10 @@ impl Log {
         // (i.e. the epoch for this trace).
         let epoch = Instant::now();
 
-        let file = OpenOptions::new().append(true).create(true).open(path)?;
+        let file = OpenOptions::new()
+            .append(true)
+            .create_new(true)
+            .open(path)?;
 
         // Write the metadata for the trace log, currently it only sets the
         // epoch time.

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -309,7 +309,7 @@ impl RunningRuntime {
                     rt::trace::finish(
                         trace_log,
                         timing,
-                        event!("Running thread-local process", {
+                        event!("Running thread-local process", attributes: {
                             id: usize = pid.0,
                             name: &'static str = name,
                         }),
@@ -334,7 +334,7 @@ impl RunningRuntime {
                     rt::trace::finish(
                         trace_log,
                         timing,
-                        event!("Running thread-safe process", {
+                        event!("Running thread-safe process", attributes: {
                             id: usize = pid.0,
                             name: &'static str = name,
                         }),

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "heph-tools"
+version = "0.1.0"
+authors = ["Thomas de Zeeuw <thomasdezeeuw@gmail.com>"]
+edition = "2018"

--- a/tools/src/bin/convert_trace.rs
+++ b/tools/src/bin/convert_trace.rs
@@ -1,0 +1,536 @@
+//! Tool to convert a Heph trace to [Chrome's Trace Event Format] so it can be
+//! opened by [Catapult trace view].
+//!
+//! [Chrome's Trace Event Format]: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+//! [Catapult trace view]: https://chromium.googlesource.com/catapult/+/refs/heads/master/tracing/README.md
+
+use std::convert::TryInto;
+use std::env::args;
+use std::fs::{File, OpenOptions};
+use std::io::{self, stdin, Read, Stdin, Write};
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+use std::{fmt, str};
+
+fn main() {
+    let mut args = args().skip(1);
+    let input = args.next().expect("missing input trace file path");
+    let output = args.next().expect("missing ouput path");
+
+    let mut trace = Trace::open(input).expect("can't open trace file");
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(output)
+        .expect("can't open output file");
+
+    output
+        .write_all(b"{\n\t\"displayTimeUnit\": \"ns\",\n\t\"traceEvents\": [\n")
+        .expect("failed to write header to output");
+
+    let mut first = true;
+    for event in trace.events() {
+        let event = event.expect("error reading trace file");
+
+        let timestamp = event
+            .start
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_micros();
+        let duration = event.end.duration_since(event.start).unwrap().as_micros();
+
+        write!(
+            output,
+            "{}\t\t{{\"tid\": {}, \"ts\": {}, \"dur\": {}, \"name\": \"{}\"",
+            if first { "" } else { ",\n" },
+            event.stream_id,
+            timestamp,
+            duration,
+            event.description,
+        )
+        .expect("failed to write event to output");
+        first = false;
+        let mut first_attribute = true;
+        if !event.attributes.is_empty() {
+            output
+                .write_all(b", \"args\": {")
+                .expect("failed to write event to output");
+            for (name, value) in event.attributes.iter() {
+                let fmt_args = match value {
+                    // NOTE: `format_args!` is useless.
+                    Value::Unsigned(value) => format!("\"{}\": {}", name, value),
+                    Value::Signed(value) => format!("\"{}\": {}", name, value),
+                    Value::Float(value) => format!("\"{}\": {}", name, value),
+                    Value::String(value) => format!("\"{}\": \"{}\"", name, value),
+                };
+                write!(
+                    output,
+                    "{}{}",
+                    if first_attribute { "" } else { ", " },
+                    fmt_args
+                )
+                .expect("failed to write event to output");
+                first_attribute = false;
+            }
+            output
+                .write_all(b"}")
+                .expect("failed to write event to output");
+        }
+        output
+            .write_all(b", \"ph\": \"X\", \"cat\": \"\", \"pid\": 0}")
+            .expect("failed to write event to output");
+    }
+
+    output
+        .write_all(b"\n\t]\n}")
+        .expect("failed to write footer to output");
+
+    println!("OK.");
+}
+
+pub struct Trace<R> {
+    reader: R,
+    epoch: SystemTime,
+    // TODO: use VecDeque?
+    buf: Vec<u8>,
+}
+
+impl Trace<File> {
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Trace<File>> {
+        File::open(path).map(Trace::from_reader)
+    }
+}
+
+impl Trace<Stdin> {
+    pub fn from_stdin() -> Trace<Stdin> {
+        Trace::from_reader(stdin())
+    }
+}
+
+impl<R> Trace<R> {
+    pub fn from_reader(reader: R) -> Trace<R> {
+        Trace {
+            reader,
+            epoch: SystemTime::now(),
+            buf: Vec::with_capacity(4096),
+        }
+    }
+
+    pub fn events<'t>(&'t mut self) -> TraceEvents<'t, R> {
+        TraceEvents { trace: self }
+    }
+}
+
+impl<R> Trace<R>
+where
+    R: Read,
+{
+    fn fill_buffer(&mut self) -> io::Result<()> {
+        let original_length = self.buf.len();
+        self.buf.resize(self.buf.capacity(), 0);
+        match self.reader.read(&mut self.buf[original_length..]) {
+            // TODO: handle 0 bytes read?
+            Ok(n) => {
+                self.buf.truncate(original_length + n);
+                Ok(())
+            }
+            Err(err) => {
+                self.buf.truncate(original_length);
+                Err(err)
+            }
+        }
+    }
+}
+
+// TODO: when hitting error maybe seek until the next magic value and continue
+// from there?
+pub struct TraceEvents<'t, R> {
+    trace: &'t mut Trace<R>,
+}
+
+const METADATA_MAGIC: u32 = 0x75D11D4D;
+const EVENT_MAGIC: u32 = 0xC1FC1FB7;
+
+/// Minimum amount of bytes in the buffer before we read again.
+const MIN_BUF_SIZE: usize = 128;
+
+// TODO: use `cmp::min`, once that stable as constant.
+const MIN_PACKET_SIZE: usize = if MIN_METADATA_PACKET_SIZE < MIN_EVENT_PACKET_SIZE {
+    MIN_METADATA_PACKET_SIZE
+} else {
+    MIN_EVENT_PACKET_SIZE
+};
+const MIN_METADATA_PACKET_SIZE: usize = 10;
+const MIN_EVENT_PACKET_SIZE: usize = 34;
+
+impl<'t, R> Iterator for TraceEvents<'t, R>
+where
+    R: Read,
+{
+    type Item = Result<Event, ParseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let trace = &mut *self.trace;
+        if trace.buf.len() < MIN_BUF_SIZE {
+            if let Err(err) = trace.fill_buffer() {
+                return Some(Err(ParseError::IO(err)));
+            }
+        }
+
+        // Ensure we can read at least one packet.
+        if trace.buf.is_empty() {
+            return None;
+        } else if trace.buf.len() < MIN_PACKET_SIZE {
+            return Some(Err(ParseError::MissingPacketData {
+                got: trace.buf.len(),
+                want: MIN_PACKET_SIZE,
+            }));
+        }
+
+        let (_, magic) = parse_u32(&trace.buf);
+        match magic {
+            METADATA_MAGIC => {
+                if let Err(err) = self.apply_metadata_packet() {
+                    Some(Err(err.into()))
+                } else {
+                    self.next()
+                }
+            }
+            EVENT_MAGIC => Some(self.parse_event_packet().map_err(|e| e.into())),
+            magic => Some(Err(ParseError::InvalidMagic(magic))),
+        }
+    }
+}
+
+impl<'t, R> TraceEvents<'t, R>
+where
+    R: Read,
+{
+    fn apply_metadata_packet(&mut self) -> Result<(), ParseError> {
+        let trace = &mut *self.trace;
+        debug_assert_eq!(trace.buf[0..4], METADATA_MAGIC.to_be_bytes());
+
+        let (left, packet_size) = parse_u32(&trace.buf[4..]);
+        let packet_size = packet_size as usize;
+        if packet_size <= MIN_METADATA_PACKET_SIZE {
+            return Err(ParseError::PacketTooSmall {
+                packet_kind: "metadata",
+                got: packet_size,
+            });
+        } else if trace.buf.len() < packet_size {
+            return Err(ParseError::MissingPacketData {
+                want: packet_size,
+                got: trace.buf.len(),
+            });
+        }
+
+        let (left, option_name) = match parse_string(left) {
+            Ok((left, option_name)) => (left, option_name),
+            Err(err) => match err {
+                StringParseError::TooSmall => {
+                    return Err(ParseError::StringTooSmall {
+                        packet_kind: "metadata",
+                        field: "option name",
+                    })
+                }
+                StringParseError::InvalidUTF8 => {
+                    return Err(ParseError::InvalidString {
+                        packet_kind: "metadata",
+                        field: "option name",
+                    })
+                }
+            },
+        };
+
+        match option_name {
+            "epoch" if left.len() <= 8 => Err(ParseError::MissingPacketData {
+                got: left.len(),
+                want: 8,
+            }),
+            "epoch" => {
+                let (_, nanos) = parse_u64(left);
+                trace.epoch = SystemTime::UNIX_EPOCH + Duration::from_nanos(nanos);
+                // TODO: check that all bytes according to packet_size are
+                // processed.
+                trace.buf.drain(..packet_size);
+                Ok(())
+            }
+            _ => Err(ParseError::UnknownOption(option_name.to_owned())),
+        }
+    }
+
+    fn parse_event_packet(&mut self) -> Result<Event, ParseError> {
+        let trace = &mut *self.trace;
+        debug_assert_eq!(trace.buf[0..4], EVENT_MAGIC.to_be_bytes());
+
+        let (left, packet_size) = parse_u32(&trace.buf[4..]);
+        let packet_size = packet_size as usize;
+        if packet_size <= MIN_EVENT_PACKET_SIZE {
+            return Err(ParseError::PacketTooSmall {
+                packet_kind: "event",
+                got: packet_size,
+            });
+        } else if trace.buf.len() < packet_size {
+            return Err(ParseError::MissingPacketData {
+                got: trace.buf.len(),
+                want: packet_size,
+            });
+        }
+
+        let (left, stream_id) = parse_u32(&left[..packet_size - 8]);
+        let (left, stream_counter) = parse_u32(left);
+        let (left, start) = parse_timestamp(left, trace.epoch);
+        let (left, end) = parse_timestamp(left, trace.epoch);
+        let (left, description) = match parse_string(left) {
+            Ok((left, description)) => (left, description.to_owned()),
+            Err(err) => match err {
+                StringParseError::TooSmall => {
+                    return Err(ParseError::StringTooSmall {
+                        packet_kind: "event",
+                        field: "description",
+                    })
+                }
+                StringParseError::InvalidUTF8 => {
+                    return Err(ParseError::InvalidString {
+                        packet_kind: "event",
+                        field: "description",
+                    })
+                }
+            },
+        };
+
+        let mut attributes = Vec::new();
+        let mut left = left;
+        while !left.is_empty() {
+            let attribute_name = match parse_string(left) {
+                Ok((l, attribute_name)) => {
+                    left = l;
+                    attribute_name.to_owned()
+                }
+                Err(err) => match err {
+                    StringParseError::TooSmall => {
+                        return Err(ParseError::StringTooSmall {
+                            packet_kind: "event",
+                            field: "attribute name",
+                        })
+                    }
+                    StringParseError::InvalidUTF8 => {
+                        return Err(ParseError::InvalidString {
+                            packet_kind: "event",
+                            field: "attribute name",
+                        })
+                    }
+                },
+            };
+
+            let attribute_value = match parse_value(left) {
+                Ok((l, attribute_value)) => {
+                    left = l;
+                    attribute_value
+                }
+                Err(err) => match err {
+                    ValueParseError::StringParseError(StringParseError::TooSmall) => {
+                        return Err(ParseError::StringTooSmall {
+                            packet_kind: "event",
+                            field: "attribute value",
+                        })
+                    }
+                    ValueParseError::StringParseError(StringParseError::InvalidUTF8) => {
+                        return Err(ParseError::InvalidString {
+                            packet_kind: "event",
+                            field: "attribute value",
+                        })
+                    }
+                    ValueParseError::UnknownType(byte) => {
+                        return Err(ParseError::UnknownValueType(byte))
+                    }
+                },
+            };
+
+            attributes.push((attribute_name, attribute_value));
+        }
+
+        // TODO: check all bytes from packet are read.
+        trace.buf.drain(..packet_size);
+
+        Ok(Event {
+            stream_id,
+            stream_counter,
+            start,
+            end,
+            description,
+            attributes,
+        })
+    }
+}
+
+/// Parse a single `u32` from `bytes`.
+///
+/// # Panics
+///
+/// Panics if `bytes` is less than 4 bytes long.
+fn parse_u32(bytes: &[u8]) -> (&[u8], u32) {
+    let n = u32::from_be_bytes(bytes[0..4].try_into().unwrap());
+    (&bytes[4..], n)
+}
+
+/// Parse a single `u64` from `bytes`.
+///
+/// # Panics
+///
+/// Panics if `bytes` is less than 8 bytes long.
+fn parse_u64(bytes: &[u8]) -> (&[u8], u64) {
+    let n = u64::from_be_bytes(bytes[0..8].try_into().unwrap());
+    (&bytes[8..], n)
+}
+
+/// See [`parse_u64`].
+fn parse_i64(bytes: &[u8]) -> (&[u8], i64) {
+    let n = i64::from_be_bytes(bytes[0..8].try_into().unwrap());
+    (&bytes[8..], n)
+}
+
+/// See [`parse_u64`].
+fn parse_f64(bytes: &[u8]) -> (&[u8], f64) {
+    let n = f64::from_be_bytes(bytes[0..8].try_into().unwrap());
+    (&bytes[8..], n)
+}
+
+/// Parse a single timestamp from `bytes`.
+///
+/// # Panics
+///
+/// Panics if `bytes` is less than 8 bytes long.
+fn parse_timestamp(bytes: &[u8], epoch: SystemTime) -> (&[u8], SystemTime) {
+    let (left, nanos) = parse_u64(bytes);
+    let timestamp = epoch + Duration::from_nanos(nanos);
+    (left, timestamp)
+}
+
+/// Parse a single string from `bytes`.
+///
+/// # Panics
+///
+/// Panics if `bytes` is less than 2 bytes long.
+fn parse_string(bytes: &[u8]) -> Result<(&[u8], &str), StringParseError> {
+    let len = u16::from_be_bytes(bytes[0..2].try_into().unwrap()) as usize;
+    if bytes.len() - 2 < len {
+        Err(StringParseError::TooSmall)
+    } else {
+        let (string, left) = bytes[2..].split_at(len);
+        match str::from_utf8(string) {
+            Ok(string) => Ok((left, string)),
+            Err(..) => Err(StringParseError::InvalidUTF8),
+        }
+    }
+}
+
+enum StringParseError {
+    TooSmall,
+    InvalidUTF8,
+}
+
+/// Parse a single value from `bytes`.
+fn parse_value(bytes: &[u8]) -> Result<(&[u8], Value), ValueParseError> {
+    match bytes[0] {
+        0b001 => {
+            let (left, value) = parse_u64(&bytes[1..]);
+            Ok((left, Value::Unsigned(value)))
+        }
+        0b010 => {
+            let (left, value) = parse_i64(&bytes[1..]);
+            Ok((left, Value::Signed(value)))
+        }
+        0b011 => {
+            let (left, value) = parse_f64(&bytes[1..]);
+            Ok((left, Value::Float(value)))
+        }
+        0b100 => match parse_string(&bytes[1..]) {
+            Ok((left, value)) => Ok((left, Value::String(value.to_owned()))),
+            Err(err) => Err(ValueParseError::StringParseError(err)),
+        },
+        byte => Err(ValueParseError::UnknownType(byte)),
+        // TODO: parse slice of values.
+    }
+}
+
+enum ValueParseError {
+    StringParseError(StringParseError),
+    UnknownType(u8),
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+    IO(io::Error),
+    MissingPacketData {
+        got: usize,
+        want: usize,
+    },
+    InvalidMagic(u32),
+    PacketTooSmall {
+        packet_kind: &'static str,
+        got: usize,
+    },
+    StringTooSmall {
+        packet_kind: &'static str,
+        field: &'static str,
+    },
+    InvalidString {
+        packet_kind: &'static str,
+        field: &'static str,
+    },
+    UnknownOption(String),
+    UnknownValueType(u8),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ParseError::*;
+        match self {
+            IO(err) => write!(f, "error reading trace: {}", err),
+            MissingPacketData { got, want } => write!(
+                f,
+                "missing packet data, want {} bytes, got {} bytes",
+                want, got
+            ),
+            InvalidMagic(got_magic) => {
+                write!(f, "packet has invalid magic value '{:#}'", got_magic)
+            }
+            PacketTooSmall { packet_kind, got } => write!(
+                f,
+                "{} packet size too small, got {} bytes",
+                packet_kind, got
+            ),
+            StringTooSmall { packet_kind, field } => write!(
+                f,
+                "missign string data in {} packet, {} field",
+                packet_kind, field
+            ),
+            InvalidString { packet_kind, field } => write!(
+                f,
+                "invalid string in {} packet, {} field",
+                packet_kind, field
+            ),
+            UnknownOption(option_name) => write!(f, "unknown option name '{}'", option_name),
+            UnknownValueType(byte) => write!(f, "unknown value type byte '{:#}'", byte),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Event {
+    stream_id: u32,
+    stream_counter: u32,
+    start: SystemTime,
+    end: SystemTime,
+    description: String,
+    attributes: Vec<(String, Value)>,
+}
+
+#[derive(Debug)]
+pub enum Value {
+    Unsigned(u64),
+    Signed(i64),
+    Float(f64),
+    String(String),
+}


### PR DESCRIPTION
Alternative to  #330. #330 collects the metrics in memory to expose them (somehow) at some point. This implementation writes events the moment they happen.

It currently writes a JSON (like) trace to a file, but it needs to use a proper (standardised) format. This an example of running the Hello World example:

```log
{"stream_id":0,"description":"Creating worker threads","start":1609960949727107000,"elapsed":"137.218µs","attributes":{"amount":"1"}}
{"stream_id":1,"description":"Initialising the worker thread","start":1609960949727290000,"elapsed":"65.237µs","attributes":{}}
{"stream_id":0,"description":"Initialising the coordinator thread","start":1609960949727345000,"elapsed":"27.821µs","attributes":{}}
{"stream_id":0,"description":"Polling for OS events","start":1609960949727391000,"elapsed":"12.341µs","attributes":{}}
{"stream_id":0,"description":"Processing worker event","start":1609960949727415000,"elapsed":"2.948µs","attributes":{}}
{"stream_id":1,"description":"Running user setup function","start":1609960949727379000,"elapsed":"53.877µs","attributes":{}}
{"stream_id":0,"description":"Processing worker event","start":1609960949727428000,"elapsed":"12.781µs","attributes":{}}
{"stream_id":0,"description":"Handling OS events","start":1609960949727412000,"elapsed":"46.092µs","attributes":{}}
{"stream_id":0,"description":"Scheduling thread-safe processes based on wake-up events","start":1609960949727467000,"elapsed":"1.773µs","attributes":{}}
{"stream_id":0,"description":"Scheduling thread-safe processes based on timers","start":1609960949727479000,"elapsed":"1.016µs","attributes":{}}
{"stream_id":1,"description":"Running thread-local process","start":1609960949727449000,"elapsed":"48.675µs","attributes":{"id":"140261507220176","name":"greeter_actor"}}
{"stream_id":0,"description":"Polling for OS events","start":1609960949727498000,"elapsed":"78.39µs","attributes":{}}
{"stream_id":0,"description":"Processing worker event","start":1609960949727601000,"elapsed":"4.318µs","attributes":{}}
{"stream_id":0,"description":"Processing worker event","start":1609960949727624000,"elapsed":"50.63µs","attributes":{}}
{"stream_id":0,"description":"Handling OS events","start":1609960949727600000,"elapsed":"87.443µs","attributes":{}}
{"stream_id":0,"description":"Scheduling thread-safe processes based on wake-up events","start":1609960949727696000,"elapsed":"913ns","attributes":{}}
{"stream_id":0,"description":"Scheduling thread-safe processes based on timers","start":1609960949727704000,"elapsed":"1.159µs","attributes":{}}
```

There are two critical components for this to work:
1. The trace should be split into streams; this uses one stream per (worker/sync worker/coordinator) thread. This allows us to group events together while not having to worry about the order being messed up.
2. Events must be allowed to have a timestamp (`start`) earlier than a previous event. This allow the creation of parent-child event relations. E.g. from the example above `Handling OS events` has a timestamp earlier than `Processing worker event` with an elapsed time that capture the two `Processing worker event` events. This create a parent-child relation with the code knowing about it. This way we don't have to drag that context through the code, something that is required for many other tracing libraries. Also wall-clock can go backwards in time, so the output processor has to deal with that anyway.

Ideally we would be able to create a nice timeline similar to what Go can do, e.g. see https://blog.gopheracademy.com/advent-2017/go-execution-tracer or https://medium.com/a-journey-with-go/go-discovery-of-the-trace-package-e5a821743c3c.

TODO:
* [x] Proper trace format. Maybe Common Trace Format (CTF): https://diamon.org/ctf?
* [x] Design document for the trace format.
* [ ] Publicly expose this (in a nice way).

Updates #31.