### PR TITLE
Rename timer methods

### DIFF
--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -134,7 +134,7 @@ impl<M, C> Context<M, C> {
     /// async fn print_actor(mut ctx: actor::Context<String>) {
     ///     // Create a timer, this will be ready once the timeout has
     ///     // passed.
-    ///     let timeout = Timer::timeout(&mut ctx, Duration::from_millis(100));
+    ///     let timeout = Timer::after(&mut ctx, Duration::from_millis(100));
     ///     // Create a future to receive a message.
     ///     let msg_future = ctx.receive_next();
     ///

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -373,7 +373,7 @@ impl<Fut, K> actor::Bound<K> for Deadline<Fut> {
 ///
 /// async fn actor(mut ctx: actor::Context<!>) {
 /// #   let start = Instant::now();
-///     let mut interval = Interval::new(&mut ctx, Duration::from_millis(200));
+///     let mut interval = Interval::every(&mut ctx, Duration::from_millis(200));
 /// #   assert!(interval.next_deadline() >= start + Duration::from_millis(200));
 ///     loop {
 ///         // Wait until the next timer expires.
@@ -395,7 +395,7 @@ pub struct Interval {
 
 impl Interval {
     /// Create a new `Interval`.
-    pub fn new<M>(ctx: &mut actor::Context<M>, interval: Duration) -> Interval {
+    pub fn every<M>(ctx: &mut actor::Context<M>, interval: Duration) -> Interval {
         let deadline = Instant::now() + interval;
         let mut runtime_ref = ctx.runtime().clone();
         let pid = ctx.pid();

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -68,7 +68,7 @@ impl From<DeadlinePassed> for io::Error {
 /// async fn actor(mut ctx: actor::Context<!>) {
 /// #   let start = Instant::now();
 ///     // Create a timer, this will be ready once the timeout has passed.
-///     let timeout = Timer::timeout(&mut ctx, Duration::from_millis(200));
+///     let timeout = Timer::after(&mut ctx, Duration::from_millis(200));
 /// #   assert!(timeout.deadline() >= start + Duration::from_millis(200));
 ///
 ///     // Wait for the timer to pass.
@@ -85,7 +85,7 @@ pub struct Timer {
 
 impl Timer {
     /// Create a new `Timer`.
-    pub fn new<M, K>(ctx: &mut actor::Context<M, K>, deadline: Instant) -> Timer
+    pub fn at<M, K>(ctx: &mut actor::Context<M, K>, deadline: Instant) -> Timer
     where
         actor::Context<M, K>: rt::Access,
     {
@@ -96,12 +96,12 @@ impl Timer {
 
     /// Create a new timer, based on a timeout.
     ///
-    /// Same as calling `Timer::new(&mut ctx, Instant::now() + timeout)`.
-    pub fn timeout<M, K>(ctx: &mut actor::Context<M, K>, timeout: Duration) -> Timer
+    /// Same as calling `Timer::at(&mut ctx, Instant::now() + timeout)`.
+    pub fn after<M, K>(ctx: &mut actor::Context<M, K>, timeout: Duration) -> Timer
     where
         actor::Context<M, K>: rt::Access,
     {
-        Timer::new(ctx, Instant::now() + timeout)
+        Timer::at(ctx, Instant::now() + timeout)
     }
 
     /// Returns the deadline set for this `Timer`.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -205,7 +205,7 @@ impl<K> actor::Bound<K> for Timer {
 ///     let future = IoFuture;
 ///     // Create our deadline.
 /// #   let start = Instant::now();
-///     let deadline_future = Deadline::timeout(&mut ctx, Duration::from_millis(100), future);
+///     let deadline_future = Deadline::after(&mut ctx, Duration::from_millis(100), future);
 /// #   assert!(deadline_future.deadline() >= start + Duration::from_millis(100));
 ///
 ///     // Now we await the results.
@@ -225,11 +225,7 @@ pub struct Deadline<Fut> {
 
 impl<Fut> Deadline<Fut> {
     /// Create a new `Deadline`.
-    pub fn new<M, K>(
-        ctx: &mut actor::Context<M, K>,
-        deadline: Instant,
-        future: Fut,
-    ) -> Deadline<Fut>
+    pub fn at<M, K>(ctx: &mut actor::Context<M, K>, deadline: Instant, future: Fut) -> Deadline<Fut>
     where
         actor::Context<M, K>: rt::Access,
     {
@@ -240,9 +236,9 @@ impl<Fut> Deadline<Fut> {
 
     /// Create a new deadline based on a timeout.
     ///
-    /// Same as calling `Deadline::new(&mut ctx, Instant::now() + timeout,
+    /// Same as calling `Deadline::at(&mut ctx, Instant::now() + timeout,
     /// future)`.
-    pub fn timeout<M, K>(
+    pub fn after<M, K>(
         ctx: &mut actor::Context<M, K>,
         timeout: Duration,
         future: Fut,
@@ -250,7 +246,7 @@ impl<Fut> Deadline<Fut> {
     where
         actor::Context<M, K>: rt::Access,
     {
-        Deadline::new(ctx, Instant::now() + timeout, future)
+        Deadline::at(ctx, Instant::now() + timeout, future)
     }
 
     /// Returns the deadline set for this `Deadline`.

--- a/tests/functional/timer.rs
+++ b/tests/functional/timer.rs
@@ -112,7 +112,7 @@ fn deadline() {
 fn interval() {
     async fn actor(mut ctx: actor::Context<!>) {
         let start = Instant::now();
-        let mut interval = Interval::new(&mut ctx, TIMEOUT);
+        let mut interval = Interval::every(&mut ctx, TIMEOUT);
         assert!(interval.next_deadline() >= start + TIMEOUT);
         let _ = next(&mut interval).await;
     }
@@ -147,7 +147,7 @@ fn triggered_timers_run_actors() {
     }
 
     async fn interval_actor(mut ctx: actor::Context<!>) {
-        let mut interval = Interval::new(&mut ctx, TIMEOUT);
+        let mut interval = Interval::every(&mut ctx, TIMEOUT);
         let _ = next(&mut interval).await;
     }
 
@@ -235,7 +235,7 @@ fn timers_actor_bound() {
     }
 
     async fn interval_actor1(mut ctx: actor::Context<!>, actor_ref: ActorRef<Interval>) {
-        let interval = Interval::new(&mut ctx, TIMEOUT);
+        let interval = Interval::every(&mut ctx, TIMEOUT);
         actor_ref.send(interval).await.unwrap();
     }
 

--- a/tests/functional/timer.rs
+++ b/tests/functional/timer.rs
@@ -84,7 +84,7 @@ fn deadline() {
     async fn actor(mut ctx: actor::Context<!>) {
         let start = Instant::now();
         let future = Pending(123);
-        let mut deadline = Deadline::timeout(&mut ctx, TIMEOUT, future.clone());
+        let mut deadline = Deadline::after(&mut ctx, TIMEOUT, future.clone());
         assert!(deadline.deadline() >= start + TIMEOUT);
         assert!(!deadline.has_passed());
         assert_eq!(*deadline.get_ref(), future);
@@ -141,7 +141,7 @@ fn triggered_timers_run_actors() {
         actor::Context<!, K>: rt::Access,
     {
         let future = Pending(123);
-        let deadline = Deadline::timeout(&mut ctx, TIMEOUT, future);
+        let deadline = Deadline::after(&mut ctx, TIMEOUT, future);
         let res: Result<(), DeadlinePassed> = deadline.await;
         assert_eq!(res, Err(DeadlinePassed));
     }
@@ -220,7 +220,7 @@ fn timers_actor_bound() {
         actor::Context<!, K>: rt::Access,
     {
         let future = Pending(123);
-        let deadline = Deadline::timeout(&mut ctx, TIMEOUT, future);
+        let deadline = Deadline::after(&mut ctx, TIMEOUT, future);
         actor_ref.send(deadline).await.unwrap();
     }
 

--- a/tests/functional/timer.rs
+++ b/tests/functional/timer.rs
@@ -26,7 +26,7 @@ fn deadline_passed_into_io_error() {
 fn timer() {
     async fn actor(mut ctx: actor::Context<!>) {
         let start = Instant::now();
-        let mut timer = Timer::timeout(&mut ctx, TIMEOUT);
+        let mut timer = Timer::after(&mut ctx, TIMEOUT);
         assert!(timer.deadline() >= start + TIMEOUT);
         assert!(!timer.has_passed());
 
@@ -60,7 +60,7 @@ fn timer_wrap() {
     async fn actor(mut ctx: actor::Context<!>) {
         let start = Instant::now();
         let future = Pending(123);
-        let mut deadline = Timer::timeout(&mut ctx, TIMEOUT).wrap(future);
+        let mut deadline = Timer::after(&mut ctx, TIMEOUT).wrap(future);
         assert!(deadline.deadline() >= start + TIMEOUT);
         assert!(!deadline.has_passed());
 
@@ -132,7 +132,7 @@ fn triggered_timers_run_actors() {
     where
         actor::Context<!, K>: rt::Access,
     {
-        let timer = Timer::timeout(&mut ctx, TIMEOUT);
+        let timer = Timer::after(&mut ctx, TIMEOUT);
         let _ = timer.await;
     }
 
@@ -200,7 +200,7 @@ fn timers_actor_bound() {
     where
         actor::Context<!, K>: rt::Access,
     {
-        let timer = Timer::timeout(&mut ctx, TIMEOUT);
+        let timer = Timer::after(&mut ctx, TIMEOUT);
         actor_ref.send(timer).await.unwrap();
     }
 


### PR DESCRIPTION
 Renames the following methods:

* `Timer::new` to `Timer::at`.
* `Timer::timeout` to `Timer::after`.
* `Deadline::new` to `Deadline::at`.
* `Deadline::timeout` to `Deadline::after`.
* `Interval::new` to `Interval::every`.