### PR TITLE
Move scheduling based on shared timers to workers

### DIFF
--- a/src/rt/timers.rs
+++ b/src/rt/timers.rs
@@ -49,6 +49,17 @@ impl Timers {
             now: Instant::now(),
         }
     }
+
+    /// Remove the next deadline that passed `now` returning the pid.
+    pub(super) fn remove_deadline(&mut self, now: Instant) -> Option<ProcessId> {
+        match self.deadlines.peek() {
+            Some(deadline) if deadline.0.deadline <= now => {
+                let deadline = self.deadlines.pop().unwrap().0;
+                Some(deadline.pid)
+            }
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -61,13 +72,7 @@ impl<'t> Iterator for Deadlines<'t> {
     type Item = ProcessId;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.timers.deadlines.peek() {
-            Some(deadline) if deadline.0.deadline <= self.now => {
-                let deadline = self.timers.deadlines.pop().unwrap().0;
-                Some(deadline.pid)
-            }
-            _ => None,
-        }
+        self.timers.remove_deadline(self.now)
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -62,14 +62,12 @@ static SHARED_INTERNAL: SyncLazy<Arc<shared::RuntimeInternals>> = SyncLazy::new(
         .registry()
         .try_clone()
         .expect("failed to clone `Registry` for test module");
-    let waker = mio::Waker::new(&registry, mio::Token(0))
-        .expect("failed to create `mio::Waker` for test module");
     let scheduler = Scheduler::new();
     let timers = Mutex::new(Timers::new());
     Arc::new_cyclic(|shared_internals| {
         let waker_id = waker::init(shared_internals.clone());
         let worker_wakers = vec![&*NOOP_WAKER].into_boxed_slice();
-        shared::RuntimeInternals::new(waker_id, waker, worker_wakers, scheduler, registry, timers)
+        shared::RuntimeInternals::new(waker_id, worker_wakers, scheduler, registry, timers)
     })
 });
 


### PR DESCRIPTION
Instead of letting the coordinator schedule thread-safe actors based on
the shared timers this commit changes the workers to schedule the
thread-safe actors.

This does introduce the "Thundering herd problem" for the shared timers
if multiple worker threads have the same timeout (based on the shared
timers) and all attempt to schedule the same thread-safe actor because
of it.