### PR TITLE
Internal cleanup

### DIFF
--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -48,10 +48,10 @@ impl Coordinator {
         let waker = mio::Waker::new(&registry, WAKER).map_err(Error::Init)?;
         let waker_id = waker::init(waker, waker_sender);
         let scheduler = Scheduler::new();
-        let timers = Arc::new(Mutex::new(Timers::new()));
+        let timers = Mutex::new(Timers::new());
 
         let shared_internals =
-            SharedRuntimeInternal::new(waker_id, scheduler.clone(), registry, timers.clone());
+            SharedRuntimeInternal::new(waker_id, scheduler.clone(), registry, timers);
         let coordinator = Coordinator {
             poll,
             waker_events,

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -56,7 +56,7 @@ impl Coordinator {
         let timers = Arc::new(Mutex::new(Timers::new()));
 
         let shared_internals =
-            SharedRuntimeInternal::new(waker_id, scheduler.create_ref(), registry, timers.clone());
+            SharedRuntimeInternal::new(waker_id, scheduler.clone(), registry, timers.clone());
         let coordinator = Coordinator {
             poll,
             waker_events,

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -50,8 +50,7 @@ impl Coordinator {
         let scheduler = Scheduler::new();
         let timers = Mutex::new(Timers::new());
 
-        let shared_internals =
-            SharedRuntimeInternal::new(waker_id, scheduler.clone(), registry, timers);
+        let shared_internals = SharedRuntimeInternal::new(waker_id, scheduler, registry, timers);
         let coordinator = Coordinator {
             poll,
             waker_events,

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -67,7 +67,7 @@ pub use signal::Signal;
 
 use coordinator::Coordinator;
 use hack::SetupFn;
-use scheduler::{LocalScheduler, SchedulerRef};
+use scheduler::{LocalScheduler, Scheduler};
 use sync_worker::SyncWorker;
 use waker::{WakerId, MAX_THREADS};
 use worker::Worker;
@@ -799,7 +799,7 @@ pub(crate) struct SharedRuntimeInternal {
     /// process.
     waker: Waker,
     /// Scheduler for thread-safe actors.
-    scheduler: SchedulerRef,
+    scheduler: Scheduler,
     /// Registry for the `Coordinator`'s `Poll` instance.
     registry: Registry,
     // FIXME: `Timers` is not up to this job.
@@ -809,7 +809,7 @@ pub(crate) struct SharedRuntimeInternal {
 impl SharedRuntimeInternal {
     pub(crate) fn new(
         waker_id: WakerId,
-        scheduler: SchedulerRef,
+        scheduler: Scheduler,
         registry: Registry,
         timers: Arc<Mutex<Timers>>,
     ) -> Arc<SharedRuntimeInternal> {

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -803,7 +803,7 @@ pub(crate) struct SharedRuntimeInternal {
     /// Registry for the `Coordinator`'s `Poll` instance.
     registry: Registry,
     // FIXME: `Timers` is not up to this job.
-    timers: Arc<Mutex<Timers>>,
+    timers: Mutex<Timers>,
 }
 
 impl SharedRuntimeInternal {
@@ -811,7 +811,7 @@ impl SharedRuntimeInternal {
         waker_id: WakerId,
         scheduler: Scheduler,
         registry: Registry,
-        timers: Arc<Mutex<Timers>>,
+        timers: Mutex<Timers>,
     ) -> Arc<SharedRuntimeInternal> {
         let waker = Waker::new(waker_id, coordinator::WAKER.into());
         Arc::new(SharedRuntimeInternal {

--- a/src/rt/scheduler/mod.rs
+++ b/src/rt/scheduler/mod.rs
@@ -20,7 +20,7 @@ mod tests;
 
 pub(super) use local::LocalScheduler;
 // Use in `test` module.
-pub(crate) use shared::{Scheduler, SchedulerRef};
+pub(crate) use shared::Scheduler;
 
 pub use priority::Priority;
 

--- a/src/rt/scheduler/shared/mod.rs
+++ b/src/rt/scheduler/shared/mod.rs
@@ -104,7 +104,7 @@ impl Scheduler {
     /// # Notes
     ///
     /// Calling this with an invalid or outdated `pid` will be silently ignored.
-    pub(in crate::rt) fn mark_ready(&mut self, pid: ProcessId) {
+    pub(in crate::rt) fn mark_ready(&self, pid: ProcessId) {
         trace!("marking process as ready: pid={}", pid);
         if let Some(process) = { self.shared.inactive.lock().unwrap().mark_ready(pid) } {
             // The process was in the `Inactive` list, so we move it to the run

--- a/src/rt/scheduler/tests.rs
+++ b/src/rt/scheduler/tests.rs
@@ -509,7 +509,7 @@ mod shared_scheduler {
 
     #[test]
     fn adding_actor() {
-        let mut scheduler = Scheduler::new();
+        let scheduler = Scheduler::new();
 
         // Shouldn't run any process yet, since none are added.
         assert!(!scheduler.has_process());
@@ -566,7 +566,7 @@ mod shared_scheduler {
 
     #[test]
     fn marking_unknown_pid_as_ready() {
-        let mut scheduler = Scheduler::new();
+        let scheduler = Scheduler::new();
 
         assert!(!scheduler.has_process());
         assert!(!scheduler.has_ready_process());
@@ -626,7 +626,7 @@ mod shared_scheduler {
 
     #[test]
     fn assert_process_unmoved() {
-        let mut scheduler = Scheduler::new();
+        let scheduler = Scheduler::new();
         let mut runtime_ref = test::runtime();
 
         let new_actor = TestAssertUnmovedNewActor(PhantomData);

--- a/src/test.rs
+++ b/src/test.rs
@@ -61,7 +61,6 @@ static SHARED_INTERNAL: SyncLazy<Arc<SharedRuntimeInternal>> = SyncLazy::new(|| 
         .try_clone()
         .expect("failed to clone `Registry` for test module");
     let scheduler = Scheduler::new();
-    let scheduler = scheduler.create_ref();
     let timers = Arc::new(Mutex::new(Timers::new()));
     SharedRuntimeInternal::new(*COORDINATOR_ID, scheduler, registry, timers)
 });

--- a/src/test.rs
+++ b/src/test.rs
@@ -61,7 +61,7 @@ static SHARED_INTERNAL: SyncLazy<Arc<SharedRuntimeInternal>> = SyncLazy::new(|| 
         .try_clone()
         .expect("failed to clone `Registry` for test module");
     let scheduler = Scheduler::new();
-    let timers = Arc::new(Mutex::new(Timers::new()));
+    let timers = Mutex::new(Timers::new());
     SharedRuntimeInternal::new(*COORDINATOR_ID, scheduler, registry, timers)
 });
 


### PR DESCRIPTION
Removes an `Arc` from the shared scheduler and timers.