### PR TITLE
Implement Actor for async functions without result

### DIFF
--- a/examples/1_hello_world.rs
+++ b/examples/1_hello_world.rs
@@ -33,11 +33,10 @@ fn add_greeter_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
 /// Our greeter actor.
 ///
 /// We'll receive a single message and print it.
-async fn greeter_actor(mut ctx: actor::Context<&'static str>) -> Result<(), !> {
+async fn greeter_actor(mut ctx: actor::Context<&'static str>) {
     // All actors have an actor context, which give the actor access to, among
     // other things, its inbox from which it can receive a message.
     while let Ok(name) = ctx.receive_next().await {
         println!("Hello {}", name);
     }
-    Ok(())
 }

--- a/examples/3_rpc.rs
+++ b/examples/3_rpc.rs
@@ -22,20 +22,18 @@ fn add_rpc_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
     Ok(())
 }
 
-async fn ping_actor(_: actor::Context<!>, actor_ref: ActorRef<PongMessage>) -> Result<(), !> {
+async fn ping_actor(_: actor::Context<!>, actor_ref: ActorRef<PongMessage>) {
     // Make a Remote Procedure Call (RPC) and await the response.
     match actor_ref.rpc(Ping).await {
         Ok(response) => println!("Got a RPC response: {}", response),
         Err(err) => eprintln!("RPC request error: {}", err),
     }
-
-    Ok(())
 }
 
 // Message type to support the ping-pong RPC.
 type PongMessage = RpcMessage<Ping, Pong>;
 
-async fn pong_actor(mut ctx: actor::Context<PongMessage>) -> Result<(), !> {
+async fn pong_actor(mut ctx: actor::Context<PongMessage>) {
     // Await a message, same as all other messages.
     while let Ok(msg) = ctx.receive_next().await {
         // Next we respond to the request.
@@ -49,8 +47,6 @@ async fn pong_actor(mut ctx: actor::Context<PongMessage>) -> Result<(), !> {
             eprintln!("failed to respond to RPC: {}", err);
         }
     }
-
-    Ok(())
 }
 
 struct Ping;

--- a/examples/6_process_signals.rs
+++ b/examples/6_process_signals.rs
@@ -79,7 +79,7 @@ fn sync_actor(mut ctx: SyncContext<Message>) {
     println!("shutting down the synchronous actor");
 }
 
-async fn thread_safe_actor(mut ctx: actor::Context<Message, ThreadSafe>) -> Result<(), !> {
+async fn thread_safe_actor(mut ctx: actor::Context<Message, ThreadSafe>) {
     while let Ok(msg) = ctx.receive_next().await {
         match msg {
             Message::Print(msg) => println!("Got a message: {}", msg),
@@ -88,10 +88,9 @@ async fn thread_safe_actor(mut ctx: actor::Context<Message, ThreadSafe>) -> Resu
     }
 
     println!("shutting down the thread local actor");
-    Ok(())
 }
 
-async fn local_actor(mut ctx: actor::Context<Message>) -> Result<(), !> {
+async fn local_actor(mut ctx: actor::Context<Message>) {
     while let Ok(msg) = ctx.receive_next().await {
         match msg {
             Message::Print(msg) => println!("Got a message: {}", msg),
@@ -100,5 +99,4 @@ async fn local_actor(mut ctx: actor::Context<Message>) -> Result<(), !> {
     }
 
     println!("shutting down the thread safe actor");
-    Ok(())
 }

--- a/examples/8_tracing.rs
+++ b/examples/8_tracing.rs
@@ -77,7 +77,7 @@ async fn relay_actor(
 }
 
 /// Sync actor that prints all messages it receives.
-fn print_actor(mut ctx: SyncContext<&'static str>) -> Result<(), !> {
+fn print_actor(mut ctx: SyncContext<&'static str>) {
     loop {
         // Start timing of receiving a message.
         let timing = ctx.start_trace();
@@ -95,5 +95,4 @@ fn print_actor(mut ctx: SyncContext<&'static str>) -> Result<(), !> {
         println!("Received message: {}", msg);
         ctx.finish_trace(timing, "printing message", &[("message", &msg)]);
     }
-    Ok(())
 }

--- a/examples/99_stress_memory.rs
+++ b/examples/99_stress_memory.rs
@@ -39,12 +39,11 @@ fn main() -> Result<(), rt::Error> {
 }
 
 /// Our "actor", but it doesn't do much.
-async fn actor(_: actor::Context<!>) -> Result<(), !> {
-    Ok(())
+async fn actor(_: actor::Context<!>) {
+    /* Nothing. */
 }
 
-async fn control_actor(_: actor::Context<!>) -> Result<(), !> {
+async fn control_actor(_: actor::Context<!>) {
     info!("Running, check the memory usage!");
     info!("Send a signal (e.g. by pressing Ctrl-C) to stop.");
-    Ok(())
 }

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -82,13 +82,12 @@ impl<M, C> Context<M, C> {
     ///
     /// use heph::actor;
     ///
-    /// async fn greeter_actor(mut ctx: actor::Context<String>) -> Result<(), !> {
+    /// async fn greeter_actor(mut ctx: actor::Context<String>) {
     ///     if let Ok(name) = ctx.try_receive_next() {
     ///         println!("Hello: {}", name);
     ///     } else {
     ///         println!("Hello world");
     ///     }
-    ///     Ok(())
     /// }
     ///
     /// # // Use the `greeter_actor` function to silence dead code warning.
@@ -111,11 +110,10 @@ impl<M, C> Context<M, C> {
     ///
     /// use heph::actor;
     ///
-    /// async fn print_actor(mut ctx: actor::Context<String>) -> Result<(), !> {
+    /// async fn print_actor(mut ctx: actor::Context<String>) {
     ///     if let Ok(msg) = ctx.receive_next().await {
     ///         println!("Got a message: {}", msg);
     ///     }
-    ///     Ok(())
     /// }
     ///
     /// # // Use the `print_actor` function to silence dead code warning.
@@ -134,7 +132,7 @@ impl<M, C> Context<M, C> {
     /// use heph::timer::Timer;
     /// use heph::util::either;
     ///
-    /// async fn print_actor(mut ctx: actor::Context<String>) -> Result<(), !> {
+    /// async fn print_actor(mut ctx: actor::Context<String>) {
     ///     // Create a timer, this will be ready once the timeout has
     ///     // passed.
     ///     let timeout = Timer::timeout(&mut ctx, Duration::from_millis(100));
@@ -147,8 +145,6 @@ impl<M, C> Context<M, C> {
     ///         Ok(Err(_)) => println!("No message"),
     ///         Err(_) => println!("Timed out receiving message"),
     ///     }
-    ///
-    ///     Ok(())
     /// }
     ///
     /// # // Use the `print_actor` function to silence dead code warning.

--- a/src/actor_ref/mod.rs
+++ b/src/actor_ref/mod.rs
@@ -46,11 +46,10 @@
 //! }
 //!
 //! /// Our actor.
-//! async fn actor(mut ctx: actor::Context<String>) -> Result<(), !> {
+//! async fn actor(mut ctx: actor::Context<String>) {
 //!     if let Ok(msg) = ctx.receive_next().await {
 //!         println!("got message: {}", msg);
 //!     }
-//!     Ok(())
 //! }
 //! ```
 //!
@@ -88,7 +87,7 @@
 //! }
 //!
 //! /// Our actor.
-//! async fn actor(mut ctx: actor::Context<String>) -> Result<(), !> {
+//! async fn actor(mut ctx: actor::Context<String>) {
 //!     if let Ok(msg) = ctx.receive_next().await {
 //!         println!("First message: {}", msg);
 //!     }
@@ -96,7 +95,6 @@
 //!     if let Ok(msg) = ctx.receive_next().await {
 //!         println!("Second message: {}", msg);
 //!     }
-//!     Ok(())
 //! }
 //! ```
 

--- a/src/actor_ref/rpc.rs
+++ b/src/actor_ref/rpc.rs
@@ -37,7 +37,7 @@
 //! }
 //!
 //! /// Receiving actor of the RPC.
-//! async fn counter(mut ctx: actor::Context<Add>) -> Result<(), !> {
+//! async fn counter(mut ctx: actor::Context<Add>) {
 //!     // State of the counter.
 //!     let mut count: usize = 0;
 //!     // Receive a message like normal.
@@ -46,12 +46,10 @@
 //!         // Send back the current state, ignoring any errors.
 //!         let _ = response.respond(count);
 //!     }
-//!     // And we're done.
-//!     Ok(())
 //! }
 //!
 //! /// Sending actor of the RPC.
-//! async fn requester(_: actor::Context<!>, actor_ref: ActorRef<Add>) -> Result<(), !> {
+//! async fn requester(_: actor::Context<!>, actor_ref: ActorRef<Add>) {
 //!     // Make the procedure call.
 //!     let response = actor_ref.rpc(10).await;
 //! #   assert!(response.is_ok());
@@ -61,7 +59,6 @@
 //!         // Actor failed to respond.
 //!         Err(err) => eprintln!("Counter didn't reply: {}", err),
 //!     }
-//!     Ok(())
 //! }
 //!
 //! # fn main() -> Result<(), rt::Error> {
@@ -133,7 +130,7 @@
 //! }
 //!
 //! /// Sending actor of the RPC.
-//! async fn requester(_: actor::Context<!>, actor_ref: ActorRef<Message>) -> Result<(), !> {
+//! async fn requester(_: actor::Context<!>, actor_ref: ActorRef<Message>) {
 //!     // Increase the counter by ten.
 //!     // NOTE: do handle the errors correctly in practice, this is just an
 //!     // example.
@@ -144,7 +141,6 @@
 //!     let count = actor_ref.rpc(()).await.unwrap();
 //! #   assert_eq!(count, 10);
 //!     println!("Current count {}", count);
-//!     Ok(())
 //! }
 //!
 //! # fn main() -> Result<(), rt::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,12 @@
 //! #
 //! # use heph::actor;
 //! #
-//! async fn actor(mut ctx: actor::Context<String>) -> Result<(), !> {
+//! async fn actor(mut ctx: actor::Context<String>) {
 //!     // Receive a message.
 //!     if let Ok(msg) = ctx.receive_next().await {
 //!         // Print the message.
 //!         println!("got a message: {}", msg);
 //!     }
-//!     // And we're done.
-//!     Ok(())
 //! }
 //! #
 //! # drop(actor); // Silence dead code warnings.

--- a/src/log.rs
+++ b/src/log.rs
@@ -36,11 +36,9 @@
 //!     Ok(())
 //! }
 //!
-//! async fn greeter_actor(_: actor::Context<!>) -> Result<(), !> {
+//! async fn greeter_actor(_: actor::Context<!>) {
 //!     // Log an informational message.
 //!     info!("Hello world");
-//!
-//!     Ok(())
 //! }
 //! ```
 

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -162,7 +162,7 @@ fn sync_worker_id() {
 /// }
 ///
 /// /// Our actor that greets people.
-/// async fn actor(mut ctx: actor::Context<&'static str>, msg: &'static str) -> Result<(), !> {
+/// async fn actor(mut ctx: actor::Context<&'static str>, msg: &'static str) {
 ///     // `msg` is the argument passed to `spawn` in the `setup` function
 ///     // above, in this example it was "Hello".
 ///
@@ -172,7 +172,6 @@ fn sync_worker_id() {
 ///         // This should print "Hello world"!
 ///         println!("{} {}", msg, name);
 ///     }
-///     Ok(())
 /// }
 /// ```
 pub struct Runtime<S = !> {

--- a/src/rt/process/tests.rs
+++ b/src/rt/process/tests.rs
@@ -156,9 +156,8 @@ fn process_data_runtime_increase() {
     assert!(process.fair_runtime >= SLEEP_TIME);
 }
 
-async fn ok_actor(mut ctx: actor::Context<()>) -> Result<(), !> {
+async fn ok_actor(mut ctx: actor::Context<()>) {
     assert_eq!(ctx.receive_next().await, Ok(()));
-    Ok(())
 }
 
 #[test]

--- a/src/rt/scheduler/tests.rs
+++ b/src/rt/scheduler/tests.rs
@@ -50,9 +50,7 @@ fn has_process() {
     assert!(!scheduler.has_ready_process());
 }
 
-async fn simple_actor(_: actor::Context<!>) -> Result<(), !> {
-    Ok(())
-}
+async fn simple_actor(_: actor::Context<!>) {}
 
 #[test]
 fn add_actor() {
@@ -239,13 +237,8 @@ fn scheduler_run_order() {
     // The order in which the processes have been run.
     let run_order = Rc::new(RefCell::new(Vec::new()));
 
-    async fn order_actor(
-        _: actor::Context<!>,
-        id: usize,
-        order: Rc<RefCell<Vec<usize>>>,
-    ) -> Result<(), !> {
+    async fn order_actor(_: actor::Context<!>, id: usize, order: Rc<RefCell<Vec<usize>>>) {
         order.borrow_mut().push(id);
-        Ok(())
     }
 
     // Add our processes.

--- a/src/rt/shared/scheduler/tests.rs
+++ b/src/rt/shared/scheduler/tests.rs
@@ -25,9 +25,7 @@ fn is_send() {
     assert_send::<Scheduler>();
 }
 
-async fn simple_actor(_: actor::Context<!, context::ThreadSafe>) -> Result<(), !> {
-    Ok(())
-}
+async fn simple_actor(_: actor::Context<!, context::ThreadSafe>) {}
 
 #[test]
 fn adding_actor() {
@@ -113,9 +111,8 @@ fn scheduler_run_order() {
         _: actor::Context<!, context::ThreadSafe>,
         id: usize,
         order: Arc<Mutex<Vec<usize>>>,
-    ) -> Result<(), !> {
+    ) {
         order.lock().unwrap().push(id);
-        Ok(())
     }
 
     // Add our processes.

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -234,9 +234,8 @@ where
 /// }
 ///
 /// /// Our actor that never returns an error.
-/// async fn actor(ctx: actor::Context<&'static str>) -> Result<(), !> {
+/// async fn actor(ctx: actor::Context<&'static str>) {
 /// #   drop(ctx); // Silence dead code warnings.
-///     Ok(())
 /// }
 /// ```
 #[derive(Copy, Clone, Debug)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -243,14 +243,12 @@ where
 /// use heph::actor;
 /// use heph::test::size_of_actor_val;
 ///
-/// async fn actor(mut ctx: actor::Context<String>) -> Result<(), !> {
+/// async fn actor(mut ctx: actor::Context<String>) {
 ///     // Receive a message.
 ///     if let Ok(msg) = ctx.receive_next().await {
 ///         // Print the message.
 ///         println!("got a message: {}", msg);
 ///     }
-///     // And we're done.
-///     Ok(())
 /// }
 ///
 /// assert_eq!(size_of_actor_val(&(actor as fn(_) -> _)), 64);
@@ -266,8 +264,8 @@ where
 fn test_size_of_actor() {
     use crate::actor::context::ThreadLocal;
 
-    async fn actor1(_: actor::Context<!>) -> Result<(), !> {
-        Ok(())
+    async fn actor1(_: actor::Context<!>) {
+        /* Nothing. */
     }
 
     #[allow(trivial_casts)]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -64,7 +64,7 @@ impl From<DeadlinePassed> for io::Error {
 /// #   Ok(())
 /// # }
 /// #
-/// async fn actor(mut ctx: actor::Context<!>) -> Result<(), !> {
+/// async fn actor(mut ctx: actor::Context<!>) {
 /// #   let start = Instant::now();
 ///     // Create a timer, this will be ready once the timeout has passed.
 ///     let timeout = Timer::timeout(&mut ctx, Duration::from_millis(200));
@@ -74,7 +74,6 @@ impl From<DeadlinePassed> for io::Error {
 ///     timeout.await;
 /// #   assert!(Instant::now() >= start + Duration::from_millis(200));
 ///     println!("One second has passed!");
-///     Ok(())
 /// }
 /// ```
 #[derive(Debug)]
@@ -200,7 +199,7 @@ impl<K> actor::Bound<K> for Timer {
 /// #     }
 /// # }
 /// #
-/// async fn actor(mut ctx: actor::Context<String, ThreadSafe>) -> Result<(), !> {
+/// async fn actor(mut ctx: actor::Context<String, ThreadSafe>) {
 ///     // `OtherFuture` is a type that implements `Future`.
 ///     let future = IoFuture;
 ///     // Create our deadline.
@@ -214,7 +213,6 @@ impl<K> actor::Bound<K> for Timer {
 ///     // However the other future is rather slow, so the timeout will pass.
 ///     assert!(result.is_err());
 ///     assert_eq!(result.unwrap_err().kind(), io::ErrorKind::TimedOut);
-///     Ok(())
 /// }
 /// ```
 #[derive(Debug)]
@@ -373,7 +371,7 @@ impl<Fut, K> actor::Bound<K> for Deadline<Fut> {
 /// #   Ok(())
 /// # }
 ///
-/// async fn actor(mut ctx: actor::Context<!>) -> Result<(), !> {
+/// async fn actor(mut ctx: actor::Context<!>) {
 /// #   let start = Instant::now();
 ///     let mut interval = Interval::new(&mut ctx, Duration::from_millis(200));
 /// #   assert!(interval.next_deadline() >= start + Duration::from_millis(200));
@@ -384,7 +382,6 @@ impl<Fut, K> actor::Bound<K> for Deadline<Fut> {
 ///         println!("Hello world");
 /// #       break;
 ///     }
-///     Ok(())
 /// }
 /// ```
 #[derive(Debug)]

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -8,6 +8,7 @@ mod util;
 
 #[path = "functional"] // rustfmt can't find the files.
 mod functional {
+    mod actor;
     mod actor_context;
     mod actor_group;
     mod actor_ref;

--- a/tests/functional/actor.rs
+++ b/tests/functional/actor.rs
@@ -1,0 +1,21 @@
+//! Tests for the [`Actor`] trait.
+
+use heph::actor::{self, NewActor};
+
+#[test]
+fn future_output_result() {
+    // Actor is implemented for `Future<Output = Result<(), E>>`.
+    async fn actor(_: actor::Context<()>) -> Result<(), ()> {
+        Ok(())
+    }
+    is_new_actor(actor as fn(_) -> _);
+}
+
+#[test]
+fn future_output_tuple() {
+    // Actor is implemented for `Future<Output = ()>`.
+    async fn actor(_: actor::Context<()>) {}
+    is_new_actor(actor as fn(_) -> _);
+}
+
+fn is_new_actor<NA: NewActor>(_: NA) {}

--- a/tests/functional/actor_context.rs
+++ b/tests/functional/actor_context.rs
@@ -19,7 +19,7 @@ fn thread_safe_is_send_sync() {
     assert_sync::<actor::Context<(), context::ThreadSafe>>();
 }
 
-async fn local_actor_context_actor(mut ctx: actor::Context<usize>) -> Result<(), !> {
+async fn local_actor_context_actor(mut ctx: actor::Context<usize>) {
     assert_eq!(ctx.try_receive_next(), Err(RecvError::Empty));
 
     let msg = ctx.receive_next().await.unwrap();
@@ -27,7 +27,6 @@ async fn local_actor_context_actor(mut ctx: actor::Context<usize>) -> Result<(),
 
     assert_eq!(ctx.receive_next().await, Err(NoMessages));
     assert_eq!(ctx.try_receive_next(), Err(RecvError::Disconnected));
-    Ok(())
 }
 
 #[test]
@@ -48,7 +47,7 @@ fn local_actor_context() {
     assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
 }
 
-async fn actor_ref_actor(mut ctx: actor::Context<usize>) -> Result<(), !> {
+async fn actor_ref_actor(mut ctx: actor::Context<usize>) {
     assert_eq!(ctx.receive_next().await, Err(NoMessages));
 
     // Send a message to ourselves.
@@ -56,8 +55,6 @@ async fn actor_ref_actor(mut ctx: actor::Context<usize>) -> Result<(), !> {
     self_ref.send(123usize).await.unwrap();
     let msg = ctx.receive_next().await.unwrap();
     assert_eq!(msg, 123);
-
-    Ok(())
 }
 
 #[test]
@@ -70,10 +67,9 @@ fn actor_ref() {
     assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
 }
 
-async fn runtime_actor(mut ctx: actor::Context<Signal>) -> Result<(), !> {
+async fn runtime_actor(mut ctx: actor::Context<Signal>) {
     let actor_ref = ctx.actor_ref();
     ctx.runtime().receive_signals(actor_ref);
-    Ok(())
 }
 
 #[test]
@@ -86,7 +82,7 @@ fn runtime() {
     assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
 }
 
-async fn thread_safe_try_spawn_actor(mut ctx: actor::Context<usize, ThreadSafe>) -> Result<(), !> {
+async fn thread_safe_try_spawn_actor(mut ctx: actor::Context<usize, ThreadSafe>) {
     let actor_ref1 = ctx
         .try_spawn(
             NoSupervisor,
@@ -104,14 +100,11 @@ async fn thread_safe_try_spawn_actor(mut ctx: actor::Context<usize, ThreadSafe>)
 
     actor_ref1.send(123usize).await.unwrap();
     actor_ref2.send(123usize).await.unwrap();
-
-    Ok(())
 }
 
-async fn spawned_actor1(mut ctx: actor::Context<usize, ThreadSafe>) -> Result<(), !> {
+async fn spawned_actor1(mut ctx: actor::Context<usize, ThreadSafe>) {
     let msg = ctx.receive_next().await.unwrap();
     assert_eq!(msg, 123);
-    Ok(())
 }
 
 #[test]

--- a/tests/functional/actor_group.rs
+++ b/tests/functional/actor_group.rs
@@ -37,7 +37,7 @@ fn empty() {
     assert!(group.is_empty());
 }
 
-async fn expect_msgs<M>(mut ctx: actor::Context<M>, expected: Vec<M>) -> Result<(), !>
+async fn expect_msgs<M>(mut ctx: actor::Context<M>, expected: Vec<M>)
 where
     M: Eq + fmt::Debug,
 {
@@ -45,7 +45,6 @@ where
         let got = ctx.receive_next().await.expect("missing message");
         assert_eq!(got, expected);
     }
-    Ok(())
 }
 
 #[test]

--- a/tests/functional/actor_ref.rs
+++ b/tests/functional/actor_ref.rs
@@ -43,7 +43,7 @@ fn send_value_future_is_send_sync() {
     assert_sync::<SendValue<()>>();
 }
 
-async fn expect_msgs<M>(mut ctx: actor::Context<M>, expected: Vec<M>) -> Result<(), !>
+async fn expect_msgs<M>(mut ctx: actor::Context<M>, expected: Vec<M>)
 where
     M: Eq + fmt::Debug,
 {
@@ -51,7 +51,6 @@ where
         let got = ctx.receive_next().await.expect("missing message");
         assert_eq!(got, expected);
     }
-    Ok(())
 }
 
 #[test]
@@ -95,14 +94,13 @@ fn try_send_disconnected() {
     assert_eq!(actor_ref.try_send(1usize), Err(SendError));
 }
 
-async fn relay_msgs<M>(_: actor::Context<M>, relay_ref: ActorRef<M>, msgs: Vec<M>) -> Result<(), !>
+async fn relay_msgs<M>(_: actor::Context<M>, relay_ref: ActorRef<M>, msgs: Vec<M>)
 where
     M: Eq + fmt::Debug + Unpin,
 {
     for msg in msgs {
         relay_ref.send(msg).await.unwrap()
     }
-    Ok(())
 }
 
 #[test]
@@ -146,9 +144,8 @@ fn send_full_inbox() {
     assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
 }
 
-async fn relay_error(_: actor::Context<!>, relay_ref: ActorRef<usize>) -> Result<(), !> {
+async fn relay_error(_: actor::Context<!>, relay_ref: ActorRef<usize>) {
     assert_eq!(relay_ref.send(1usize).await, Err(SendError));
-    Ok(())
 }
 
 #[test]
@@ -322,10 +319,9 @@ fn try_mapped_send() {
 
 // Sends zero to a `NonZeroUsize` mapped actor reference causing a conversion
 // error.
-async fn send_error(_: actor::Context<!>, relay_ref: ActorRef<usize>) -> Result<(), !> {
+async fn send_error(_: actor::Context<!>, relay_ref: ActorRef<usize>) {
     let res = relay_ref.send(0usize).await;
     assert_eq!(res, Err(SendError));
-    Ok(())
 }
 
 #[test]
@@ -399,20 +395,18 @@ fn send_error_format() {
     assert_eq!(format!("{}", SendError), "unable to send message");
 }
 
-async fn wake_on_send(_: actor::Context<usize>, relay_ref: ActorRef<usize>) -> Result<(), !> {
+async fn wake_on_send(_: actor::Context<usize>, relay_ref: ActorRef<usize>) {
     relay_ref
         .send(123usize)
         .await
         .expect("failed to send message");
-    Ok(())
 }
 
-async fn wake_on_receive(mut ctx: actor::Context<usize>, expected: Vec<usize>) -> Result<(), !> {
+async fn wake_on_receive(mut ctx: actor::Context<usize>, expected: Vec<usize>) {
     for expected in expected {
         let got = ctx.receive_next().await.expect("missing message");
         assert_eq!(got, expected);
     }
-    Ok(())
 }
 
 #[test]
@@ -456,11 +450,10 @@ struct Ping;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct Pong;
 
-async fn ping(_: actor::Context<!>, relay_ref: ActorRef<RpcTestMessage>) -> Result<(), !> {
+async fn ping(_: actor::Context<!>, relay_ref: ActorRef<RpcTestMessage>) {
     let rpc = relay_ref.rpc(Ping);
     let res = rpc.await;
     assert_eq!(res, Ok(Pong));
-    Ok(())
 }
 
 enum RpcTestMessage {
@@ -474,14 +467,13 @@ impl From<RpcMessage<Ping, Pong>> for RpcTestMessage {
     }
 }
 
-async fn pong(mut ctx: actor::Context<RpcTestMessage>) -> Result<(), !> {
+async fn pong(mut ctx: actor::Context<RpcTestMessage>) {
     while let Ok(msg) = ctx.receive_next().await {
         match msg {
             RpcTestMessage::Ping(msg) => msg.handle(|_| Pong).unwrap(),
             RpcTestMessage::Check => {}
         }
     }
-    Ok(())
 }
 
 #[test]
@@ -511,14 +503,10 @@ fn rpc() {
     );
 }
 
-async fn rpc_send_error_actor(
-    _: actor::Context<!>,
-    relay_ref: ActorRef<RpcTestMessage>,
-) -> Result<(), !> {
+async fn rpc_send_error_actor(_: actor::Context<!>, relay_ref: ActorRef<RpcTestMessage>) {
     let rpc = relay_ref.rpc(Ping);
     let res = rpc.await;
     assert_eq!(res, Err(RpcError::SendError));
-    Ok(())
 }
 
 #[test]
@@ -574,14 +562,10 @@ fn rpc_full_inbox() {
     );
 }
 
-async fn ping_no_response(
-    _: actor::Context<!>,
-    relay_ref: ActorRef<RpcTestMessage>,
-) -> Result<(), !> {
+async fn ping_no_response(_: actor::Context<!>, relay_ref: ActorRef<RpcTestMessage>) {
     let rpc = relay_ref.rpc(Ping);
     let res = rpc.await;
     assert_eq!(res, Err(RpcError::NoResponse));
-    Ok(())
 }
 
 #[test]
@@ -604,7 +588,7 @@ fn rpc_no_response() {
     );
 }
 
-async fn pong_respond_error(mut ctx: actor::Context<RpcTestMessage>) -> Result<(), !> {
+async fn pong_respond_error(mut ctx: actor::Context<RpcTestMessage>) {
     while let Ok(msg) = ctx.receive_next().await {
         match msg {
             RpcTestMessage::Ping(RpcMessage { response, .. }) => {
@@ -613,7 +597,6 @@ async fn pong_respond_error(mut ctx: actor::Context<RpcTestMessage>) -> Result<(
             RpcTestMessage::Check => {}
         }
     }
-    Ok(())
 }
 
 #[test]
@@ -637,7 +620,7 @@ fn rpc_respond_error() {
     );
 }
 
-async fn pong_is_connected(mut ctx: actor::Context<RpcTestMessage>) -> Result<(), !> {
+async fn pong_is_connected(mut ctx: actor::Context<RpcTestMessage>) {
     while let Ok(msg) = ctx.receive_next().await {
         match msg {
             RpcTestMessage::Ping(RpcMessage { response, .. }) => {
@@ -651,7 +634,6 @@ async fn pong_is_connected(mut ctx: actor::Context<RpcTestMessage>) -> Result<()
             RpcTestMessage::Check => {}
         }
     }
-    Ok(())
 }
 
 #[test]
@@ -683,24 +665,19 @@ fn rpc_error_format() {
     assert_eq!(format!("{}", RpcError::NoResponse), "no RPC response");
 }
 
-async fn wake_on_response(
-    _: actor::Context<!>,
-    relay_ref: ActorRef<RpcTestMessage>,
-) -> Result<(), !> {
+async fn wake_on_response(_: actor::Context<!>, relay_ref: ActorRef<RpcTestMessage>) {
     let rpc = relay_ref.rpc(Ping);
     let res = rpc.await;
     assert_eq!(res, Ok(Pong));
-    Ok(())
 }
 
-async fn wake_on_rpc_receive(mut ctx: actor::Context<RpcTestMessage>) -> Result<(), !> {
+async fn wake_on_rpc_receive(mut ctx: actor::Context<RpcTestMessage>) {
     while let Ok(msg) = ctx.receive_next().await {
         match msg {
             RpcTestMessage::Ping(msg) => msg.handle(|_| Pong).unwrap(),
             RpcTestMessage::Check => {}
         }
     }
-    Ok(())
 }
 
 #[test]

--- a/tests/functional/from_message.rs
+++ b/tests/functional/from_message.rs
@@ -53,7 +53,7 @@ fn from_message() {
     );
 }
 
-async fn ping_actor(_: actor::Context<!>, actor_ref: ActorRef<Message>) -> Result<(), !> {
+async fn ping_actor(_: actor::Context<!>, actor_ref: ActorRef<Message>) {
     actor_ref.send("Hello!".to_owned()).await.unwrap();
 
     let response = actor_ref.rpc("Rpc".to_owned()).await.unwrap();
@@ -61,11 +61,9 @@ async fn ping_actor(_: actor::Context<!>, actor_ref: ActorRef<Message>) -> Resul
 
     let response = actor_ref.rpc(("Rpc2".to_owned(), 2)).await.unwrap();
     assert_eq!(response, (1, 2));
-
-    Ok(())
 }
 
-async fn pong_actor(mut ctx: actor::Context<Message>) -> Result<(), !> {
+async fn pong_actor(mut ctx: actor::Context<Message>) {
     let msg = ctx.receive_next().await.unwrap();
     assert!(matches!(msg, Message::Msg(msg) if msg == "Hello!"));
 
@@ -84,5 +82,4 @@ async fn pong_actor(mut ctx: actor::Context<Message>) -> Result<(), !> {
     }
 
     assert_eq!(count, 3);
-    Ok(())
 }

--- a/tests/functional/tcp/listener.rs
+++ b/tests/functional/tcp/listener.rs
@@ -17,7 +17,7 @@ use crate::util::{any_local_address, any_local_ipv6_address, run_actors};
 
 #[test]
 fn local_addr() {
-    async fn actor(mut ctx: actor::Context<!>) -> Result<(), !> {
+    async fn actor(mut ctx: actor::Context<!>) {
         let address = "127.0.0.1:12345".parse().unwrap();
         let mut listener = TcpListener::bind(&mut ctx, address).unwrap();
         assert_eq!(listener.local_addr().unwrap(), address);
@@ -26,8 +26,6 @@ fn local_addr() {
         let address = "[::1]:12345".parse().unwrap();
         let mut listener = TcpListener::bind(&mut ctx, address).unwrap();
         assert_eq!(listener.local_addr().unwrap(), address);
-
-        Ok(())
     }
 
     let actor = actor as fn(_) -> _;
@@ -38,7 +36,7 @@ fn local_addr() {
 
 #[test]
 fn local_addr_port_zero() {
-    async fn actor(mut ctx: actor::Context<!>) -> Result<(), !> {
+    async fn actor(mut ctx: actor::Context<!>) {
         let address = any_local_address();
         let mut listener = TcpListener::bind(&mut ctx, address).unwrap();
         let got = listener.local_addr().unwrap();
@@ -51,8 +49,6 @@ fn local_addr_port_zero() {
         let got = listener.local_addr().unwrap();
         assert_eq!(got.ip(), address.ip());
         assert!(got.port() != 0);
-
-        Ok(())
     }
 
     let actor = actor as fn(_) -> _;
@@ -63,15 +59,13 @@ fn local_addr_port_zero() {
 
 #[test]
 fn ttl() {
-    async fn actor(mut ctx: actor::Context<!>) -> Result<(), !> {
+    async fn actor(mut ctx: actor::Context<!>) {
         let mut listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
 
         let initial = listener.ttl().unwrap();
         let expected = initial + 10;
         listener.set_ttl(expected).unwrap();
         assert_eq!(listener.ttl().unwrap(), expected);
-
-        Ok(())
     }
 
     let actor = actor as fn(_) -> _;
@@ -82,7 +76,7 @@ fn ttl() {
 
 const DATA: &[u8] = b"Hello world";
 
-async fn stream_actor<K>(mut ctx: actor::Context<SocketAddr, K>) -> Result<(), !>
+async fn stream_actor<K>(mut ctx: actor::Context<SocketAddr, K>)
 where
     actor::Context<SocketAddr, K>: rt::Access,
 {
@@ -94,7 +88,6 @@ where
 
     let n = stream.send(DATA).await.unwrap();
     assert_eq!(n, DATA.len());
-    Ok(())
 }
 
 #[test]
@@ -117,10 +110,7 @@ fn try_accept() {
         YieldOnce(false)
     }
 
-    async fn listener_actor(
-        mut ctx: actor::Context<!>,
-        actor_ref: ActorRef<SocketAddr>,
-    ) -> Result<(), !> {
+    async fn listener_actor(mut ctx: actor::Context<!>, actor_ref: ActorRef<SocketAddr>) {
         let mut listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
 
         let address = listener.local_addr().unwrap();
@@ -143,8 +133,6 @@ fn try_accept() {
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, DATA.len());
         assert_eq!(buf, DATA);
-
-        Ok(())
     }
 
     let stream_actor = stream_actor as fn(_) -> _;
@@ -160,10 +148,7 @@ fn try_accept() {
 
 #[test]
 fn accept() {
-    async fn listener_actor(
-        mut ctx: actor::Context<!>,
-        actor_ref: ActorRef<SocketAddr>,
-    ) -> Result<(), !> {
+    async fn listener_actor(mut ctx: actor::Context<!>, actor_ref: ActorRef<SocketAddr>) {
         let mut listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
 
         let address = listener.local_addr().unwrap();
@@ -177,8 +162,6 @@ fn accept() {
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, DATA.len());
         assert_eq!(buf, DATA);
-
-        Ok(())
     }
 
     let stream_actor = stream_actor as fn(_) -> _;
@@ -194,10 +177,7 @@ fn accept() {
 
 #[test]
 fn incoming() {
-    async fn listener_actor(
-        mut ctx: actor::Context<!>,
-        actor_ref: ActorRef<SocketAddr>,
-    ) -> Result<(), !> {
+    async fn listener_actor(mut ctx: actor::Context<!>, actor_ref: ActorRef<SocketAddr>) {
         let mut listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
 
         let address = listener.local_addr().unwrap();
@@ -212,8 +192,6 @@ fn incoming() {
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, DATA.len());
         assert_eq!(buf, DATA);
-
-        Ok(())
     }
 
     let stream_actor = stream_actor as fn(_) -> _;
@@ -229,23 +207,18 @@ fn incoming() {
 
 #[test]
 fn actor_bound() {
-    async fn listener_actor1<K>(
-        mut ctx: actor::Context<!, K>,
-        actor_ref: ActorRef<TcpListener>,
-    ) -> Result<(), !>
+    async fn listener_actor1<K>(mut ctx: actor::Context<!, K>, actor_ref: ActorRef<TcpListener>)
     where
         actor::Context<!, K>: rt::Access,
     {
         let listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
         actor_ref.send(listener).await.unwrap();
-        Ok(())
     }
 
     async fn listener_actor2<K>(
         mut ctx: actor::Context<TcpListener, K>,
         actor_ref: ActorRef<SocketAddr>,
-    ) -> Result<(), !>
-    where
+    ) where
         actor::Context<TcpListener, K>: rt::Access,
     {
         let mut listener = ctx.receive_next().await.unwrap();
@@ -265,7 +238,6 @@ fn actor_bound() {
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, DATA.len());
         assert_eq!(buf, DATA);
-        Ok(())
     }
 
     fn setup(mut runtime_ref: RuntimeRef) -> Result<(), !> {

--- a/tests/functional/tcp/server.rs
+++ b/tests/functional/tcp/server.rs
@@ -55,7 +55,7 @@ where
     }
 }
 
-async fn actor<K>(_: actor::Context<!, K>, mut stream: TcpStream, _: SocketAddr) -> Result<(), !>
+async fn actor<K>(_: actor::Context<!, K>, mut stream: TcpStream, _: SocketAddr)
 where
     actor::Context<SocketAddr, K>: rt::Access,
 {
@@ -63,7 +63,6 @@ where
     let n = stream.recv(&mut buf).await.unwrap();
     assert_eq!(n, DATA.len());
     assert_eq!(buf, DATA);
-    Ok(())
 }
 
 const DATA: &[u8] = b"Hello world";
@@ -72,8 +71,7 @@ async fn stream_actor<K>(
     mut ctx: actor::Context<!, K>,
     address: SocketAddr,
     actor_ref: ActorRef<server::Message>,
-) -> Result<(), !>
-where
+) where
     actor::Context<!, K>: rt::Access,
 {
     let mut stream = TcpStream::connect(&mut ctx, address)
@@ -86,8 +84,6 @@ where
 
     // Send a message to stop the listener.
     actor_ref.send(Terminate).await.unwrap();
-
-    Ok(())
 }
 
 #[test]
@@ -258,7 +254,7 @@ fn new_actor_error() {
     let (server_actor, _) = init_local_actor(server, ()).unwrap();
     let server_actor: Box<dyn Actor<Error = !>> = Box::new(ServerWrapper(server_actor));
 
-    async fn stream_actor<K>(mut ctx: actor::Context<!, K>, address: SocketAddr) -> Result<(), !>
+    async fn stream_actor<K>(mut ctx: actor::Context<!, K>, address: SocketAddr)
     where
         actor::Context<!, K>: rt::Access,
     {
@@ -269,8 +265,6 @@ fn new_actor_error() {
 
         // Just need to create the connection.
         drop(stream);
-
-        Ok(())
     }
 
     let stream_actor = stream_actor as fn(_, _) -> _;

--- a/tests/functional/tcp/stream.rs
+++ b/tests/functional/tcp/stream.rs
@@ -1049,10 +1049,7 @@ fn peek_vectored() {
 
 #[test]
 fn shutdown_read() {
-    async fn listener_actor(
-        mut ctx: actor::Context<!>,
-        actor_ref: ActorRef<SocketAddr>,
-    ) -> Result<(), !> {
+    async fn listener_actor(mut ctx: actor::Context<!>, actor_ref: ActorRef<SocketAddr>) {
         let mut listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
 
         let address = listener.local_addr().unwrap();
@@ -1068,11 +1065,9 @@ fn shutdown_read() {
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, DATA.len());
         assert_eq!(buf, DATA);
-
-        Ok(())
     }
 
-    async fn stream_actor(mut ctx: actor::Context<SocketAddr>) -> Result<(), !> {
+    async fn stream_actor(mut ctx: actor::Context<SocketAddr>) {
         let address = ctx.receive_next().await.unwrap();
         let mut stream = TcpStream::connect(&mut ctx, address)
             .unwrap()
@@ -1086,8 +1081,6 @@ fn shutdown_read() {
         assert_eq!(n, 0);
 
         stream.send_all(DATA).await.unwrap();
-
-        Ok(())
     }
 
     let stream_actor = stream_actor as fn(_) -> _;
@@ -1103,10 +1096,7 @@ fn shutdown_read() {
 
 #[test]
 fn shutdown_write() {
-    async fn listener_actor(
-        mut ctx: actor::Context<!>,
-        actor_ref: ActorRef<SocketAddr>,
-    ) -> Result<(), !> {
+    async fn listener_actor(mut ctx: actor::Context<!>, actor_ref: ActorRef<SocketAddr>) {
         let mut listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
 
         let address = listener.local_addr().unwrap();
@@ -1122,10 +1112,9 @@ fn shutdown_write() {
         assert_eq!(n, 0);
 
         stream.send_all(DATA).await.unwrap();
-        Ok(())
     }
 
-    async fn stream_actor(mut ctx: actor::Context<SocketAddr>) -> Result<(), !> {
+    async fn stream_actor(mut ctx: actor::Context<SocketAddr>) {
         let address = ctx.receive_next().await.unwrap();
         let mut stream = TcpStream::connect(&mut ctx, address)
             .unwrap()
@@ -1141,8 +1130,6 @@ fn shutdown_write() {
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, DATA.len());
         assert_eq!(buf, DATA);
-
-        Ok(())
     }
 
     let stream_actor = stream_actor as fn(_) -> _;
@@ -1158,10 +1145,7 @@ fn shutdown_write() {
 
 #[test]
 fn shutdown_both() {
-    async fn listener_actor(
-        mut ctx: actor::Context<!>,
-        actor_ref: ActorRef<SocketAddr>,
-    ) -> Result<(), !> {
+    async fn listener_actor(mut ctx: actor::Context<!>, actor_ref: ActorRef<SocketAddr>) {
         let mut listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
 
         let address = listener.local_addr().unwrap();
@@ -1174,11 +1158,9 @@ fn shutdown_both() {
         let mut buf = Vec::with_capacity(2);
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, 0);
-
-        Ok(())
     }
 
-    async fn stream_actor(mut ctx: actor::Context<SocketAddr>) -> Result<(), !> {
+    async fn stream_actor(mut ctx: actor::Context<SocketAddr>) {
         let address = ctx.receive_next().await.unwrap();
         let mut stream = TcpStream::connect(&mut ctx, address)
             .unwrap()
@@ -1193,8 +1175,6 @@ fn shutdown_both() {
         let mut buf = Vec::with_capacity(2);
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, 0);
-
-        Ok(())
     }
 
     let stream_actor = stream_actor as fn(_) -> _;

--- a/tests/message_loss.rs
+++ b/tests/message_loss.rs
@@ -14,13 +14,13 @@ use std::task::Poll;
 use heph::actor::{self, NoMessages};
 use heph::test::{init_local_actor, poll_actor, set_message_loss};
 
-async fn expect_1_messages(mut ctx: actor::Context<usize>) -> Result<(), !> {
+async fn expect_1_messages(mut ctx: actor::Context<usize>) {
     let msg = ctx.receive_next().await.expect("missing first message");
     assert_eq!(msg, 123);
 
     match ctx.receive_next().await {
         Ok(msg) => panic!("unexpected message: {:?}", msg),
-        Err(NoMessages) => Ok(()),
+        Err(NoMessages) => return,
     }
 }
 


### PR DESCRIPTION
This allows us to drop `Result<(), !>` as return type from many simple
actors.

Updates #164 (already closed).