### PR TITLE
Don't export log macros in log module

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -2,9 +2,7 @@
 //!
 //! Logging in Heph is done via the [`log`] crate, much like the entire Rust
 //! ecosystem does (or should). However the log crate doesn't provide an actual
-//! logging implementation, it only defines macros for it. Those macros are
-//! re-exported here, which means that the macros in the `log` crate can also be
-//! used.
+//! logging implementation, it only defines macros for logging.
 //!
 //! Heph doesn't provide a logging implementation, but it recommends the
 //! [`std-logger`] crate.
@@ -44,5 +42,12 @@
 //! }
 //! ```
 
-#[doc(no_inline)]
-pub use log::{debug, error, info, log, log_enabled, trace, warn};
+#[doc(hidden)]
+pub mod _private {
+    //! Private module to support the [`restart_supervisor!`] macro.
+    //!
+    //! [`restart_supervisor!`]: crate::restart_supervisor
+
+    #[doc(no_inline)]
+    pub use log::warn;
+}

--- a/src/rt/process/mod.rs
+++ b/src/rt/process/mod.rs
@@ -21,12 +21,11 @@ pub(crate) use actor::ActorProcess;
 /// Process id, or pid for short, is an identifier for a process in an
 /// [`Runtime`].
 ///
-/// This can only be created by one of the [schedulers] and should be seen as an
+/// This can only be created by one of the schedulers and should be seen as an
 /// opaque type for the rest of the crate. For convince this can converted from
 /// and into an [`Token`] as used by Mio.
 ///
 /// [`Runtime`]: crate::Runtime
-/// [schedulers]: crate::rt::scheduler
 // NOTE: public because it used in the `RuntimeAccess` trait.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 #[repr(transparent)]

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -457,13 +457,13 @@ macro_rules! __heph_restart_supervisor_impl {
 
                 if self.restarts_left >= 1 {
                     self.restarts_left -= 1;
-                    $crate::log::warn!(
+                    $crate::log::_private::warn!(
                         std::concat!($actor_name, " actor failed to restart, trying again ({}/{} restarts left): {}", $log_extra),
                         self.restarts_left, $max_restarts, err, $( self.args $(. $log_arg_field )* ),*
                     );
                     $crate::SupervisorStrategy::Restart(self.args.clone())
                 } else {
-                    $crate::log::warn!(
+                    $crate::log::_private::warn!(
                         std::concat!($actor_name, " actor failed to restart, stopping it (no restarts left): {}", $log_extra),
                         err, $( self.args $(. $log_arg_field )* ),*
                     );
@@ -472,7 +472,7 @@ macro_rules! __heph_restart_supervisor_impl {
             }
 
             fn second_restart_error(&mut self, err: NA::Error) {
-                $crate::log::warn!(
+                $crate::log::_private::warn!(
                     std::concat!($actor_name, " actor failed to restart a second time, stopping it: {}", $log_extra),
                     err, $( self.args $(. $log_arg_field )* ),*
                 );
@@ -515,13 +515,13 @@ macro_rules! __heph_restart_supervisor_impl {
 
         if $self.restarts_left >= 1 {
             $self.restarts_left -= 1;
-            $crate::log::warn!(
+            $crate::log::_private::warn!(
                 std::concat!($actor_name, " failed, restarting it ({}/{} restarts left): {}", $log_extra),
                 $self.restarts_left, $max_restarts, $err, $( $self.args $(. $log_arg_field )* ),*
             );
             $crate::SupervisorStrategy::Restart($self.args.clone())
         } else {
-            $crate::log::warn!(
+            $crate::log::_private::warn!(
                 std::concat!($actor_name, " failed, stopping it (no restarts left): {}", $log_extra),
                 $err, $( $self.args $(. $log_arg_field )* ),*
             );


### PR DESCRIPTION
Now the module only serves as documentation.

This means we'll no longer be tied to a fixed version of the log crate.

Closes  #390.
