### PR TITLE
Remove futures crates as depdencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ socket2           = { version = "0.4.0-alpha.5", default-features = false, featu
 getrandom         = { version = "0.2.2", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
-futures-test      = { version = "0.3.4", default-features = false, features = ["std"] }
 getrandom         = { version = "0.2.2", default-features = false, features = ["std"] }
 # Enable logging panics via `std-logger` and add timestamps to each log message.
 std-logger        = { version = "0.3.6", default-features = false, features = ["log-panic", "timestamp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ getrandom         = { version = "0.2.2", default-features = false, features = ["
 
 [dev-dependencies]
 futures-test      = { version = "0.3.4", default-features = false, features = ["std"] }
-futures-util      = { version = "0.3.4", default-features = false, features = ["async-await-macro"] }
 getrandom         = { version = "0.2.2", default-features = false, features = ["std"] }
 # Enable logging panics via `std-logger` and add timestamps to each log message.
 std-logger        = { version = "0.3.6", default-features = false, features = ["log-panic", "timestamp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ test = ["getrandom"]
 
 [dependencies]
 crossbeam-channel = { version = "0.5.0", default-features = false, features = ["std"] }
-futures-core      = { version = "0.3.6", default-features = false }
 # FIXME: use released version.
 inbox             = { git = "https://github.com/Thomasdezeeuw/inbox", rev = "6e11ff5d8bb947c93b5067f22071022baf8bd2d4" }
 libc              = { version = "0.2.79", default-features = false }

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -130,29 +130,23 @@ impl<M, C> Context<M, C> {
     ///
     /// use std::time::Duration;
     ///
-    /// use futures_util::future::FutureExt;
-    /// use futures_util::select;
     /// use heph::actor;
     /// use heph::timer::Timer;
+    /// use heph::util::either;
     ///
     /// async fn print_actor(mut ctx: actor::Context<String>) -> Result<(), !> {
     ///     // Create a timer, this will be ready once the timeout has
     ///     // passed.
-    ///     let mut timeout = Timer::timeout(&mut ctx, Duration::from_millis(100)).fuse();
+    ///     let timeout = Timer::timeout(&mut ctx, Duration::from_millis(100));
     ///     // Create a future to receive a message.
-    ///     let mut msg_future = ctx.receive_next().fuse();
+    ///     let msg_future = ctx.receive_next();
     ///
     ///     // Now let them race!
-    ///     // This is basically a match statement for futures, whichever
-    ///     // future is ready first will be the winner and we'll take that
-    ///     // branch.
-    ///     select! {
-    ///         msg = msg_future => match msg {
-    ///             Ok(msg) => println!("Got a message: {}", msg),
-    ///             Err(_) => println!("No message"),
-    ///         },
-    ///         _ = timeout => println!("No message"),
-    ///     };
+    ///     match either(msg_future, timeout).await {
+    ///         Ok(Ok(msg)) => println!("Got a message: {}", msg),
+    ///         Ok(Err(_)) => println!("No message"),
+    ///         Err(_) => println!("Timed out receiving message"),
+    ///     }
     ///
     ///     Ok(())
     /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub mod rt;
 pub mod supervisor;
 pub mod timer;
 pub mod trace;
+pub mod util;
 
 #[cfg(any(test, feature = "test"))]
 pub mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@
 
 #![feature(
     array_methods,
+    async_stream,
     available_concurrency,
     const_fn,
     const_option,
@@ -86,8 +87,7 @@
     maybe_uninit_uninit_array,
     never_type,
     new_uninit,
-    vec_spare_capacity,
-    wake_trait
+    vec_spare_capacity
 )]
 #![allow(incomplete_features)] // NOTE: for `generic_associated_types`.
 #![cfg_attr(any(test, feature = "test"), feature(once_cell))]

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -4,10 +4,9 @@ use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::stream::Stream;
 use std::task::{self, Poll};
 
-use futures_core::future::FusedFuture;
-use futures_core::stream::{FusedStream, Stream};
 use mio::{net, Interest};
 
 use crate::actor;
@@ -305,12 +304,6 @@ impl<'a> Future for Accept<'a> {
     }
 }
 
-impl<'a> FusedFuture for Accept<'a> {
-    fn is_terminated(&self) -> bool {
-        self.listener.is_none()
-    }
-}
-
 /// The [`Stream`] behind [`TcpListener::incoming`].
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
@@ -323,12 +316,6 @@ impl<'a> Stream for Incoming<'a> {
 
     fn poll_next(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
         try_io!(self.listener.try_accept()).map(Some)
-    }
-}
-
-impl<'a> FusedStream for Incoming<'a> {
-    fn is_terminated(&self) -> bool {
-        false
     }
 }
 

--- a/src/rt/process/tests.rs
+++ b/src/rt/process/tests.rs
@@ -1,11 +1,11 @@
 //! Tests for the process module.
 
+use std::future::{pending, Pending};
 use std::pin::Pin;
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
 
 use futures_test::future::{AssertUnmoved, FutureTestExt};
-use futures_util::future::{pending, Pending};
 use mio::Token;
 
 use crate::actor::{self, context, Actor, NewActor};

--- a/src/rt/process/tests.rs
+++ b/src/rt/process/tests.rs
@@ -5,13 +5,12 @@ use std::pin::Pin;
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
 
-use futures_test::future::{AssertUnmoved, FutureTestExt};
 use mio::Token;
 
 use crate::actor::{self, context, Actor, NewActor};
 use crate::rt::process::{ActorProcess, Process, ProcessId, ProcessResult};
 use crate::supervisor::{NoSupervisor, Supervisor, SupervisorStrategy};
-use crate::test::{self, init_local_actor_with_inbox, TEST_PID};
+use crate::test::{self, init_local_actor_with_inbox, AssertUnmoved, TEST_PID};
 
 #[test]
 fn pid() {
@@ -151,7 +150,7 @@ impl NewActor for TestAssertUnmovedNewActor {
         _: actor::Context<Self::Message>,
         _: Self::Argument,
     ) -> Result<Self::Actor, Self::Error> {
-        Ok(pending().assert_unmoved())
+        Ok(AssertUnmoved::new(pending()))
     }
 }
 

--- a/src/rt/scheduler/tests.rs
+++ b/src/rt/scheduler/tests.rs
@@ -8,13 +8,11 @@ use std::pin::Pin;
 use std::thread::sleep;
 use std::time::Duration;
 
-use futures_test::future::{AssertUnmoved, FutureTestExt};
-
 use crate::actor::{self, NewActor};
 use crate::rt::process::{Process, ProcessId, ProcessResult};
 use crate::rt::scheduler::{local, shared, Priority, ProcessData};
 use crate::rt::RuntimeRef;
-use crate::test;
+use crate::test::{self, AssertUnmoved};
 
 fn assert_size<T>(expected: usize) {
     assert_eq!(mem::size_of::<T>(), expected);
@@ -181,7 +179,7 @@ impl<C> NewActor for TestAssertUnmovedNewActor<C> {
         // In the test we need the access to the inbox, to achieve that we can't
         // drop the context, so we forget about it here leaking the inbox.
         forget(ctx);
-        Ok(pending().assert_unmoved())
+        Ok(AssertUnmoved::new(pending()))
     }
 }
 

--- a/src/rt/scheduler/tests.rs
+++ b/src/rt/scheduler/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the scheduler.
 
 use std::cmp::Ordering;
+use std::future::{pending, Pending};
 use std::marker::PhantomData;
 use std::mem::{self, forget};
 use std::pin::Pin;
@@ -8,7 +9,6 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use futures_test::future::{AssertUnmoved, FutureTestExt};
-use futures_util::future::{pending, Pending};
 
 use crate::actor::{self, NewActor};
 use crate::rt::process::{Process, ProcessId, ProcessResult};

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -9,16 +9,13 @@
 //!   deadline has passed.
 //! - [`Interval`](Interval) implements [`Stream`] which yields an item
 //!   after the deadline has passed each interval.
-//!
-//! [`Stream`]: futures_core::stream::Stream
 
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
+use std::stream::Stream;
 use std::task::{self, Poll};
 use std::time::{Duration, Instant};
-
-use futures_core::stream::{FusedStream, Stream};
 
 use crate::actor::context::ThreadLocal;
 use crate::rt::{self, PrivateAccess, ProcessId};
@@ -342,8 +339,6 @@ impl<Fut, K> actor::Bound<K> for Deadline<Fut> {
 /// This stream will never return `None`, it will always set another deadline
 /// and yield another item after the deadline has passed.
 ///
-/// [`Stream`]: futures_core::stream::Stream
-///
 /// # Notes
 ///
 /// The next deadline will always will be set after this returns `Poll::Ready`.
@@ -436,12 +431,6 @@ impl Stream for Interval {
         } else {
             Poll::Pending
         }
-    }
-}
-
-impl FusedStream for Interval {
-    fn is_terminated(&self) -> bool {
-        false
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,43 @@
+//! Module with various utilities.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{self, Poll};
+
+/// Helper [`Future`] that poll `future1` and `future2` and returns the output
+/// of the future that completes first.
+pub const fn either<Fut1, Fut2>(future1: Fut1, future2: Fut2) -> Either<Fut1, Fut2> {
+    Either { future1, future2 }
+}
+
+/// The [`Future`] behind [`either`].
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Either<Fut1, Fut2> {
+    future1: Fut1,
+    future2: Fut2,
+}
+
+impl<Fut1, Fut2> Future for Either<Fut1, Fut2>
+where
+    Fut1: Future,
+    Fut2: Future,
+{
+    type Output = Result<Fut1::Output, Fut2::Output>;
+
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        // Safety: not moving `future1`.
+        let future1 = unsafe { Pin::map_unchecked_mut(self.as_mut(), |s| &mut s.future1) };
+        match future1.poll(ctx) {
+            Poll::Ready(value) => Poll::Ready(Ok(value)),
+            Poll::Pending => {
+                // Safety: not moving `future2`.
+                let future2 = unsafe { Pin::map_unchecked_mut(self, |s| &mut s.future2) };
+                match future2.poll(ctx) {
+                    Poll::Ready(value) => Poll::Ready(Err(value)),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,9 +2,8 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::stream::Stream;
 use std::task::{self, Poll};
-
-use futures_core::stream::Stream;
 
 /// Helper [`Future`] that poll `future1` and `future2` and returns the output
 /// of the future that completes first.

--- a/tests/functional/actor_ref.rs
+++ b/tests/functional/actor_ref.rs
@@ -7,15 +7,13 @@ use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::task::Poll;
 
-use futures_util::pending;
-
 use heph::actor_ref::{ActorRef, RpcError, RpcMessage, SendError, SendValue};
 use heph::rt::options::Priority;
 use heph::supervisor::NoSupervisor;
 use heph::test::{init_local_actor, poll_actor};
 use heph::{actor, ActorOptions, Runtime};
 
-use crate::util::{assert_send, assert_size, assert_sync};
+use crate::util::{assert_send, assert_size, assert_sync, pending_once};
 
 /// Default size of the inbox, keep in sync with the inbox crate.
 const INBOX_SIZE: usize = 8;
@@ -645,7 +643,7 @@ async fn pong_is_connected(mut ctx: actor::Context<RpcTestMessage>) -> Result<()
             RpcTestMessage::Ping(RpcMessage { response, .. }) => {
                 response.is_connected();
 
-                pending!();
+                pending_once().await;
 
                 assert!(!response.is_connected());
                 assert_eq!(response.respond(Pong), Err(SendError));

--- a/tests/functional/tcp/listener.rs
+++ b/tests/functional/tcp/listener.rs
@@ -6,12 +6,11 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use futures_util::StreamExt;
-
 use heph::actor::{self, Bound};
 use heph::net::{TcpListener, TcpStream};
 use heph::supervisor::NoSupervisor;
 use heph::test::{init_local_actor, poll_actor};
+use heph::util::next;
 use heph::{rt, Actor, ActorOptions, ActorRef, Runtime, RuntimeRef};
 
 use crate::util::{any_local_address, any_local_ipv6_address, run_actors};
@@ -205,7 +204,7 @@ fn incoming() {
         actor_ref.send(address).await.unwrap();
 
         let mut incoming = listener.incoming();
-        let (stream, remote_address) = incoming.next().await.unwrap().unwrap();
+        let (stream, remote_address) = next(&mut incoming).await.unwrap().unwrap();
         let mut stream = stream.bind_to(&mut ctx).unwrap();
         assert!(remote_address.ip().is_loopback());
 

--- a/tests/functional/tcp/stream.rs
+++ b/tests/functional/tcp/stream.rs
@@ -11,8 +11,6 @@ use std::task::{self, Poll};
 use std::thread::sleep;
 use std::time::Duration;
 
-use futures_util::pin_mut;
-
 use heph::net::{TcpListener, TcpStream};
 use heph::test::{init_local_actor, poll_actor};
 use heph::{actor, Actor, ActorRef};
@@ -87,7 +85,7 @@ fn smoke() {
     let address = listener.local_addr().unwrap();
 
     let (actor, actor_ref) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -130,7 +128,7 @@ fn connect() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(STAGE.poll_till(Pin::as_mut(&mut actor), 1));
@@ -170,7 +168,7 @@ fn connect_connection_refused() {
     }
 
     let (actor, _) = init_local_actor(actor as fn(_) -> _, ()).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
     expect_ready_ok(STAGE.poll_till(Pin::as_mut(&mut actor), 2), ());
 }
 
@@ -238,7 +236,7 @@ fn try_recv() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(STAGE.poll_till(Pin::as_mut(&mut actor), 1));
@@ -276,7 +274,7 @@ fn recv() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -318,7 +316,7 @@ fn recv_n_read_exact_amount() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -364,7 +362,7 @@ fn recv_n_read_more_bytes() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -401,7 +399,7 @@ fn recv_n_less_bytes() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -436,7 +434,7 @@ fn recv_n_from_multiple_writes() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -485,7 +483,7 @@ fn send() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(STAGE.poll_till(Pin::as_mut(&mut actor), 1));
@@ -528,7 +526,7 @@ fn send_all() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -598,7 +596,7 @@ fn send_vectored() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(STAGE.poll_till(Pin::as_mut(&mut actor), 1));
@@ -645,7 +643,7 @@ fn send_vectored_all() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -729,7 +727,7 @@ fn recv_vectored() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(STAGE.poll_till(Pin::as_mut(&mut actor), 1));
@@ -784,7 +782,7 @@ fn recv_n_vectored_exact_amount() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -831,7 +829,7 @@ fn recv_n_vectored_more_bytes() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -869,7 +867,7 @@ fn recv_n_vectored_less_bytes() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -908,7 +906,7 @@ fn recv_n_vectored_from_multiple_writes() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -955,7 +953,7 @@ fn peek() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(poll_actor(Pin::as_mut(&mut actor)));
@@ -1022,7 +1020,7 @@ fn peek_vectored() {
     let address = listener.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(actor as fn(_, _) -> _, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Stream should not yet be connected.
     expect_pending(STAGE.poll_till(Pin::as_mut(&mut actor), 1));

--- a/tests/functional/timer.rs
+++ b/tests/functional/timer.rs
@@ -7,12 +7,11 @@ use std::task::{self, Poll};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use futures_util::stream::StreamExt;
-
 use heph::actor::{self, Bound};
 use heph::supervisor::NoSupervisor;
 use heph::test::{init_local_actor, poll_actor};
 use heph::timer::{Deadline, DeadlinePassed, Interval, Timer};
+use heph::util::next;
 use heph::{rt, ActorOptions, ActorRef, Runtime, RuntimeRef};
 
 const TIMEOUT: Duration = Duration::from_millis(100);
@@ -118,7 +117,7 @@ fn interval() {
         let start = Instant::now();
         let mut interval = Interval::new(&mut ctx, TIMEOUT);
         assert!(interval.next_deadline() >= start + TIMEOUT);
-        let _ = interval.next().await;
+        let _ = next(&mut interval).await;
         Ok(())
     }
 
@@ -155,7 +154,7 @@ fn triggered_timers_run_actors() {
 
     async fn interval_actor(mut ctx: actor::Context<!>) -> Result<(), !> {
         let mut interval = Interval::new(&mut ctx, TIMEOUT);
-        let _ = interval.next().await;
+        let _ = next(&mut interval).await;
         Ok(())
     }
 
@@ -261,7 +260,7 @@ fn timers_actor_bound() {
     async fn interval_actor2(mut ctx: actor::Context<Interval>) -> Result<(), !> {
         let mut interval = ctx.receive_next().await.unwrap();
         interval.bind_to(&mut ctx).unwrap();
-        let _ = interval.next().await;
+        let _ = next(&mut interval).await;
         Ok(())
     }
 

--- a/tests/functional/udp.rs
+++ b/tests/functional/udp.rs
@@ -9,8 +9,6 @@ use std::task::Poll;
 use std::thread::sleep;
 use std::time::Duration;
 
-use futures_util::pin_mut;
-
 use heph::actor::{self, context, Actor, NewActor};
 use heph::net::UdpSocket;
 use heph::test::{init_local_actor, poll_actor};
@@ -54,7 +52,7 @@ where
     let address = echo_socket.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(new_actor, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Send the data, peeking should return pending.
     match poll_actor(Pin::as_mut(&mut actor)) {
@@ -157,7 +155,7 @@ fn test_reconnecting(local_address: SocketAddr) {
     #[allow(trivial_casts)]
     let reconnecting_actor = reconnecting_actor as fn(_, _, _) -> _;
     let (actor, _) = init_local_actor(reconnecting_actor, (address1, address2)).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Let the actor send all data.
     loop {
@@ -321,7 +319,7 @@ where
     let address = echo_socket.local_addr().unwrap();
 
     let (actor, _) = init_local_actor(new_actor, address).unwrap();
-    pin_mut!(actor);
+    let mut actor = Box::pin(actor);
 
     // Send the data.
     match poll_actor(Pin::as_mut(&mut actor)) {


### PR DESCRIPTION
Removes all future-* crates as dependencies.

Reduce the number of crates to build from 86 to 63 (when testing). Also reduces the `cargo check` from 26.58s to 19.19s.

Includes #367.
Includes #368.