### PR TITLE
Make the output argument of convert_trace optional

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -67,10 +67,10 @@ Trace Event Format] so it can be opened by [Catapult trace view].
  $ cargo run --example 8_tracing       # Run the example, to generate the trace.
  $ cd tools                            # Got into the tools directory.
                                        # Convert the trace to Chrome's format.
- $ cargo run --bin convert_trace ../heph_tracing_example.bin.log heph_tracing_example.json
+ $ cargo run --bin convert_trace ../heph_tracing_example.bin.log
                                        # Make the trace viewable in HTML.
- $ $(CAPAPULT_REPO)/tracing/bin/trace2html heph_tracing_example.json
- $ open heph_tracing_example.html      # Finally open the trace in your browser.
+ $ $(CATAPULT_REPO)/tracing/bin/trace2html ../heph_tracing_example.json
+ $ open ../heph_tracing_example.html   # Finally open the trace in your browser.
 ```
 
 [Trace Format design document]: ../doc/Trace%20Format.md

--- a/tools/src/bin/convert_trace.rs
+++ b/tools/src/bin/convert_trace.rs
@@ -8,14 +8,25 @@ use std::convert::TryInto;
 use std::env::args;
 use std::fs::{File, OpenOptions};
 use std::io::{self, stdin, Read, Stdin, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use std::{fmt, str};
 
 fn main() {
     let mut args = args().skip(1);
     let input = args.next().expect("missing input trace file path");
-    let output = args.next().expect("missing ouput path");
+    let output = match args.next() {
+        Some(output) => PathBuf::from(output),
+        None => {
+            let end_idx = input.rfind('.').unwrap_or(input.len());
+            let mut output = PathBuf::from(&input[..end_idx]);
+            // If the input has a single extension this will add `json` to it.
+            // If however it has two extensions, e.g. `.bin.log` this will
+            // overwrite the extension.
+            output.set_extension("json");
+            output
+        }
+    };
 
     let mut trace = Trace::open(input).expect("can't open trace file");
     let mut output = OpenOptions::new()


### PR DESCRIPTION
If the output argument is not provided it will use the input path with
the extension replaced with ".json".