### PR TITLE
Improve restart_supervisor! ergonomics

### DIFF
--- a/examples/7_restart_supervisor.rs
+++ b/examples/7_restart_supervisor.rs
@@ -35,8 +35,8 @@ restart_supervisor!(
     PrintSupervisor,
     "print actor",
     String,
-    default,
-    default,
+    5,
+    Duration::from_secs(5),
     ": actor message '{}'",
     args
 );

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -351,7 +351,7 @@ where
 /// );
 ///
 /// // Create a new supervisor.
-/// let supervisor = MySupervisor::new((true, 23));
+/// let supervisor = MySupervisor::new(true, 23);
 /// # drop(supervisor);
 /// ```
 #[macro_export]
@@ -400,6 +400,7 @@ macro_rules! restart_supervisor {
 }
 
 /// Private macro to implement the [`restart_supervisor`].
+#[doc(hidden)]
 #[macro_export]
 macro_rules! __heph_restart_supervisor_impl {
     (
@@ -420,6 +421,7 @@ macro_rules! __heph_restart_supervisor_impl {
                 "within a duration of: `", stringify!($max_duration), "`.",
             ),
             #[derive(Debug)]
+            #[allow(unused_qualifications)]
             $vis struct $supervisor_name {
                 /// The number of restarts left.
                 restarts_left: std::primitive::usize,
@@ -430,6 +432,7 @@ macro_rules! __heph_restart_supervisor_impl {
             }
         );
 
+        #[allow(unused_qualifications)]
         impl $supervisor_name {
             /// Maximum number of restarts within a [`Self::MAX_DURATION`] time
             /// period before the actor is stopped.
@@ -563,7 +566,77 @@ macro_rules! __heph_restart_supervisor_impl {
         );
     };
     // Tuple type as argument.
-    // TODO: expand arguments passed to the `new` function.
+    // Tuple of 2.
+    (impl_new $vis: vis $supervisor_name: ident, ($arg0: ty, $arg1: ty)) => {
+        $crate::__heph_doc!(
+            std::concat!("Create a new `", stringify!($supervisor_name), "`."),
+            #[allow(dead_code)]
+            $vis const fn new(arg0: $arg0, arg1: $arg1) -> $supervisor_name {
+                $supervisor_name {
+                    restarts_left: Self::MAX_RESTARTS,
+                    last_restart: None,
+                    args: (arg0, arg1),
+                }
+            }
+        );
+    };
+    // Tuple of 3.
+    (impl_new $vis: vis $supervisor_name: ident, ($arg0: ty, $arg1: ty, $arg2: ty)) => {
+        $crate::__heph_doc!(
+            std::concat!("Create a new `", stringify!($supervisor_name), "`."),
+            #[allow(dead_code)]
+            $vis const fn new(arg0: $arg0, arg1: $arg1, arg2: $arg2) -> $supervisor_name {
+                $supervisor_name {
+                    restarts_left: Self::MAX_RESTARTS,
+                    last_restart: None,
+                    args: (arg0, arg1, arg2),
+                }
+            }
+        );
+    };
+    // Tuple of 4.
+    (impl_new $vis: vis $supervisor_name: ident, ($arg0: ty, $arg1: ty, $arg2: ty, $arg3: ty)) => {
+        $crate::__heph_doc!(
+            std::concat!("Create a new `", stringify!($supervisor_name), "`."),
+            #[allow(dead_code)]
+            $vis const fn new(arg0: $arg0, arg1: $arg1, arg2: $arg2, arg3: $arg3) -> $supervisor_name {
+                $supervisor_name {
+                    restarts_left: Self::MAX_RESTARTS,
+                    last_restart: None,
+                    args: (arg0, arg1, arg2, arg3),
+                }
+            }
+        );
+    };
+    // Tuple of 5.
+    (impl_new $vis: vis $supervisor_name: ident, ($arg0: ty, $arg1: ty, $arg2: ty, $arg3: ty, $arg4: ty)) => {
+        $crate::__heph_doc!(
+            std::concat!("Create a new `", stringify!($supervisor_name), "`."),
+            #[allow(dead_code)]
+            $vis const fn new(arg0: $arg0, arg1: $arg1, arg2: $arg2, arg3: $arg3, arg4: $arg4) -> $supervisor_name {
+                $supervisor_name {
+                    restarts_left: Self::MAX_RESTARTS,
+                    last_restart: None,
+                    args: (arg0, arg1, arg2, arg3, arg4),
+                }
+            }
+        );
+    };
+    // Tuple of 6.
+    (impl_new $vis: vis $supervisor_name: ident, ($arg0: ty, $arg1: ty, $arg2: ty, $arg3: ty, $arg4: ty, $arg5: ty)) => {
+        $crate::__heph_doc!(
+            std::concat!("Create a new `", stringify!($supervisor_name), "`."),
+            #[allow(dead_code)]
+            $vis const fn new(arg0: $arg0, arg1: $arg1, arg2: $arg2, arg3: $arg3, arg4: $arg4, arg5: $arg5) -> $supervisor_name {
+                $supervisor_name {
+                    restarts_left: Self::MAX_RESTARTS,
+                    last_restart: None,
+                    args: (arg0, arg1, arg2, arg3, arg4, arg5),
+                }
+            }
+        );
+    };
+    // Tuple of 6+.
     (impl_new $vis: vis $supervisor_name: ident, ( $( $arg: ty ),* )) => {
         $crate::__heph_doc!(
             std::concat!("Create a new `", stringify!($supervisor_name), "`."),
@@ -580,8 +653,8 @@ macro_rules! __heph_restart_supervisor_impl {
 }
 
 /// Helper macro to document type created in [`restart_supervisor`].
-#[macro_export]
 #[doc(hidden)]
+#[macro_export]
 macro_rules! __heph_doc {
     ($doc: expr, $( $tt: tt )*) => {
         #[doc = $doc]

--- a/tests/functional/restart_supervisor.rs
+++ b/tests/functional/restart_supervisor.rs
@@ -19,85 +19,117 @@ const DEFAULT_MAX_RESTARTS: usize = 5;
 const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(5);
 
 #[test]
-fn defaults_not_specified() {
-    restart_supervisor!(Supervisor, "my actor", ());
+fn new_actor_unit_argument() {
+    restart_supervisor!(Supervisor, "my actor");
+    // Should be able to create it without arguments passed to `new`.
+    let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
     assert_eq!(Supervisor::MAX_DURATION, DEFAULT_MAX_DURATION);
 }
 
 #[test]
-fn defaults_with_max_restarts() {
-    restart_supervisor!(Supervisor, "my actor", (), 2);
-    assert_eq!(Supervisor::MAX_RESTARTS, 2);
+fn new_actor_unit_argument_explicit() {
+    restart_supervisor!(Supervisor, "my actor", ());
+    // Should be able to create it without arguments passed to `new`.
+    let _supervisor = Supervisor::new();
+    assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
     assert_eq!(Supervisor::MAX_DURATION, DEFAULT_MAX_DURATION);
 }
 
 #[test]
-fn defaults_with_max_restarts_and_duration() {
+fn new_actor_single_argument() {
+    restart_supervisor!(Supervisor, "my actor", String);
+    // Should be able to directly pass argument.
+    let _supervisor = Supervisor::new("Hello World".to_owned());
+    assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
+    assert_eq!(Supervisor::MAX_DURATION, DEFAULT_MAX_DURATION);
+}
+
+#[test]
+fn new_actor_tuple_argument() {
+    restart_supervisor!(Supervisor, "my actor", (String, usize));
+    // Should be able to directly pass argument.
+    let _supervisor = Supervisor::new(("Hello World".to_owned(), 123));
+    assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
+    assert_eq!(Supervisor::MAX_DURATION, DEFAULT_MAX_DURATION);
+}
+
+#[test]
+fn no_log_unit_argument() {
     restart_supervisor!(Supervisor, "my actor", (), 2, Duration::from_secs(10));
+    let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
 }
 
 #[test]
-fn defaults_with_log_extra() {
+fn no_log_single_argument() {
+    restart_supervisor!(Supervisor, "my actor", usize, 2, Duration::from_secs(10));
+    let _supervisor = Supervisor::new(123);
+    assert_eq!(Supervisor::MAX_RESTARTS, 2);
+    assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
+}
+
+#[test]
+fn no_log_tuple_argument() {
+    restart_supervisor!(
+        Supervisor,
+        "my actor",
+        (u8, u16),
+        2,
+        Duration::from_secs(10)
+    );
+    let _supervisor = Supervisor::new((123, 456));
+    assert_eq!(Supervisor::MAX_RESTARTS, 2);
+    assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
+}
+
+#[test]
+fn all_unit_argument() {
     restart_supervisor!(
         Supervisor,
         "my actor",
         (),
-        default,
-        default,
-        "something extra",
-    );
-    assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
-    assert_eq!(Supervisor::MAX_DURATION, DEFAULT_MAX_DURATION);
-}
-
-#[test]
-fn defaults_with_log_extra_and_arg() {
-    restart_supervisor!(
-        Supervisor,
-        "my actor",
-        bool,
-        default,
-        default,
-        "something extra: {}",
-        args
-    );
-    assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
-    assert_eq!(Supervisor::MAX_DURATION, DEFAULT_MAX_DURATION);
-}
-
-/* FIXME: can't use default twice as it will be picked up as `expr`.
-#[test]
-fn defaults_with_max_restarts_and_log_extra_and_arg() {
-    restart_supervisor!(
-        Supervisor,
-        "my actor",
-        bool,
         2,
-        default,
-        "something extra: {}",
-        args
+        Duration::from_secs(10),
+        ": log extra",
     );
+    let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
-    assert_eq!(Supervisor::MAX_DURATION, DEFAULT_MAX_DURATION);
+    assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
 }
-*/
 
 #[test]
-fn defaults_with_max_duration_and_log_extra_and_arg() {
+fn all_single_argument() {
     restart_supervisor!(
         Supervisor,
         "my actor",
-        bool,
-        default,
-        Duration::from_secs(60),
-        "something extra: {}",
+        usize,
+        2,
+        Duration::from_secs(10),
+        ": log extra: {}",
         args
     );
-    assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
-    assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(60));
+    let _supervisor = Supervisor::new(123);
+    assert_eq!(Supervisor::MAX_RESTARTS, 2);
+    assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
+}
+
+#[test]
+fn all_tuple_argument() {
+    restart_supervisor!(
+        Supervisor,
+        "my actor",
+        (u8, u16),
+        2,
+        Duration::from_secs(10),
+        ": log extra: {}, {}",
+        args.0,
+        args.1,
+    );
+    let _supervisor = Supervisor::new((123, 456));
+    assert_eq!(Supervisor::MAX_RESTARTS, 2);
+    assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
 }
 
 const ERROR1: &str = "error 1";

--- a/tests/functional/restart_supervisor.rs
+++ b/tests/functional/restart_supervisor.rs
@@ -11,8 +11,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use heph::actor::context::ThreadSafe;
-use heph::restart_supervisor;
-use heph::{actor, Actor, NewActor, Supervisor, SupervisorStrategy};
+use heph::{actor, restart_supervisor, Actor, NewActor, Supervisor, SupervisorStrategy};
 
 // NOTE: keep in sync with the documentation.
 const DEFAULT_MAX_RESTARTS: usize = 5;
@@ -49,7 +48,7 @@ fn new_actor_single_argument() {
 fn new_actor_tuple_argument() {
     restart_supervisor!(Supervisor, "my actor", (String, usize));
     // Should be able to directly pass argument.
-    let _supervisor = Supervisor::new(("Hello World".to_owned(), 123));
+    let _supervisor = Supervisor::new("Hello World".to_owned(), 123);
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
     assert_eq!(Supervisor::MAX_DURATION, DEFAULT_MAX_DURATION);
 }
@@ -79,7 +78,7 @@ fn no_log_tuple_argument() {
         2,
         Duration::from_secs(10)
     );
-    let _supervisor = Supervisor::new((123, 456));
+    let _supervisor = Supervisor::new(123, 456);
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
 }
@@ -127,9 +126,55 @@ fn all_tuple_argument() {
         args.0,
         args.1,
     );
-    let _supervisor = Supervisor::new((123, 456));
+    let _supervisor = Supervisor::new(123, 456);
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
+}
+
+#[test]
+fn typle_2() {
+    restart_supervisor!(Supervisor, "my actor", (String, usize));
+    // Should be able to directly pass argument.
+    let _supervisor = Supervisor::new("Hello World".to_owned(), 123);
+}
+
+#[test]
+fn typle_3() {
+    restart_supervisor!(Supervisor, "my actor", (String, usize, u8));
+    // Should be able to directly pass argument.
+    let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1);
+}
+
+#[test]
+fn typle_4() {
+    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, &'static str));
+    // Should be able to directly pass argument.
+    let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, "arg");
+}
+
+#[test]
+fn typle_5() {
+    restart_supervisor!(
+        Supervisor,
+        "my actor",
+        (String, usize, u8, &'static str, u8)
+    );
+    // Should be able to directly pass argument.
+    let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, "arg", 1);
+}
+
+#[test]
+fn typle_6() {
+    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, u8, u8, u8));
+    // Should be able to directly pass argument.
+    let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, 2, 3, 4);
+}
+
+#[test]
+fn typle_7() {
+    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, u8, u8, u8, u8));
+    // Need to use tuple format.
+    let _supervisor = Supervisor::new(("Hello World".to_owned(), 123, 1, 2, 3, 4, 5));
 }
 
 const ERROR1: &str = "error 1";


### PR DESCRIPTION
Changes the generated `new` function to accept no arguments when a unit arguments is used as `NewActor::Argument`. Also changes the generated `new` function to accept each part of the tuple as an argument, rather than a single argument with the complete tuple.

This also removes the `default` options as there are too many branches already.

Closes #302.
Closes #314.