### PR TITLE
Remove futures-test dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ socket2           = { version = "0.4.0-alpha.5", default-features = false, featu
 getrandom         = { version = "0.2.2", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
-futures-test      = { version = "0.3.4", default-features = false, features = ["std"] }
 futures-util      = { version = "0.3.4", default-features = false, features = ["async-await-macro"] }
 getrandom         = { version = "0.2.2", default-features = false, features = ["std"] }
 # Enable logging panics via `std-logger` and add timestamps to each log message.

--- a/src/rt/process/tests.rs
+++ b/src/rt/process/tests.rs
@@ -4,14 +4,13 @@ use std::pin::Pin;
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
 
-use futures_test::future::{AssertUnmoved, FutureTestExt};
 use futures_util::future::{pending, Pending};
 use mio::Token;
 
 use crate::actor::{self, context, Actor, NewActor};
 use crate::rt::process::{ActorProcess, Process, ProcessId, ProcessResult};
 use crate::supervisor::{NoSupervisor, Supervisor, SupervisorStrategy};
-use crate::test::{self, init_local_actor_with_inbox, TEST_PID};
+use crate::test::{self, init_local_actor_with_inbox, AssertUnmoved, TEST_PID};
 
 #[test]
 fn pid() {
@@ -151,7 +150,7 @@ impl NewActor for TestAssertUnmovedNewActor {
         _: actor::Context<Self::Message>,
         _: Self::Argument,
     ) -> Result<Self::Actor, Self::Error> {
-        Ok(pending().assert_unmoved())
+        Ok(AssertUnmoved::new(pending()))
     }
 }
 

--- a/src/rt/scheduler/tests.rs
+++ b/src/rt/scheduler/tests.rs
@@ -7,14 +7,13 @@ use std::pin::Pin;
 use std::thread::sleep;
 use std::time::Duration;
 
-use futures_test::future::{AssertUnmoved, FutureTestExt};
 use futures_util::future::{pending, Pending};
 
 use crate::actor::{self, NewActor};
 use crate::rt::process::{Process, ProcessId, ProcessResult};
 use crate::rt::scheduler::{local, shared, Priority, ProcessData};
 use crate::rt::RuntimeRef;
-use crate::test;
+use crate::test::{self, AssertUnmoved};
 
 fn assert_size<T>(expected: usize) {
     assert_eq!(mem::size_of::<T>(), expected);
@@ -181,7 +180,7 @@ impl<C> NewActor for TestAssertUnmovedNewActor<C> {
         // In the test we need the access to the inbox, to achieve that we can't
         // drop the context, so we forget about it here leaking the inbox.
         forget(ctx);
-        Ok(pending().assert_unmoved())
+        Ok(AssertUnmoved::new(pending()))
     }
 }
 


### PR DESCRIPTION
Only used a single type from it, but it pulled in many dependencies.