### PR TITLE
Change tracing events to use trait objects

### DIFF
--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -104,7 +104,8 @@ impl Coordinator {
         rt::trace::finish(
             &mut trace_log,
             timing,
-            event!("Initialising the coordinator thread"),
+            "Initialising the coordinator thread",
+            &[],
         );
 
         // Index of the last worker we waked, must never be larger then
@@ -119,7 +120,7 @@ impl Coordinator {
             // Process OS events.
             self.poll(&mut events)
                 .map_err(|err| rt::Error::coordinator(Error::Polling(err)))?;
-            rt::trace::finish(&mut trace_log, timing, event!("Polling for OS events"));
+            rt::trace::finish(&mut trace_log, timing, "Polling for OS events", &[]);
 
             let timing = rt::trace::start(&trace_log);
             for event in events.iter() {
@@ -129,22 +130,14 @@ impl Coordinator {
                         let timing = rt::trace::start(&trace_log);
                         relay_signals(&mut signals, &mut workers, &mut signal_refs)
                             .map_err(|err| rt::Error::coordinator(Error::SignalRelay(err)))?;
-                        rt::trace::finish(
-                            &mut trace_log,
-                            timing,
-                            event!("Relaying process signal"),
-                        );
+                        rt::trace::finish(&mut trace_log, timing, "Relaying process signal", &[]);
                     }
                     // We always check for waker events below.
                     WAKER => {}
                     token if token.0 < SYNC_WORKER_ID_START => {
                         let timing = rt::trace::start(&trace_log);
                         handle_worker_event(&mut workers, event)?;
-                        rt::trace::finish(
-                            &mut trace_log,
-                            timing,
-                            event!("Processing worker event"),
-                        );
+                        rt::trace::finish(&mut trace_log, timing, "Processing worker event", &[]);
                     }
                     token if token.0 <= SYNC_WORKER_ID_END => {
                         let timing = rt::trace::start(&trace_log);
@@ -152,7 +145,8 @@ impl Coordinator {
                         rt::trace::finish(
                             &mut trace_log,
                             timing,
-                            event!("Processing sync worker event"),
+                            "Processing sync worker event",
+                            &[],
                         );
                     }
                     token => {
@@ -164,12 +158,13 @@ impl Coordinator {
                         rt::trace::finish(
                             &mut trace_log,
                             timing,
-                            event!("Scheduling thread-safe process"),
+                            "Scheduling thread-safe process",
+                            &[],
                         );
                     }
                 }
             }
-            rt::trace::finish(&mut trace_log, timing, event!("Handling OS events"));
+            rt::trace::finish(&mut trace_log, timing, "Handling OS events", &[]);
 
             trace!("polling wake-up events");
             let timing = rt::trace::start(&trace_log);
@@ -183,7 +178,8 @@ impl Coordinator {
             rt::trace::finish(
                 &mut trace_log,
                 timing,
-                event!("Scheduling thread-safe processes based on wake-up events"),
+                "Scheduling thread-safe processes based on wake-up events",
+                &[],
             );
 
             trace!("polling timers");
@@ -196,7 +192,8 @@ impl Coordinator {
             rt::trace::finish(
                 &mut trace_log,
                 timing,
-                event!("Scheduling thread-safe processes based on timers"),
+                "Scheduling thread-safe processes based on timers",
+                &[],
             );
 
             // In case the worker threads are polling we need to wake them up.
@@ -231,9 +228,8 @@ impl Coordinator {
                 rt::trace::finish(
                     &mut trace_log,
                     timing,
-                    event!("Waking worker threads", attributes: {
-                        amount: usize = wake_workers,
-                    }),
+                    "Waking worker threads",
+                    &[("amount", &wake_workers)],
                 );
             }
 

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -434,9 +434,8 @@ where
         trace::finish(
             &mut self.trace_log,
             timing,
-            event!("Creating worker threads", attributes: {
-                amount: usize = self.threads,
-            }),
+            "Creating worker threads",
+            &[("amount", &self.threads)],
         );
 
         // Drop stuff we don't need anymore. For the setup function this is

--- a/src/rt/trace.rs
+++ b/src/rt/trace.rs
@@ -1,17 +1,11 @@
 //! Tracing utilities.
 
-#![allow(dead_code, unused_imports, missing_docs, missing_debug_implementations)]
-
-use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
-use std::mem::size_of;
 use std::path::Path;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Instant, SystemTime};
 
 use log::warn;
-
-use crate::rt::ProcessId;
 
 /// Default buffer size of `Log`.
 const BUF_SIZE: usize = 128;
@@ -77,16 +71,13 @@ impl Log {
     }
 
     /// Append `event` to trace `Log`.
-    pub(crate) fn append<E>(&mut self, event: &Metadata<E>) -> io::Result<()>
-    where
-        E: Event,
-    {
+    fn append(&mut self, event: &Event<'_>) -> io::Result<()> {
         const MAGIC: u32 = 0xC1FC1FB7;
 
         let stream_count: u32 = self.next_stream_count();
         let start_nanos: u64 = self.nanos_since_epoch(event.start);
         let end_nanos: u64 = self.nanos_since_epoch(event.end);
-        let description: &[u8] = E::DESCRIPTION.as_bytes();
+        let description: &[u8] = event.description.as_bytes();
         let description_len: u16 = description.len() as u16;
 
         self.buf.clear();
@@ -98,7 +89,12 @@ impl Log {
         self.buf.extend_from_slice(&end_nanos.to_be_bytes());
         self.buf.extend_from_slice(&description_len.to_be_bytes());
         self.buf.extend_from_slice(description);
-        event.event.write_attributes(&mut self.buf);
+        for (name, value) in event.attributes {
+            use private::AttributeValue;
+            (&**name).write_attribute(&mut self.buf);
+            self.buf.push(value.type_byte());
+            value.write_attribute(&mut self.buf);
+        }
         let packet_size = self.buf.len() as u32;
         self.buf[4..8].copy_from_slice(&packet_size.to_be_bytes());
 
@@ -143,42 +139,6 @@ fn write_epoch_metadata(buf: &mut Vec<u8>, time: SystemTime) {
     buf.extend_from_slice(&nanos_since_unix.to_be_bytes());
 }
 
-/// Returns the number of nanoseconds since `epoch`.
-///
-/// (2 ^ 64) / 1000000000 / (365 * 24 * 60 * 60) ~= 584 years.
-/// So restart the application once every 500 years and you're good.
-#[track_caller]
-fn nanos_since_epoch(epoch: Instant, time: Instant) -> u64 {
-    time.duration_since(epoch).as_nanos() as u64
-}
-
-/// Start timing for an event (using [`EventTiming`]) if we're tracing, i.e. if
-/// `log` is `Some`.
-pub(crate) fn start(log: &Option<Log>) -> Option<EventTiming> {
-    if log.is_some() {
-        Some(EventTiming::start())
-    } else {
-        None
-    }
-}
-
-/// Finish a trace, partner function to [`start`].
-///
-/// If `log` is `Some` `timing` must also be `Some.
-#[track_caller]
-pub(crate) fn finish<E>(log: &mut Option<Log>, timing: Option<EventTiming>, event: E)
-where
-    E: Event,
-{
-    if let Some(log) = log.as_mut() {
-        let timing = timing.unwrap();
-        let event = timing.finish(event);
-        if let Err(err) = log.append(&event) {
-            warn!("error writing trace data: {}", err);
-        }
-    }
-}
-
 /// Write the entire `buf`fer into the `output` or return an error.
 #[inline(always)]
 fn write_once<W>(mut output: W, buf: &[u8]) -> io::Result<()>
@@ -199,222 +159,202 @@ where
     })
 }
 
-/// Metadata wrapping an [`Event`].
-#[derive(Debug)]
-pub(crate) struct Metadata<E> {
-    start: Instant,
-    end: Instant,
-    event: E,
+/// Start timing an event (using [`EventTiming`]) if we're tracing, i.e. if
+/// `log` is `Some`.
+pub(crate) fn start(log: &Option<Log>) -> Option<EventTiming> {
+    if log.is_some() {
+        Some(EventTiming::start())
+    } else {
+        None
+    }
+}
+
+/// Finish a trace, partner function to [`start`].
+///
+/// If `log` is `Some` `timing` must also be `Some`.
+#[track_caller]
+pub(crate) fn finish(
+    log: &mut Option<Log>,
+    timing: Option<EventTiming>,
+    description: &str,
+    attributes: &[(&str, &dyn AttributeValue)],
+) {
+    if let Some(log) = log.as_mut() {
+        let timing = timing.unwrap();
+        let event = timing.finish(description, attributes);
+        if let Err(err) = log.append(&event) {
+            warn!("error writing trace data: {}", err);
+        }
+    }
 }
 
 /// Time an [`Event`].
 #[derive(Debug)]
-pub(crate) struct EventTiming {
+pub struct EventTiming {
     start: Instant,
 }
 
 impl EventTiming {
-    /// Start timing.
-    pub(crate) fn start() -> EventTiming {
+    /// Start timing an event.
+    fn start() -> EventTiming {
         let start = Instant::now();
         EventTiming { start }
     }
 
-    /// Finish timing `event`.
-    pub(crate) fn finish<E>(self, event: E) -> Metadata<E> {
+    /// Finish timing an event.
+    fn finish<'e>(
+        self,
+        description: &'e str,
+        attributes: &'e [(&'e str, &'e dyn AttributeValue)],
+    ) -> Event<'e> {
         let end = Instant::now();
-        Metadata {
+        Event {
             start: self.start,
             end,
-            event,
+            description,
+            attributes,
         }
     }
 }
 
-/// Trait that defines an event.
-///
-/// An event is simple, it has a human-readable description and optional
-/// attributes. To create an event type use the [`event!`] macro.
-pub(crate) trait Event {
-    /// Description of the event in human-readable text, e.g. `run process`.
-    const DESCRIPTION: &'static str;
-
-    /// Write attributes related to this event to the `buf`fer.
-    ///
-    /// For example if we're running a process we would write the process id as
-    /// a possible attribute.
-    ///
-    /// Use the [`WriteAttribute`] trait for this.
-    fn write_attributes(&self, buf: &mut Vec<u8>);
-
-    /// Use the [`event!`] macro instead.
-    #[doc(hidden)]
-    fn _do_not_manually_implement_this_it_wont_work();
+/// A trace event.
+pub struct Event<'e> {
+    start: Instant,
+    end: Instant,
+    description: &'e str,
+    attributes: &'e [(&'e str, &'e dyn AttributeValue)],
 }
 
-/// The [`WriteAttribute::TYPE_BYTE`] constants.
-const UNSIGNED_INTEGER_BYTE: u8 = 0b001;
-const SIGNED_INTEGER_BYTE: u8 = 0b010;
-const FLOAT_BYTE: u8 = 0b011;
-pub(crate) const STRING_BYTE: u8 = 0b100; // Used in `event!` macro.
-/// Marks a type bytes as array.
-const ARRAY_MARKER_BYTE: u8 = 1 << 7;
+pub trait AttributeValue: private::AttributeValue {}
 
-// Use in `event!` macro.
-pub(crate) trait WriteAttribute {
-    /// The type byte for this attribute.
-    const TYPE_BYTE: u8;
+impl<T> AttributeValue for T where T: private::AttributeValue {}
 
-    /// Must return [`Self::TYPE_BYTE`].
-    fn type_byte(&self) -> u8 {
-        Self::TYPE_BYTE
+mod private {
+    //! Module with private version of [`AttributeValue`].
+
+    /// The [`WriteAttribute::TYPE_BYTE`] constants.
+    const UNSIGNED_INTEGER_BYTE: u8 = 0b001;
+    const SIGNED_INTEGER_BYTE: u8 = 0b010;
+    const FLOAT_BYTE: u8 = 0b011;
+    const STRING_BYTE: u8 = 0b100;
+    /// Marks a type bytes as array.
+    const ARRAY_MARKER_BYTE: u8 = 1 << 7;
+
+    pub trait AttributeValue {
+        /// The type byte for this attribute value.
+        // NOTE: this should be a assiociated constant, however that is not
+        // object safe.
+        fn type_byte(&self) -> u8;
+
+        /// Write the contents of the attribute, without type byte.
+        fn write_attribute(&self, buf: &mut Vec<u8>);
     }
 
-    /// Write the contents of the attribute, without type byte.
-    fn write_attribute(&self, buf: &mut Vec<u8>);
-}
+    impl<'a, T> AttributeValue for &'a T
+    where
+        T: AttributeValue + ?Sized,
+    {
+        #[inline(always)]
+        fn type_byte(&self) -> u8 {
+            (&**self).type_byte()
+        }
 
-macro_rules! impl_write_attribute {
-    ($ty: ty as $f_ty: ty, $type_byte: expr) => {
-        impl WriteAttribute for $ty {
-            const TYPE_BYTE: u8 = $type_byte;
+        fn write_attribute(&self, buf: &mut Vec<u8>) {
+            (&**self).write_attribute(buf)
+        }
+    }
 
-            fn write_attribute(&self, buf: &mut Vec<u8>) {
-                #[allow(trivial_numeric_casts)] // for `u64 as u64`, etc.
-                let value = *self as $f_ty;
-                buf.extend_from_slice(&value.to_be_bytes());
+    macro_rules! impl_write_attribute {
+        ($ty: ty as $f_ty: ty, $type_byte: expr) => {
+            impl AttributeValue for $ty {
+                #[inline(always)]
+                fn type_byte(&self) -> u8 {
+                    $type_byte
+                }
+
+                fn write_attribute(&self, buf: &mut Vec<u8>) {
+                    #[allow(trivial_numeric_casts)] // for `u64 as u64`, etc.
+                    let value = *self as $f_ty;
+                    buf.extend_from_slice(&value.to_be_bytes());
+                }
+            }
+        };
+    }
+
+    impl_write_attribute!(u8 as u64, UNSIGNED_INTEGER_BYTE);
+    impl_write_attribute!(u16 as u64, UNSIGNED_INTEGER_BYTE);
+    impl_write_attribute!(u32 as u64, UNSIGNED_INTEGER_BYTE);
+    impl_write_attribute!(u64 as u64, UNSIGNED_INTEGER_BYTE);
+    impl_write_attribute!(usize as u64, UNSIGNED_INTEGER_BYTE);
+
+    impl_write_attribute!(i8 as i64, SIGNED_INTEGER_BYTE);
+    impl_write_attribute!(i16 as i64, SIGNED_INTEGER_BYTE);
+    impl_write_attribute!(i32 as i64, SIGNED_INTEGER_BYTE);
+    impl_write_attribute!(i64 as i64, SIGNED_INTEGER_BYTE);
+    impl_write_attribute!(isize as i64, SIGNED_INTEGER_BYTE);
+
+    impl_write_attribute!(f32 as f64, FLOAT_BYTE);
+    impl_write_attribute!(f64 as f64, FLOAT_BYTE);
+
+    impl AttributeValue for str {
+        #[inline(always)]
+        fn type_byte(&self) -> u8 {
+            STRING_BYTE
+        }
+
+        fn write_attribute(&self, buf: &mut Vec<u8>) {
+            let bytes = self.as_bytes();
+            let length = bytes.len() as u16;
+            buf.extend_from_slice(&length.to_be_bytes());
+            buf.extend_from_slice(bytes);
+        }
+    }
+
+    impl AttributeValue for String {
+        #[inline(always)]
+        fn type_byte(&self) -> u8 {
+            (&**self).type_byte()
+        }
+
+        fn write_attribute(&self, buf: &mut Vec<u8>) {
+            (&**self).write_attribute(buf)
+        }
+    }
+
+    impl<T> AttributeValue for [T]
+    where
+        T: AttributeValue + Default,
+    {
+        #[inline(always)]
+        fn type_byte(&self) -> u8 {
+            let type_byte = match self.first() {
+                Some(elem) => elem.type_byte(),
+                // NOTE: this is not ideal...
+                None => T::default().type_byte(),
+            };
+            type_byte | ARRAY_MARKER_BYTE
+        }
+
+        fn write_attribute(&self, buf: &mut Vec<u8>) {
+            let length = self.len() as u16;
+            buf.extend_from_slice(&length.to_be_bytes());
+            for attribute in self.iter() {
+                attribute.write_attribute(buf)
             }
         }
-    };
-}
-
-impl_write_attribute!(u8 as u64, UNSIGNED_INTEGER_BYTE);
-impl_write_attribute!(u16 as u64, UNSIGNED_INTEGER_BYTE);
-impl_write_attribute!(u32 as u64, UNSIGNED_INTEGER_BYTE);
-impl_write_attribute!(u64 as u64, UNSIGNED_INTEGER_BYTE);
-impl_write_attribute!(usize as u64, UNSIGNED_INTEGER_BYTE);
-
-impl_write_attribute!(i8 as i64, SIGNED_INTEGER_BYTE);
-impl_write_attribute!(i16 as i64, SIGNED_INTEGER_BYTE);
-impl_write_attribute!(i32 as i64, SIGNED_INTEGER_BYTE);
-impl_write_attribute!(i64 as i64, SIGNED_INTEGER_BYTE);
-impl_write_attribute!(isize as i64, SIGNED_INTEGER_BYTE);
-
-impl_write_attribute!(f32 as f64, FLOAT_BYTE);
-impl_write_attribute!(f64 as f64, FLOAT_BYTE);
-
-impl WriteAttribute for str {
-    const TYPE_BYTE: u8 = STRING_BYTE;
-
-    fn write_attribute(&self, buf: &mut Vec<u8>) {
-        let bytes = self.as_bytes();
-        let length = bytes.len() as u16;
-        buf.extend_from_slice(&length.to_be_bytes());
-        buf.extend_from_slice(bytes);
     }
-}
 
-impl WriteAttribute for String {
-    const TYPE_BYTE: u8 = <str as WriteAttribute>::TYPE_BYTE;
+    impl<T, const N: usize> AttributeValue for [T; N]
+    where
+        T: AttributeValue + Default,
+    {
+        #[inline(always)]
+        fn type_byte(&self) -> u8 {
+            (&self[..]).type_byte()
+        }
 
-    fn write_attribute(&self, buf: &mut Vec<u8>) {
-        (&**self).write_attribute(buf)
-    }
-}
-
-impl<T> WriteAttribute for [T]
-where
-    T: WriteAttribute,
-{
-    const TYPE_BYTE: u8 = T::TYPE_BYTE | ARRAY_MARKER_BYTE;
-
-    fn write_attribute(&self, buf: &mut Vec<u8>) {
-        let length = self.len() as u16;
-        buf.extend_from_slice(&length.to_be_bytes());
-        for attribute in self.iter() {
-            attribute.write_attribute(buf)
+        fn write_attribute(&self, buf: &mut Vec<u8>) {
+            (&self[..]).write_attribute(buf)
         }
     }
-}
-
-impl<T, const N: usize> WriteAttribute for [T; N]
-where
-    T: WriteAttribute,
-{
-    const TYPE_BYTE: u8 = <[T] as WriteAttribute>::TYPE_BYTE;
-
-    fn write_attribute(&self, buf: &mut Vec<u8>) {
-        (&self[..]).write_attribute(buf)
-    }
-}
-
-/// Macro to create a new [`Event`] type.
-///
-/// The attributes supported are currently limited to any sized (un)signed
-/// integer (e.g. `u64`, `usize`, `i64` etc), floats (`f32` and `f64`), strings
-/// (`str` and `String`) and slices (and arrays).
-macro_rules! event {
-    ($msg: expr) => {{
-        #[allow(missing_docs)]
-        struct Event;
-
-        impl $crate::rt::trace::Event for Event {
-            const DESCRIPTION: &'static str = $msg;
-
-            fn write_attributes(&self, _: &mut Vec<u8>) { /* Do nothing. */ }
-
-            fn _do_not_manually_implement_this_it_wont_work() {}
-        }
-
-        impl std::fmt::Debug for Event {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                use $crate::rt::trace::Event;
-                f.debug_struct("Event")
-                    .field("description", &Self::DESCRIPTION)
-                    .finish()
-            }
-        }
-
-        Event
-    }};
-    ($msg: expr, attributes: {
-        $( $attribute_name: ident : $attribute_type: ty = $attribute_value: expr),+ $(,)*
-    }) => {{
-        #[allow(missing_docs)]
-        struct Event {
-            $( $attribute_name : $attribute_type ),+
-        }
-
-        impl $crate::rt::trace::Event for Event {
-            const DESCRIPTION: &'static str = $msg;
-
-            fn write_attributes(&self, buf: &mut Vec<u8>) {
-                use $crate::rt::trace::WriteAttribute;
-                $(
-                    // Write the attribute name.
-                    stringify!($attribute_name).write_attribute(buf);
-                    // Write the attribute value.
-                    buf.push(self.$attribute_name.type_byte());
-                    self.$attribute_name.write_attribute(buf);
-                )+
-            }
-
-            fn _do_not_manually_implement_this_it_wont_work() {}
-        }
-
-        impl std::fmt::Debug for Event {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                use $crate::rt::trace::Event;
-                f.debug_struct("Event")
-                    .field("description", &Self::DESCRIPTION)
-                    $( .field(stringify!($attribute_name), &self.$attribute_name) )+
-                    .finish()
-            }
-        }
-
-        #[allow(clippy::redundant_field_names)]
-        Event {
-            $( $attribute_name : $attribute_value ),+
-        }
-    }};
 }

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -182,7 +182,8 @@ where
     rt::trace::finish(
         &mut trace_log,
         timing,
-        event!("Initialising the worker thread"),
+        "Initialising the worker thread",
+        &[],
     );
 
     // Run optional setup.
@@ -190,11 +191,7 @@ where
         let timing = rt::trace::start(&trace_log);
         let runtime_ref = runtime.create_ref();
         setup.setup(runtime_ref).map_err(rt::Error::setup)?;
-        rt::trace::finish(
-            &mut trace_log,
-            timing,
-            event!("Running user setup function"),
-        );
+        rt::trace::finish(&mut trace_log, timing, "Running user setup function", &[]);
     }
 
     // All setup is done, so we're ready to run the event loop.
@@ -374,10 +371,8 @@ impl RunningRuntime {
                     rt::trace::finish(
                         trace_log,
                         timing,
-                        event!("Running thread-local process", attributes: {
-                            id: usize = pid.0,
-                            name: &'static str = name,
-                        }),
+                        "Running thread-local process",
+                        &[("id", &pid.0), ("name", &name)],
                     );
                     // Only run a single process per iteration.
                     continue;
@@ -399,10 +394,8 @@ impl RunningRuntime {
                     rt::trace::finish(
                         trace_log,
                         timing,
-                        event!("Running thread-safe process", attributes: {
-                            id: usize = pid.0,
-                            name: &'static str = name,
-                        }),
+                        "Running thread-safe process",
+                        &[("id", &pid.0), ("name", &name)],
                     );
                     // Only run a single process per iteration.
                     continue;
@@ -433,7 +426,7 @@ impl RunningRuntime {
         // Start with polling for OS events.
         let timing = rt::trace::start(&trace_log);
         self.poll().map_err(Error::Polling)?;
-        rt::trace::finish(trace_log, timing, event!("Polling for OS events"));
+        rt::trace::finish(trace_log, timing, "Polling for OS events", &[]);
 
         // Based on the OS event scheduler thread-local processes.
         let timing = rt::trace::start(&trace_log);
@@ -447,7 +440,7 @@ impl RunningRuntime {
                 token => scheduler.mark_ready(token.into()),
             }
         }
-        rt::trace::finish(trace_log, timing, event!("Handling OS events"));
+        rt::trace::finish(trace_log, timing, "Handling OS events", &[]);
 
         // User space wake up events, e.g. used by the `Future` task system.
         trace!("polling wakup events");
@@ -458,7 +451,8 @@ impl RunningRuntime {
         rt::trace::finish(
             trace_log,
             timing,
-            event!("Scheduling thread-local processes based on wake-up events"),
+            "Scheduling thread-local processes based on wake-up events",
+            &[],
         );
 
         // User space timers, powers the `timer` module.
@@ -470,7 +464,8 @@ impl RunningRuntime {
         rt::trace::finish(
             trace_log,
             timing,
-            event!("Scheduling thread-local processes based on timers"),
+            "Scheduling thread-local processes based on timers",
+            &[],
         );
 
         if check_coordinator {
@@ -479,7 +474,7 @@ impl RunningRuntime {
             // Process coordinator messages.
             let timing = rt::trace::start(&trace_log);
             self.check_coordinator()?;
-            rt::trace::finish(trace_log, timing, event!("Process coordinator messages"));
+            rt::trace::finish(trace_log, timing, "Process coordinator messages", &[]);
         }
         Ok(())
     }


### PR DESCRIPTION
This reduces the binary size by roughly 30k. This is also a decent step
into an API that can be publicly exposed.

Closes  #346.

TODO:
* [ ] Measure performance impact.