### PR TITLE
Implement vectored I/O for net types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ test = ["rand"]
 [dependencies]
 crossbeam-channel = { version = "0.5.0", default-features = false, features = ["std"] }
 futures-core      = { version = "0.3.6", default-features = false }
-futures-io        = { version = "0.3.6", default-features = false, features = ["std"] }
 # FIXME: use released version.
 inbox             = { git = "https://github.com/Thomasdezeeuw/inbox", rev = "6e11ff5d8bb947c93b5067f22071022baf8bd2d4" }
 libc              = { version = "0.2.79", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ libc              = { version = "0.2.79", default-features = false }
 log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }
 mio-signals       = { version = "0.1.2", default-features = false }
-socket2           = { version = "0.4.0-alpha.4", default-features = false, features = ["all"] }
+socket2           = { version = "0.4.0-alpha.5", default-features = false, features = ["all"] }
 # Enable logging panics via `std-logger` and add timestamps to each log message.
 std-logger        = { version = "0.3.6", default-features = false, features = ["log-panic", "timestamp"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ libc              = { version = "0.2.79", default-features = false }
 log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }
 mio-signals       = { version = "0.1.2", default-features = false }
+socket2           = { version = "0.4.0-alpha.3", default-features = false, features = ["all"] }
 # Enable logging panics via `std-logger` and add timestamps to each log message.
 std-logger        = { version = "0.3.6", default-features = false, features = ["log-panic", "timestamp"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ libc              = { version = "0.2.79", default-features = false }
 log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }
 mio-signals       = { version = "0.1.2", default-features = false }
-socket2           = { version = "0.4.0-alpha.3", default-features = false, features = ["all"] }
+socket2           = { version = "0.4.0-alpha.4", default-features = false, features = ["all"] }
 # Enable logging panics via `std-logger` and add timestamps to each log message.
 std-logger        = { version = "0.3.6", default-features = false, features = ["log-panic", "timestamp"] }
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 
 check_all_targets: $(TARGETS)
 $(TARGETS):
-	cargo check --all-features --target $@
+	cargo check --all-features --all-targets --target $@
 
 # NOTE: when using this command you might want to change the `test` target to
 # only run a subset of the tests you're actively working on.

--- a/examples/2_my_ip.rs
+++ b/examples/2_my_ip.rs
@@ -3,8 +3,6 @@
 use std::io;
 use std::net::SocketAddr;
 
-use futures_util::AsyncWriteExt;
-
 use heph::actor::{self, context, NewActor};
 use heph::log::{self, error, info};
 use heph::net::{tcp, TcpServer, TcpStream};
@@ -118,5 +116,5 @@ async fn conn_actor(
     let ip = address.ip().to_string();
 
     // Next we'll write the IP address to the connection.
-    stream.write_all(ip.as_bytes()).await
+    stream.send_all(ip.as_bytes()).await
 }

--- a/examples/7_restart_supervisor.rs
+++ b/examples/7_restart_supervisor.rs
@@ -42,11 +42,11 @@ restart_supervisor!(
 );
 
 /// A very bad printing actor.
-async fn print_actor(_ctx: actor::Context<()>, msg: String) -> Result<(), String> {
+async fn print_actor(_: actor::Context<()>, msg: String) -> Result<(), String> {
     Err(format!("can't print message '{}'", msg))
 }
 
 /// A very bad synchronous printing actor.
-fn sync_print_actor(_ctx: SyncContext<String>, msg: String) -> Result<(), String> {
+fn sync_print_actor(_: SyncContext<String>, msg: String) -> Result<(), String> {
     Err(format!("can't print message synchronously '{}'", msg))
 }

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -333,7 +333,7 @@ pub trait NewActor {
     /// #
     /// // Actor that handles a connection.
     /// async fn conn_actor(
-    ///     _ctx: actor::Context<!>,
+    ///     _: actor::Context<!>,
     ///     mut stream: TcpStream,
     ///     address: SocketAddr,
     ///     greet_mars: bool

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -260,8 +260,6 @@ pub trait NewActor {
     /// use std::io;
     /// use std::net::SocketAddr;
     ///
-    /// use futures_util::AsyncWriteExt;
-    ///
     /// # use heph::actor::messages::Terminate;
     /// # use heph::actor::context;
     /// use heph::actor::{self, NewActor};
@@ -341,9 +339,9 @@ pub trait NewActor {
     /// #   drop(address); // Silence dead code warnings.
     ///     if greet_mars {
     ///         // In case this example ever reaches Mars.
-    ///         stream.write_all(b"Hello Mars").await
+    ///         stream.send_all(b"Hello Mars").await
     ///     } else {
-    ///         stream.write_all(b"Hello World").await
+    ///         stream.send_all(b"Hello World").await
     ///     }
     /// }
     /// ```

--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -282,7 +282,7 @@ impl<M> SyncContext<M> {
     ///     }
     /// }
     ///
-    /// # fn assert_sync_actor<A: heph::actor::sync::SyncActor>(_a: A) { }
+    /// # fn assert_sync_actor<A: heph::actor::sync::SyncActor>(_: A) { }
     /// # assert_sync_actor(greeter_actor as fn(_) -> _);
     /// ```
     pub fn try_receive_next(&mut self) -> Result<M, RecvError> {
@@ -310,7 +310,7 @@ impl<M> SyncContext<M> {
     ///     }
     /// }
     ///
-    /// # fn assert_sync_actor<A: heph::actor::sync::SyncActor>(_a: A) { }
+    /// # fn assert_sync_actor<A: heph::actor::sync::SyncActor>(_: A) { }
     /// # assert_sync_actor(print_actor as fn(_) -> _);
     /// ```
     pub fn receive_next(&mut self) -> Result<M, NoMessages> {

--- a/src/actor_ref/rpc.rs
+++ b/src/actor_ref/rpc.rs
@@ -51,7 +51,7 @@
 //! }
 //!
 //! /// Sending actor of the RPC.
-//! async fn requester(_ctx: actor::Context<!>, actor_ref: ActorRef<Add>) -> Result<(), !> {
+//! async fn requester(_: actor::Context<!>, actor_ref: ActorRef<Add>) -> Result<(), !> {
 //!     // Make the procedure call.
 //!     let response = actor_ref.rpc(10).await;
 //! #   assert!(response.is_ok());
@@ -133,7 +133,7 @@
 //! }
 //!
 //! /// Sending actor of the RPC.
-//! async fn requester(_ctx: actor::Context<!>, actor_ref: ActorRef<Message>) -> Result<(), !> {
+//! async fn requester(_: actor::Context<!>, actor_ref: ActorRef<Message>) -> Result<(), !> {
 //!     // Increase the counter by ten.
 //!     // NOTE: do handle the errors correctly in practice, this is just an
 //!     // example.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,16 +74,20 @@
     const_raw_ptr_to_usize_cast,
     drain_filter,
     duration_zero,
+    generic_associated_types,
     io_slice_advance,
     is_sorted,
+    maybe_uninit_array_assume_init,
     maybe_uninit_extra,
     maybe_uninit_ref,
     maybe_uninit_slice,
+    maybe_uninit_uninit_array,
     never_type,
     new_uninit,
     vec_spare_capacity,
     wake_trait
 )]
+#![allow(incomplete_features)] // NOTE: for `generic_associated_types`.
 #![cfg_attr(any(test, feature = "test"), feature(once_cell))]
 #![warn(
     anonymous_parameters,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@
     const_raw_ptr_to_usize_cast,
     drain_filter,
     duration_zero,
+    io_slice_advance,
     is_sorted,
     maybe_uninit_extra,
     maybe_uninit_ref,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -214,6 +214,7 @@ impl<'a> MaybeUninitSlice<'a> {
     }
 
     /// Returns `bufs` as [`socket2::MaybeUninitSlice`].
+    #[allow(clippy::wrong_self_convention)]
     fn as_socket2<'b>(
         bufs: &'b mut [MaybeUninitSlice<'a>],
     ) -> &'b mut [socket2::MaybeUninitSlice<'a>] {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -16,9 +16,11 @@
 //! [User Datagram Protocol]: crate::net::udp
 //! [`UdpSocket`]: crate::net::UdpSocket
 
-use std::io;
+use std::cmp::min;
 use std::mem::MaybeUninit;
 use std::net::SocketAddr;
+use std::ops::{Deref, DerefMut};
+use std::{fmt, io};
 
 use socket2::SockAddr;
 
@@ -55,6 +57,11 @@ pub use udp::UdpSocket;
 /// [see below]: #foreign-impls
 pub trait Bytes {
     /// Returns itself as a slice of bytes that may or may not be initialised.
+    ///
+    /// The implementation must guarantee that two calls (without any call to
+    /// [`update_length`] in between returns the same slice of bytes.
+    ///
+    /// [`update_length`]: Bytes::update_length
     fn as_bytes(&mut self) -> &mut [MaybeUninit<u8>];
 
     /// Update the length of the byte slice.
@@ -62,7 +69,9 @@ pub trait Bytes {
     /// # Safety
     ///
     /// The caller must ensure that at least `n` of the bytes returned by
-    /// [`Bytes::as_bytes`] are initialised.
+    /// [`as_bytes`] are initialised.
+    ///
+    /// [`as_bytes`]: Bytes::as_bytes
     unsafe fn update_length(&mut self, n: usize);
 }
 
@@ -168,6 +177,264 @@ impl Bytes for Vec<u8> {
         self.set_len(new);
     }
 }
+
+/// A version of [`IoSliceMut`] that allows the buffer to be uninitialised.
+///
+/// [`IoSliceMut`]: std::io::IoSliceMut
+#[repr(transparent)]
+pub struct MaybeUninitSlice<'a>(socket2::MaybeUninitSlice<'a>);
+
+impl<'a> fmt::Debug for MaybeUninitSlice<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a> MaybeUninitSlice<'a> {
+    /// Creates a new `MaybeUninitSlice` wrapping a byte slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics on Windows if the slice is larger than 4GB.
+    pub fn new(buf: &'a mut [MaybeUninit<u8>]) -> MaybeUninitSlice<'a> {
+        MaybeUninitSlice(socket2::MaybeUninitSlice::new(buf))
+    }
+
+    /// Creates a new `MaybeUninitSlice` from a [`Vec`]tor.
+    ///
+    /// Similar to the [`Bytes`] implementation for `Vec<u8>` this only uses the
+    /// uninitialised capacity of the vector.
+    ///
+    /// # Panics
+    ///
+    /// Panics on Windows if the vector's uninitialised capacity is larger than
+    /// 4GB.
+    pub fn from_vec(buf: &'a mut Vec<u8>) -> MaybeUninitSlice<'a> {
+        MaybeUninitSlice(socket2::MaybeUninitSlice::new(buf.as_bytes()))
+    }
+}
+
+impl<'a> Deref for MaybeUninitSlice<'a> {
+    type Target = [MaybeUninit<u8>];
+
+    fn deref(&self) -> &[MaybeUninit<u8>] {
+        self.0.deref()
+    }
+}
+
+impl<'a> DerefMut for MaybeUninitSlice<'a> {
+    fn deref_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        self.0.deref_mut()
+    }
+}
+
+impl<'a> Bytes for MaybeUninitSlice<'a> {
+    // NOTE: keep this function in sync with the impl below.
+    fn as_bytes(&mut self) -> &mut [MaybeUninit<u8>] {
+        self
+    }
+
+    unsafe fn update_length(&mut self, _: usize) {
+        // Can't update the length of an array.
+    }
+}
+
+/// Trait to make easier to work with vectored I/O using uninitialised bytes.
+///
+/// This is implemented for arrays and tuples. When all of buffers are
+/// *homogeneous*, i.e. of the same type, the array implementation is the
+/// easiest to use along side with the [`Bytes`] trait. If however the buffers
+/// are *heterogeneous*, i.e. of different types, the tuple implementation can
+/// be used. See the examples below.
+///
+/// # Examples
+///
+/// Using the homogeneous array implementation.
+///
+/// ```
+/// # #![feature(maybe_uninit_write_slice)]
+/// use heph::net::BytesVectored;
+///
+/// let mut buf1 = Vec::with_capacity(12);
+/// let mut buf2 = Vec::with_capacity(1);
+/// let mut buf3 = Vec::with_capacity(5);
+/// let mut buf4 = Vec::with_capacity(10); // Has extra capacity.
+///
+/// let bufs = [&mut buf1, &mut buf2, &mut buf3, &mut buf4];
+/// let text = b"Hello world. From mars!";
+/// let bytes_written = write_vectored(bufs, text);
+/// assert_eq!(bytes_written, text.len());
+///
+/// assert_eq!(buf1, b"Hello world.");
+/// assert_eq!(buf2, b" ");
+/// assert_eq!(buf3, b"From ");
+/// assert_eq!(buf4, b"mars!");
+///
+/// /// Writes `text` to the `bufs`.
+/// fn write_vectored<B>(mut bufs: B, text: &[u8]) -> usize
+///     where B: BytesVectored,
+/// {
+///     // Implementation is not relevant to the example.
+/// #   use heph::net::Bytes;
+/// #   let mut written = 0;
+/// #   let mut left = text;
+/// #   for buf in bufs.as_bufs().as_mut().iter_mut() {
+/// #       let dst = buf.as_bytes();
+/// #       let n = std::cmp::min(dst.len(), left.len());
+/// #       let _ = std::mem::MaybeUninit::write_slice(&mut dst[..n], &left[..n]);
+/// #       left = &left[n..];
+/// #       written += n;
+/// #       if left.is_empty() {
+/// #           break;
+/// #       }
+/// #   }
+/// #   // NOTE: we could update the length of the buffers in the loop above,
+/// #   // but this also acts as a smoke test for the implementation and this is
+/// #   // what would happen with actual vectored I/O.
+/// #   unsafe { bufs.update_lengths(written); }
+/// #   written
+/// }
+/// ```
+///
+/// Using the heterogeneous tuple implementation.
+///
+/// ```
+/// # #![feature(maybe_uninit_slice, maybe_uninit_write_slice)]
+/// use std::mem::MaybeUninit;
+///
+/// use heph::net::BytesVectored;
+///
+/// // Buffers of different types.
+/// let mut buf1 = Vec::with_capacity(12);
+/// let mut buf2 = [MaybeUninit::uninit(); 1];
+/// let mut buf3 = &mut [MaybeUninit::uninit(); 20]; // Has extra capacity.
+///
+/// // Using tuples we can different kind of buffers. Here we use a `Vec`, array
+/// // and a slice.
+/// let bufs = (&mut buf1, &mut buf2, &mut buf3);
+/// let text = b"Hello world. From mars!";
+/// let bytes_written = write_vectored(bufs, text);
+/// assert_eq!(bytes_written, text.len());
+///
+/// assert_eq!(buf1, b"Hello world.");
+/// assert_eq!(unsafe { MaybeUninit::slice_assume_init_ref(&buf2) }, b" ");
+/// assert_eq!(unsafe { MaybeUninit::slice_assume_init_ref(&buf3[..10]) }, b"From mars!");
+///
+/// /// Writes `text` to the `bufs`.
+/// fn write_vectored<B>(mut bufs: B, text: &[u8]) -> usize
+///     where B: BytesVectored,
+/// {
+///     // Implementation is not relevant to the example.
+/// #   use heph::net::Bytes;
+/// #   let mut written = 0;
+/// #   let mut left = text;
+/// #   for buf in bufs.as_bufs().as_mut().iter_mut() {
+/// #       let dst = buf.as_bytes();
+/// #       let n = std::cmp::min(dst.len(), left.len());
+/// #       let _ = MaybeUninit::write_slice(&mut dst[..n], &left[..n]);
+/// #       left = &left[n..];
+/// #       written += n;
+/// #       if left.is_empty() {
+/// #           break;
+/// #       }
+/// #   }
+/// #   // NOTE: we could update the length of the buffers in the loop above,
+/// #   // but this also acts as a smoke test for the implementation and this is
+/// #   // what would happen with actual vectored I/O.
+/// #   unsafe { bufs.update_lengths(written); }
+/// #   written
+/// }
+/// ```
+pub trait BytesVectored {
+    /// Type used as slice of buffers, usually this is an array.
+    type Bufs<'b>: AsMut<[MaybeUninitSlice<'b>]>;
+
+    /// Returns itself as a slice of [`MaybeUninitSlice`].
+    fn as_bufs<'b>(&'b mut self) -> Self::Bufs<'b>;
+
+    /// Update the length of the buffers in the slice.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that at least `n` of the bytes returned by
+    /// [`as_bufs`] are initialised, starting at the first buffer.
+    ///
+    /// [`as_bufs`]: BytesVectored::as_bufs
+    unsafe fn update_lengths(&mut self, n: usize);
+}
+
+impl<B, const N: usize> BytesVectored for [B; N]
+where
+    B: Bytes,
+{
+    type Bufs<'b> = [MaybeUninitSlice<'b>; N];
+
+    fn as_bufs<'b>(&'b mut self) -> Self::Bufs<'b> {
+        // Safety: `MaybeUninitSlice` doesn't implement `Drop`, so it's safe to
+        // leak it.
+        let mut bufs = MaybeUninit::uninit_array::<N>();
+        for (i, buf) in self.iter_mut().enumerate() {
+            let _ = bufs[i].write(MaybeUninitSlice::new(buf.as_bytes()));
+        }
+        unsafe { MaybeUninit::array_assume_init(bufs) }
+    }
+
+    unsafe fn update_lengths(&mut self, n: usize) {
+        let mut left = n;
+        for buf in self.iter_mut() {
+            let n = min(left, buf.as_bytes().len());
+            buf.update_length(n);
+            left -= n;
+            if left == 0 {
+                return;
+            }
+        }
+    }
+}
+
+macro_rules! impl_vectored_bytes_tuple {
+    ( $N: tt : $( $t: ident $idx: tt ),+ ) => {
+        impl<$( $t ),+> BytesVectored for ( $( $t ),+ )
+            where $( $t: Bytes ),+
+        {
+            type Bufs<'b> = [MaybeUninitSlice<'b>; $N];
+
+            fn as_bufs<'b>(&'b mut self) -> Self::Bufs<'b> {
+                // Safety: `MaybeUninitSlice` doesn't implement `Drop`, so it's
+                // safe to leak it.
+                let mut bufs = MaybeUninit::uninit_array::<$N>();
+                $(
+                    let _ = bufs[$idx].write(MaybeUninitSlice::new(self.$idx.as_bytes()));
+                )+
+                unsafe { MaybeUninit::array_assume_init(bufs) }
+            }
+
+            unsafe fn update_lengths(&mut self, n: usize) {
+                let mut left = n;
+                $(
+                    let n = min(left, self.$idx.as_bytes().len());
+                    self.$idx.update_length(n);
+                    left -= n;
+                    if left == 0 {
+                        return;
+                    }
+                )+
+            }
+        }
+    };
+}
+
+impl_vectored_bytes_tuple! { 12: B0 0, B1 1, B2 2, B3 3, B4 4, B5 5, B6 6, B7 7, B8 8, B9 9, B10 10, B11 11 }
+impl_vectored_bytes_tuple! { 11: B0 0, B1 1, B2 2, B3 3, B4 4, B5 5, B6 6, B7 7, B8 8, B9 9, B10 10 }
+impl_vectored_bytes_tuple! { 10: B0 0, B1 1, B2 2, B3 3, B4 4, B5 5, B6 6, B7 7, B8 8, B9 9 }
+impl_vectored_bytes_tuple! { 9: B0 0, B1 1, B2 2, B3 3, B4 4, B5 5, B6 6, B7 7, B8 8 }
+impl_vectored_bytes_tuple! { 8: B0 0, B1 1, B2 2, B3 3, B4 4, B5 5, B6 6, B7 7 }
+impl_vectored_bytes_tuple! { 7: B0 0, B1 1, B2 2, B3 3, B4 4, B5 5, B6 6 }
+impl_vectored_bytes_tuple! { 6: B0 0, B1 1, B2 2, B3 3, B4 4, B5 5 }
+impl_vectored_bytes_tuple! { 5: B0 0, B1 1, B2 2, B3 3, B4 4 }
+impl_vectored_bytes_tuple! { 4: B0 0, B1 1, B2 2, B3 3 }
+impl_vectored_bytes_tuple! { 3: B0 0, B1 1, B2 2 }
+impl_vectored_bytes_tuple! { 2: B0 0, B1 1 }
 
 /// Convert a `socket2:::SockAddr` into a `std::net::SocketAddr`.
 fn convert_address(address: SockAddr) -> io::Result<SocketAddr> {

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -291,7 +291,7 @@ pub struct Accept<'a> {
 impl<'a> Future for Accept<'a> {
     type Output = io::Result<(UnboundTcpStream, SocketAddr)>;
 
-    fn poll(mut self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         match self.listener {
             Some(ref mut listener) => try_io!(listener.try_accept()).map(|res| {
                 // Only remove the listener if we return a stream.
@@ -319,10 +319,7 @@ pub struct Incoming<'a> {
 impl<'a> Stream for Incoming<'a> {
     type Item = io::Result<(UnboundTcpStream, SocketAddr)>;
 
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        _ctx: &mut task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
         try_io!(self.listener.try_accept()).map(Some)
     }
 }

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -153,8 +153,6 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// use std::io;
 /// use std::net::SocketAddr;
 ///
-/// use futures_util::AsyncWriteExt;
-///
 /// use heph::actor::{self, context, NewActor};
 /// # use heph::actor::messages::Terminate;
 /// use heph::log::error;
@@ -234,7 +232,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// /// The actor responsible for a single TCP stream.
 /// async fn conn_actor(_: actor::Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
 /// #   drop(address); // Silence dead code warnings.
-///     stream.write_all(b"Hello World").await
+///     stream.send_all(b"Hello World").await
 /// }
 /// ```
 ///
@@ -246,8 +244,6 @@ impl<S, NA> Clone for Setup<S, NA> {
 ///
 /// use std::io;
 /// use std::net::SocketAddr;
-///
-/// use futures_util::AsyncWriteExt;
 ///
 /// # use heph::actor::context;
 /// use heph::actor::messages::Terminate;
@@ -322,7 +318,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// /// The actor responsible for a single TCP stream.
 /// async fn conn_actor(_: actor::Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
 /// #   drop(address); // Silence dead code warnings.
-///     stream.write_all(b"Hello World").await
+///     stream.send_all(b"Hello World").await
 /// }
 /// ```
 ///
@@ -335,8 +331,6 @@ impl<S, NA> Clone for Setup<S, NA> {
 ///
 /// use std::io;
 /// use std::net::SocketAddr;
-///
-/// use futures_util::AsyncWriteExt;
 ///
 /// use heph::actor::{self, NewActor};
 /// use heph::actor::context::ThreadSafe;
@@ -411,7 +405,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// /// The actor responsible for a single TCP stream.
 /// async fn conn_actor(_: actor::Context<!, ThreadSafe>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
 /// #   drop(address); // Silence dead code warnings.
-///     stream.write_all(b"Hello World").await
+///     stream.send_all(b"Hello World").await
 /// }
 #[derive(Debug)]
 pub struct TcpServer<S, NA, K> {

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -232,7 +232,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// }
 ///
 /// /// The actor responsible for a single TCP stream.
-/// async fn conn_actor(_ctx: actor::Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
+/// async fn conn_actor(_: actor::Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
 /// #   drop(address); // Silence dead code warnings.
 ///     stream.write_all(b"Hello World").await
 /// }
@@ -320,7 +320,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// # }
 /// #
 /// /// The actor responsible for a single TCP stream.
-/// async fn conn_actor(_ctx: actor::Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
+/// async fn conn_actor(_: actor::Context<!>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
 /// #   drop(address); // Silence dead code warnings.
 ///     stream.write_all(b"Hello World").await
 /// }
@@ -409,7 +409,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// }
 ///
 /// /// The actor responsible for a single TCP stream.
-/// async fn conn_actor(_ctx: actor::Context<!, ThreadSafe>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
+/// async fn conn_actor(_: actor::Context<!, ThreadSafe>, mut stream: TcpStream, address: SocketAddr) -> io::Result<()> {
 /// #   drop(address); // Silence dead code warnings.
 ///     stream.write_all(b"Hello World").await
 /// }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -64,37 +64,10 @@ impl TcpStream {
 
     /// Set the CPU affinity to `cpu`.
     ///
-    /// On Linux this uses `SO_INCOMING_CPU`, on other platforms this is
-    /// currently a no-op.
-    pub fn set_cpu_affinity(&mut self, cpu: usize) -> io::Result<()> {
-        #[cfg(target_os = "linux")]
-        {
-            let socket = SockRef::from(&self.socket);
-            socket.set_cpu_affinity(cpu)
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            let _ = cpu; // Silence unused variables warnings.
-            Ok(())
-        }
-    }
-
-    /// Returns the CPU affinity.
-    ///
-    /// On Linux this uses `SO_INCOMING_CPU`, on other platforms this returns
-    /// `Ok(0)`.
-    pub fn cpu_affinity(&mut self) -> io::Result<usize> {
-        #[cfg(target_os = "linux")]
-        {
-            let socket = SockRef::from(&self.socket);
-            socket.cpu_affinity()
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            Ok(0)
-        }
+    /// On Linux this uses `SO_INCOMING_CPU`.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn set_cpu_affinity(&mut self, cpu: usize) -> io::Result<()> {
+        SockRef::from(&self.socket).set_cpu_affinity(cpu)
     }
 
     /// Sets the value for the `IP_TTL` option on this socket.

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -326,7 +326,7 @@ impl Future for Connect {
     type Output = io::Result<TcpStream>;
 
     #[track_caller]
-    fn poll(mut self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         // This relates directly Mio and `kqueue(2)` and `epoll(2)`. To do a
         // non-blocking TCP connect properly we need to a couple of things.
         //
@@ -403,7 +403,7 @@ pub struct Send<'a, 'b> {
 impl<'a, 'b> Future for Send<'a, 'b> {
     type Output = io::Result<usize>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let Send { stream, buf } = Pin::into_inner(self);
         try_io!(stream.try_send(buf))
     }
@@ -420,7 +420,7 @@ pub struct SendAll<'a, 'b> {
 impl<'a, 'b> Future for SendAll<'a, 'b> {
     type Output = io::Result<()>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let SendAll { stream, buf } = Pin::into_inner(self);
         loop {
             match stream.try_send(buf) {
@@ -453,7 +453,7 @@ where
 {
     type Output = io::Result<usize>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let Recv { stream, buf } = Pin::into_inner(self);
         try_io!(stream.try_recv(&mut *buf))
     }
@@ -474,7 +474,7 @@ where
 {
     type Output = io::Result<()>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let RecvN { stream, buf, left } = Pin::into_inner(self);
         loop {
             match stream.try_recv(&mut *buf) {
@@ -496,7 +496,7 @@ where
 impl AsyncRead for TcpStream {
     fn poll_read(
         mut self: Pin<&mut Self>,
-        _ctx: &mut task::Context<'_>,
+        _: &mut task::Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
         try_io!(self.socket.read(buf))
@@ -504,7 +504,7 @@ impl AsyncRead for TcpStream {
 
     fn poll_read_vectored(
         mut self: Pin<&mut Self>,
-        _ctx: &mut task::Context<'_>,
+        _: &mut task::Context<'_>,
         bufs: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
         try_io!(self.socket.read_vectored(bufs))
@@ -514,7 +514,7 @@ impl AsyncRead for TcpStream {
 impl AsyncWrite for TcpStream {
     fn poll_write(
         mut self: Pin<&mut Self>,
-        _ctx: &mut task::Context<'_>,
+        _: &mut task::Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         try_io!(self.socket.write(buf))
@@ -522,13 +522,13 @@ impl AsyncWrite for TcpStream {
 
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
-        _ctx: &mut task::Context<'_>,
+        _: &mut task::Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
         try_io!(self.socket.write_vectored(bufs))
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_flush(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         try_io!(self.socket.flush())
     }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -299,7 +299,7 @@ pub struct SendTo<'a, 'b> {
 impl<'a, 'b> Future for SendTo<'a, 'b> {
     type Output = io::Result<usize>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let SendTo {
             socket,
             buf,
@@ -323,7 +323,7 @@ where
 {
     type Output = io::Result<(usize, SocketAddr)>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let RecvFrom { socket, buf } = Pin::into_inner(self);
         try_io!(socket.try_recv_from(&mut *buf))
     }
@@ -343,7 +343,7 @@ where
 {
     type Output = io::Result<(usize, SocketAddr)>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let PeekFrom { socket, buf } = Pin::into_inner(self);
         try_io!(socket.try_peek_from(&mut *buf))
     }
@@ -442,7 +442,7 @@ pub struct Send<'a, 'b> {
 impl<'a, 'b> Future for Send<'a, 'b> {
     type Output = io::Result<usize>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let Send { socket, buf } = Pin::into_inner(self);
         try_io!(socket.try_send(buf))
     }
@@ -462,7 +462,7 @@ where
 {
     type Output = io::Result<usize>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let Recv { socket, buf } = Pin::into_inner(self);
         try_io!(socket.try_recv(&mut *buf))
     }
@@ -482,7 +482,7 @@ where
 {
     type Output = io::Result<usize>;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         let Peek { socket, buf } = Pin::into_inner(self);
         try_io!(socket.try_peek(&mut *buf))
     }

--- a/src/rt/scheduler/tests.rs
+++ b/src/rt/scheduler/tests.rs
@@ -150,7 +150,7 @@ impl Process for SleepyProcess {
         "SleepyProcess"
     }
 
-    fn run(self: Pin<&mut Self>, _runtime_ref: &mut RuntimeRef, _pid: ProcessId) -> ProcessResult {
+    fn run(self: Pin<&mut Self>, _: &mut RuntimeRef, _: ProcessId) -> ProcessResult {
         sleep(self.0);
         ProcessResult::Pending
     }
@@ -176,7 +176,7 @@ impl<C> NewActor for TestAssertUnmovedNewActor<C> {
     fn new(
         &mut self,
         ctx: actor::Context<Self::Message, Self::Context>,
-        _arg: Self::Argument,
+        _: Self::Argument,
     ) -> Result<Self::Actor, Self::Error> {
         // In the test we need the access to the inbox, to achieve that we can't
         // drop the context, so we forget about it here leaking the inbox.
@@ -200,7 +200,7 @@ mod local_scheduler {
 
     use super::{NopTestProcess, TestAssertUnmovedNewActor};
 
-    async fn simple_actor(_ctx: actor::Context<!>) -> Result<(), !> {
+    async fn simple_actor(_: actor::Context<!>) -> Result<(), !> {
         Ok(())
     }
 
@@ -406,7 +406,7 @@ mod local_scheduler {
         let run_order = Rc::new(RefCell::new(Vec::new()));
 
         async fn order_actor(
-            _ctx: actor::Context<!>,
+            _: actor::Context<!>,
             id: usize,
             order: Rc<RefCell<Vec<usize>>>,
         ) -> Result<(), !> {
@@ -499,7 +499,7 @@ mod shared_scheduler {
 
     use super::TestAssertUnmovedNewActor;
 
-    async fn simple_actor(_ctx: actor::Context<!, context::ThreadSafe>) -> Result<(), !> {
+    async fn simple_actor(_: actor::Context<!, context::ThreadSafe>) -> Result<(), !> {
         Ok(())
     }
 
@@ -593,7 +593,7 @@ mod shared_scheduler {
         let run_order = Arc::new(Mutex::new(Vec::new()));
 
         async fn order_actor(
-            _ctx: actor::Context<!, context::ThreadSafe>,
+            _: actor::Context<!, context::ThreadSafe>,
             id: usize,
             order: Arc<Mutex<Vec<usize>>>,
         ) -> Result<(), !> {

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -93,7 +93,7 @@
 //! }
 //!
 //! /// Our badly behaving actor.
-//! async fn bad_actor(_ctx: actor::Context<!>) -> Result<(), Error> {
+//! async fn bad_actor(_: actor::Context<!>) -> Result<(), Error> {
 //!     Err(Error)
 //! }
 //! ```

--- a/src/test.rs
+++ b/src/test.rs
@@ -243,7 +243,7 @@ where
 ///
 /// assert_eq!(size_of_actor_val(&(actor as fn(_) -> _)), 64);
 /// ```
-pub const fn size_of_actor_val<NA>(_new_actor: &NA) -> usize
+pub const fn size_of_actor_val<NA>(_: &NA) -> usize
 where
     NA: NewActor,
 {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -130,7 +130,7 @@ impl Timer {
 impl Future for Timer {
     type Output = DeadlinePassed;
 
-    fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         if self.has_passed() {
             Poll::Ready(DeadlinePassed)
         } else {
@@ -198,7 +198,7 @@ impl<K> actor::Bound<K> for Timer {
 /// #
 /// # impl Future for IoFuture {
 /// #     type Output = io::Result<()>;
-/// #     fn poll(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+/// #     fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
 /// #         Poll::Pending
 /// #     }
 /// # }
@@ -429,7 +429,7 @@ impl Interval {
 impl Stream for Interval {
     type Item = DeadlinePassed;
 
-    fn poll_next(self: Pin<&mut Self>, _ctx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
         if self.deadline <= Instant::now() {
             // Determine the next deadline.
             let next_deadline = Instant::now() + self.interval;

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1,6 +1,6 @@
 //! Functional tests.
 
-#![feature(drain_filter, never_type, maybe_uninit_slice)]
+#![feature(drain_filter, never_type, maybe_uninit_slice, write_all_vectored)]
 
 #[path = "util/mod.rs"] // rustfmt can't find the file.
 #[macro_use]

--- a/tests/functional/udp.rs
+++ b/tests/functional/udp.rs
@@ -18,41 +18,37 @@ use heph::test::{init_local_actor, poll_actor};
 use crate::util::{any_local_address, any_local_ipv6_address};
 
 const DATA: &[u8] = b"Hello world";
+const DATAV: &[&[u8]] = &[b"Hello world!", b" ", b"From mars."];
+const DATAV_LEN: usize = DATAV[0].len() + DATAV[1].len() + DATAV[2].len();
 
 #[test]
-fn unconnected_udp_socket_ipv4() {
+fn unconnected_ipv4() {
     let new_actor = unconnected_udp_actor as fn(_, _) -> _;
-    test_udp_socket(any_local_address(), new_actor)
+    test(any_local_address(), new_actor)
 }
 
 #[test]
-fn unconnected_udp_socket_ipv6() {
+fn unconnected_ipv6() {
     let new_actor = unconnected_udp_actor as fn(_, _) -> _;
-    test_udp_socket(any_local_ipv6_address(), new_actor)
+    test(any_local_ipv6_address(), new_actor)
 }
 
 #[test]
-fn connected_udp_socket_ipv4() {
+fn connected_ipv4() {
     let new_actor = connected_udp_actor as fn(_, _) -> _;
-    test_udp_socket(any_local_address(), new_actor)
+    test(any_local_address(), new_actor)
 }
 
 #[test]
-fn connected_udp_socket_ipv6() {
+fn connected_ipv6() {
     let new_actor = connected_udp_actor as fn(_, _) -> _;
-    test_udp_socket(any_local_ipv6_address(), new_actor)
+    test(any_local_ipv6_address(), new_actor)
 }
 
-fn test_udp_socket<NA, A>(local_address: SocketAddr, new_actor: NA)
+fn test<NA>(local_address: SocketAddr, new_actor: NA)
 where
-    NA: NewActor<
-        Message = !,
-        Argument = SocketAddr,
-        Actor = A,
-        Error = !,
-        Context = context::ThreadLocal,
-    >,
-    A: Actor<Error = io::Error>,
+    NA: NewActor<Argument = SocketAddr, Error = !, Context = context::ThreadLocal>,
+    <NA as NewActor>::Actor: Actor<Error = io::Error>,
 {
     let echo_socket = std::net::UdpSocket::bind(local_address).unwrap();
     let address = echo_socket.local_addr().unwrap();
@@ -141,16 +137,16 @@ async fn connected_udp_actor(
 }
 
 #[test]
-fn reconnecting_udp_socket_ipv4() {
-    test_reconnecting_udp_socket(any_local_address())
+fn reconnecting_ipv4() {
+    test_reconnecting(any_local_address())
 }
 
 #[test]
-fn reconnecting_udp_socket_ipv6() {
-    test_reconnecting_udp_socket(any_local_ipv6_address())
+fn reconnecting_ipv6() {
+    test_reconnecting(any_local_ipv6_address())
 }
 
-fn test_reconnecting_udp_socket(local_address: SocketAddr) {
+fn test_reconnecting(local_address: SocketAddr) {
     let local_address = SocketAddr::new(local_address.ip(), 0);
     let socket1 = std::net::UdpSocket::bind(local_address).unwrap();
     let socket2 = std::net::UdpSocket::bind(local_address).unwrap();

--- a/tests/functional/udp.rs
+++ b/tests/functional/udp.rs
@@ -351,7 +351,7 @@ where
 }
 
 fn assert_read(mut got: &[u8], expected: &[&[u8]]) {
-    for expected in expected.into_iter().copied() {
+    for expected in expected.iter().copied() {
         let len = expected.len();
         assert_eq!(&got[..len], expected);
         let (_, g) = got.split_at(len);

--- a/tests/functional/udp.rs
+++ b/tests/functional/udp.rs
@@ -248,18 +248,26 @@ async fn unconnected_vectored_io_actor(
     let bytes_written = socket.send_to_vectored(bufs, peer_address).await?;
     assert_eq!(bytes_written, DATAV_LEN);
 
-    // TODO: replace with vectored peeking.
-    let mut buf = Vec::with_capacity(DATAV_LEN + 2);
-    let (bytes_peeked, address) = socket.peek_from(&mut buf).await?;
+    let mut buf1 = Vec::with_capacity(DATAV[0].len());
+    let mut buf2 = Vec::with_capacity(DATAV[1].len());
+    let mut buf3 = Vec::with_capacity(DATAV[2].len() + 2);
+    let mut bufs = [&mut buf1, &mut buf2, &mut buf3];
+    let (bytes_peeked, address) = socket.peek_from_vectored(&mut bufs).await?;
     assert_eq!(bytes_peeked, DATAV_LEN);
-    assert_read(&buf, DATAV);
+    assert_eq!(buf1, DATAV[0]);
+    assert_eq!(buf2, DATAV[1]);
+    assert_eq!(buf3, DATAV[2]);
     assert_eq!(address, peer_address);
 
-    // TODO: replace with vectored reading.
-    buf.clear();
-    let (bytes_read, address) = socket.recv_from(&mut buf).await?;
+    buf1.clear();
+    buf2.clear();
+    buf3.clear();
+    let mut bufs = [&mut buf1, &mut buf2, &mut buf3];
+    let (bytes_read, address) = socket.recv_from_vectored(&mut bufs).await?;
     assert_eq!(bytes_read, DATAV_LEN);
-    assert_read(&buf, DATAV);
+    assert_eq!(buf1, DATAV[0]);
+    assert_eq!(buf2, DATAV[1]);
+    assert_eq!(buf3, DATAV[2]);
     assert_eq!(address, peer_address);
 
     Ok(())
@@ -281,17 +289,25 @@ async fn connected_vectored_io_actor(
     let bytes_written = socket.send_vectored(bufs).await?;
     assert_eq!(bytes_written, DATAV_LEN);
 
-    // TODO: replace with vectored peeking.
-    let mut buf = Vec::with_capacity(DATAV_LEN + 2);
-    let bytes_peeked = socket.peek(&mut buf).await?;
+    let mut buf1 = Vec::with_capacity(DATAV[0].len());
+    let mut buf2 = Vec::with_capacity(DATAV[1].len());
+    let mut buf3 = Vec::with_capacity(DATAV[2].len() + 2);
+    let mut bufs = [&mut buf1, &mut buf2, &mut buf3];
+    let bytes_peeked = socket.peek_vectored(&mut bufs).await?;
     assert_eq!(bytes_peeked, DATAV_LEN);
-    assert_read(&buf, DATAV);
+    assert_eq!(buf1, DATAV[0]);
+    assert_eq!(buf2, DATAV[1]);
+    assert_eq!(buf3, DATAV[2]);
 
-    // TODO: replace with vectored reading.
-    buf.clear();
-    let bytes_read = socket.recv(&mut buf).await?;
+    buf1.clear();
+    buf2.clear();
+    buf3.clear();
+    let mut bufs = [&mut buf1, &mut buf2, &mut buf3];
+    let bytes_read = socket.recv_vectored(&mut bufs).await?;
     assert_eq!(bytes_read, DATAV_LEN);
-    assert_read(&buf, DATAV);
+    assert_eq!(buf1, DATAV[0]);
+    assert_eq!(buf2, DATAV[1]);
+    assert_eq!(buf3, DATAV[2]);
 
     Ok(())
 }


### PR DESCRIPTION
This implements vectored I/O for UdpSocket and TcpStream based on the socket2 crate.

Adds the following API:
 * `net::MaybeUninitSlice` structure.
 * `net::BytesVectored` structure.

For `TcpStream`:
 * `TcpStream::try_send_vectored`
 * `TcpStream::send_vectored`
 * `TcpStream::send_vectored_all`
 *  `TcpStream::try_recv_vectored`
 * `TcpStream::recv_vectored`
 * `TcpStream::recv_n_vectored`

For `UdpSocket`:
 * `UdpSocket::try_send_to_vectored`
 * `UdpSocket::send_to_vectored`
 * `UdpSocket::try_send_vectored`
 * `UdpSocket::send_vectored`
 * `UdpSocket::try_recv_from_vectored`
 * `UdpSocket::recv_from_vectored`
 * `UdpSocket::try_peek_from_vectored`
 * `UdpSocket::peek_from_vectored`
 * `UdpSocket::try_recv_vectored`
 * `UdpSocket::recv_vectored`
 * `UdpSocket::try_peek_vectored`
 * `UdpSocket::peek_vectored`

Removes the following:
 * `TcpStream::set_cpu_affinity` and `TcpStream::cpu_affinity`, now private.

Closes #305, #353,  #352.