### PR TITLE
Change task::Waker impl for sync actor to be based on thread parking

### DIFF
--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -381,7 +381,7 @@ impl SyncWaker {
         let mut future = fut;
         let mut future = unsafe { Pin::new_unchecked(&mut future) };
 
-        let task_waker = task::Waker::from(self.clone());
+        let task_waker = task::Waker::from(self);
         let mut task_ctx = task::Context::from_waker(&task_waker);
         loop {
             match Future::poll(future.as_mut(), &mut task_ctx) {


### PR DESCRIPTION
The thread parking implementation for Linux using futex which could be
considerably faster than our generic locking implementation. By
happenstance the generic implementation looks a lot like the old
implementation, but now we don't have to worry about it functioning
correctly.