### PR TITLE
Move std-logger to dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,8 @@ log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }
 mio-signals       = { version = "0.1.2", default-features = false }
 socket2           = { version = "0.4.0-alpha.5", default-features = false, features = ["all"] }
-# Enable logging panics via `std-logger` and add timestamps to each log message.
-std-logger        = { version = "0.3.6", default-features = false, features = ["log-panic", "timestamp"] }
 
+# Optional dependencies, enabled by features.
 # Required by the `test` feature.
 rand              = { version = "0.7.3", default-features = false, features = ["std"], optional = true }
 
@@ -41,3 +40,5 @@ rand              = { version = "0.7.3", default-features = false, features = ["
 futures-test      = { version = "0.3.4", default-features = false, features = ["std"] }
 futures-util      = { version = "0.3.4", default-features = false, features = ["async-await-macro"] }
 rand              = { version = "0.7.3", default-features = false, features = ["std"] }
+# Enable logging panics via `std-logger` and add timestamps to each log message.
+std-logger        = { version = "0.3.6", default-features = false, features = ["log-panic", "timestamp"] }

--- a/examples/2_my_ip.rs
+++ b/examples/2_my_ip.rs
@@ -4,11 +4,11 @@ use std::io;
 use std::net::SocketAddr;
 
 use heph::actor::{self, context, NewActor};
-use heph::log::{self, error, info};
 use heph::net::{tcp, TcpServer, TcpStream};
 use heph::rt::options::Priority;
 use heph::supervisor::{Supervisor, SupervisorStrategy};
 use heph::{rt, ActorOptions, Runtime};
+use log::{error, info};
 
 fn main() -> Result<(), rt::Error<io::Error>> {
     // For this example we'll enable logging, this give us a bit more insight
@@ -16,7 +16,7 @@ fn main() -> Result<(), rt::Error<io::Error>> {
     // messages, the environment variable `LOG_LEVEL` can be set to change this.
     // For example enabling logging of trace severity message can be done by
     // setting `LOG_LEVEL=trace`.
-    log::init();
+    std_logger::init();
 
     // Create our TCP server. This server will create a new actor for each
     // incoming TCP connection. As always, actors needs supervision, this is

--- a/examples/7_restart_supervisor.rs
+++ b/examples/7_restart_supervisor.rs
@@ -6,7 +6,7 @@ use heph::rt::{self, ActorOptions, Runtime, RuntimeRef, SyncActorOptions};
 use heph::{actor, restart_supervisor};
 
 fn main() -> Result<(), rt::Error> {
-    heph::log::init();
+    std_logger::init();
     let mut runtime = Runtime::new()?;
 
     let sync_actor = sync_print_actor as fn(_, _) -> _;

--- a/examples/99_stress_memory.rs
+++ b/examples/99_stress_memory.rs
@@ -11,7 +11,7 @@ use heph::supervisor::NoSupervisor;
 use heph::{actor, rt, ActorOptions, Runtime};
 
 fn main() -> Result<(), rt::Error> {
-    heph::log::init();
+    std_logger::init();
     Runtime::new()?
         .with_setup(move |mut runtime_ref| {
             const N: usize = 10_000_000;

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -263,11 +263,11 @@ pub trait NewActor {
     /// # use heph::actor::messages::Terminate;
     /// # use heph::actor::context;
     /// use heph::actor::{self, NewActor};
-    /// # use heph::log::error;
     /// use heph::net::{TcpServer, TcpStream};
     /// # use heph::net::tcp::server;
     /// # use heph::supervisor::{Supervisor, SupervisorStrategy};
     /// use heph::{rt, ActorOptions, Runtime, RuntimeRef};
+    /// # use log::error;
     ///
     /// fn main() -> Result<(), rt::Error<io::Error>> {
     ///     // Create and run runtime

--- a/src/log.rs
+++ b/src/log.rs
@@ -6,14 +6,11 @@
 //! re-exported here, which means that the macros in the `log` crate can also be
 //! used.
 //!
-//! The actual logging implementation comes from the [`std-logger`] crate. By
-//! default logs are written to standard error and requests log are written to
-//! standard out. To log a request the `request` macro can be used, which is
-//! re-exported from the `std-logger` crate.
-//!
-//! To enable logging call [`init`].
+//! Heph doesn't provide a logging implementation, but it recommends the
+//! [`std-logger`] crate.
 //!
 //! [`log`]: https://crates.io/crates/log
+//! [`std-logger`]: https://crates.io/crates/std_logger
 //!
 //! # Examples
 //!
@@ -24,11 +21,11 @@
 //!
 //! use heph::supervisor::NoSupervisor;
 //! use heph::{actor, rt, ActorOptions, Runtime, RuntimeRef};
-//! use heph::log::{self, request};
+//! use log::info;
 //!
 //! fn main() -> Result<(), rt::Error> {
 //!     // Enable logging.
-//!     log::init();
+//!     std_logger::init();
 //!
 //!     Runtime::new()?.with_setup(add_greeter_actor).start()
 //! }
@@ -40,20 +37,12 @@
 //! }
 //!
 //! async fn greeter_actor(_: actor::Context<!>) -> Result<(), !> {
-//!     // Log a request.
-//!     request!("Hello world");
+//!     // Log an informational message.
+//!     info!("Hello world");
 //!
 //!     Ok(())
 //! }
 //! ```
-//!
-//! [`std-logger`]: std_logger
-// [`request`]: crate::log::request
-// FIXME: this doesn't seem to work, see Rust issue #43466.
-//! [`init`]: crate::log::init
 
 #[doc(no_inline)]
 pub use log::{debug, error, info, log, log_enabled, trace, warn};
-
-#[doc(no_inline)]
-pub use std_logger::{init, request, try_init, REQUEST_TARGET};

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -38,12 +38,12 @@ use crate::rt::{self, PrivateAccess};
 /// use log::error;
 ///
 /// # use heph::net::TcpStream;
-/// use heph::log::request;
 /// use heph::net::TcpListener;
 /// use heph::{actor, rt, ActorOptions, Runtime, RuntimeRef, SupervisorStrategy};
+/// use log::info;
 ///
 /// fn main() -> Result<(), rt::Error> {
-///     heph::log::init();
+///     std_logger::init();
 ///
 ///     Runtime::new().map_err(rt::Error::map_type)?.with_setup(setup).start()
 /// }
@@ -79,7 +79,7 @@ use crate::rt::{self, PrivateAccess};
 ///
 ///     // Accept a connection.
 ///     let (unbound_stream, peer_address) = listener.accept().await?;
-///     request!("accepted connection from: {}", peer_address);
+///     info!("accepted connection from: {}", peer_address);
 ///
 ///     // Next we need to bind the stream to this actor.
 ///     let mut stream = unbound_stream.bind_to(&mut ctx)?;
@@ -103,12 +103,12 @@ use crate::rt::{self, PrivateAccess};
 /// use log::error;
 ///
 /// # use heph::net::TcpStream;
-/// use heph::log::request;
 /// use heph::net::TcpListener;
 /// use heph::{actor, rt, ActorOptions, Runtime, RuntimeRef, SupervisorStrategy};
+/// use log::info;
 ///
 /// fn main() -> Result<(), rt::Error> {
-///     heph::log::init();
+///     std_logger::init();
 ///
 ///     Runtime::new().map_err(rt::Error::map_type)?.with_setup(setup).start()
 /// }
@@ -145,7 +145,7 @@ use crate::rt::{self, PrivateAccess};
 /// #   let streams = streams.take(1);
 ///
 ///     streams.try_for_each(|(unbound_stream, peer_address)| {
-///         request!("accepted connection from: {}", peer_address);
+///         info!("accepted connection from: {}", peer_address);
 ///         // Next we need to bind the stream to this actor.
 ///         ready(unbound_stream.bind_to(&mut ctx)).and_then(async move |mut stream| {
 ///             // Next we write the IP address to the connection.

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -155,11 +155,11 @@ impl<S, NA> Clone for Setup<S, NA> {
 ///
 /// use heph::actor::{self, context, NewActor};
 /// # use heph::actor::messages::Terminate;
-/// use heph::log::error;
 /// use heph::net::tcp::{server, TcpServer, TcpStream};
 /// use heph::supervisor::{Supervisor, SupervisorStrategy};
 /// use heph::rt::options::Priority;
 /// use heph::{rt, ActorOptions, Runtime, RuntimeRef};
+/// use log::error;
 ///
 /// fn main() -> Result<(), rt::Error<io::Error>> {
 ///     // Create and start the Heph runtime.
@@ -248,12 +248,12 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// # use heph::actor::context;
 /// use heph::actor::messages::Terminate;
 /// use heph::{actor, NewActor};
-/// use heph::log::error;
 /// use heph::net::{TcpServer, TcpStream};
 /// # use heph::net::tcp;
 /// use heph::supervisor::{Supervisor, SupervisorStrategy};
 /// use heph::rt::options::Priority;
 /// use heph::{rt, ActorOptions, Runtime, RuntimeRef};
+/// use log::error;
 ///
 /// fn main() -> Result<(), rt::Error<io::Error>> {
 ///     Runtime::new().map_err(rt::Error::map_type)?.with_setup(setup).start()
@@ -335,11 +335,11 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// use heph::actor::{self, NewActor};
 /// use heph::actor::context::ThreadSafe;
 /// # use heph::actor::messages::Terminate;
-/// use heph::log::error;
 /// use heph::net::tcp::{server, TcpServer, TcpStream};
 /// use heph::supervisor::{Supervisor, SupervisorStrategy};
 /// use heph::rt::options::Priority;
 /// use heph::{rt, ActorOptions, Runtime};
+/// use log::error;
 ///
 /// fn main() -> Result<(), rt::Error<io::Error>> {
 ///     let mut runtime = Runtime::new().map_err(rt::Error::map_type)?;

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -70,7 +70,7 @@ pub enum Connected {}
 /// use heph::{actor, rt, ActorOptions, Runtime, RuntimeRef, SupervisorStrategy};
 ///
 /// fn main() -> Result<(), rt::Error> {
-///     heph::log::init();
+///     std_logger::init();
 ///
 ///     Runtime::new().map_err(rt::Error::map_type)?.with_setup(setup).start()
 /// }

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -65,13 +65,13 @@
 //! ```
 //! #![feature(never_type)]
 //!
-//! use heph::log::{self, error};
 //! use heph::supervisor::SupervisorStrategy;
 //! use heph::{actor, rt, ActorOptions, Runtime};
+//! use log::error;
 //!
 //! fn main() -> Result<(), rt::Error> {
 //!     // Enable logging so we can see the error message.
-//!     log::init();
+//!     std_logger::init();
 //!
 //!     Runtime::new().map_err(rt::Error::map_type)?
 //!         .with_setup(|mut runtime_ref| {


### PR DESCRIPTION
Std-logger isn't really a required feature, if users want to use another
logging implementation this would just include dead code.

Reduces the number of crates from 56 to 37 crates when building without
features.

Removes the following API:
 * log::init
 * log::try_init
 * log::request
 * log::REQUEST_TARGET