### PR TITLE
Move ThreadLocal and ThreadSafe into the actor module

### DIFF
--- a/examples/2_my_ip.rs
+++ b/examples/2_my_ip.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::net::SocketAddr;
 
-use heph::actor::{self, NewActor, ThreadLocal};
+use heph::actor::{self, Actor, NewActor};
 use heph::net::{tcp, TcpServer, TcpStream};
 use heph::rt::options::Priority;
 use heph::supervisor::{Supervisor, SupervisorStrategy};
@@ -54,13 +54,10 @@ fn main() -> Result<(), rt::Error> {
 #[derive(Copy, Clone, Debug)]
 struct ServerSupervisor;
 
-impl<S, NA> Supervisor<tcp::server::Setup<S, NA>> for ServerSupervisor
+impl<NA> Supervisor<NA> for ServerSupervisor
 where
-    // Trait bounds needed by `tcp::server::Setup`.
-    S: Supervisor<NA> + Clone + 'static,
-    NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, Context = ThreadLocal>
-        + Clone
-        + 'static,
+    NA: NewActor<Argument = (), Error = io::Error>,
+    NA::Actor: Actor<Error = tcp::server::Error<!>>,
 {
     fn decide(&mut self, err: tcp::server::Error<!>) -> SupervisorStrategy<()> {
         use tcp::server::Error::*;

--- a/examples/2_my_ip.rs
+++ b/examples/2_my_ip.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::net::SocketAddr;
 
-use heph::actor::{self, context, NewActor};
+use heph::actor::{self, NewActor, ThreadLocal};
 use heph::net::{tcp, TcpServer, TcpStream};
 use heph::rt::options::Priority;
 use heph::supervisor::{Supervisor, SupervisorStrategy};
@@ -58,7 +58,7 @@ impl<S, NA> Supervisor<tcp::server::Setup<S, NA>> for ServerSupervisor
 where
     // Trait bounds needed by `tcp::server::Setup`.
     S: Supervisor<NA> + Clone + 'static,
-    NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, Context = context::ThreadLocal>
+    NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, Context = ThreadLocal>
         + Clone
         + 'static,
 {

--- a/examples/6_process_signals.rs
+++ b/examples/6_process_signals.rs
@@ -2,8 +2,7 @@
 
 use std::convert::TryFrom;
 
-use heph::actor::context::ThreadSafe;
-use heph::actor::{self, SyncContext};
+use heph::actor::{self, SyncContext, ThreadSafe};
 use heph::rt::{self, ActorOptions, Runtime, RuntimeRef, Signal, SyncActorOptions};
 use heph::supervisor::NoSupervisor;
 

--- a/src/actor/tests.rs
+++ b/src/actor/tests.rs
@@ -21,11 +21,11 @@ fn actor_name() {
         ),
         // Generic parameter(s) wrapped in GenFuture.
         (
-            "core::future::from_generator::GenFuture<functional::functional::timer::triggered_timers_run_actors::deadline_actor<heph::actor::context_priv::ThreadLocal>::{{closure}}>",
+            "core::future::from_generator::GenFuture<functional::functional::timer::triggered_timers_run_actors::deadline_actor<heph::actor::context::ThreadLocal>::{{closure}}>",
             "deadline_actor",
         ),
         (
-            "core::future::from_generator::GenFuture<functional::functional::timer::triggered_timers_run_actors::timer_actor<heph::actor::context_priv::ThreadSafe>::{{closure}}>",
+            "core::future::from_generator::GenFuture<functional::functional::timer::triggered_timers_run_actors::timer_actor<heph::actor::context::ThreadSafe>::{{closure}}>",
             "timer_actor"
         ),
         (
@@ -55,7 +55,7 @@ fn actor_name() {
         ),
         // Type implementing `Actor`.
         (
-            "heph::net::tcp::server::TcpServer<2_my_ip::conn_supervisor, fn(heph::actor::context_priv::Context<!>, heph::net::tcp::stream::TcpStream, std::net::addr::SocketAddr) -> core::future::from_generator::GenFuture<2_my_ip::conn_actor::{{closure}}>, heph::actor::context_priv::ThreadLocal>",
+            "heph::net::tcp::server::TcpServer<2_my_ip::conn_supervisor, fn(heph::actor::context::Context<!>, heph::net::tcp::stream::TcpStream, std::net::addr::SocketAddr) -> core::future::from_generator::GenFuture<2_my_ip::conn_actor::{{closure}}>, heph::actor::context::ThreadLocal>",
             "TcpServer",
         ),
         // If the module path is removed from `std::any::type_name`.
@@ -68,7 +68,7 @@ fn actor_name() {
             "greeter::actor",
         ),
         (
-            "TcpServer<2_my_ip::conn_supervisor, fn(heph::actor::context_priv::Context<!>, heph::net::tcp::stream::TcpStream, std::net::addr::SocketAddr) -> core::future::from_generator::GenFuture<2_my_ip::conn_actor::{{closure}}>, heph::actor::context_priv::ThreadLocal>",
+            "TcpServer<2_my_ip::conn_supervisor, fn(heph::actor::context::Context<!>, heph::net::tcp::stream::TcpStream, std::net::addr::SocketAddr) -> core::future::from_generator::GenFuture<2_my_ip::conn_actor::{{closure}}>, heph::actor::context::ThreadLocal>",
             "TcpServer",
         ),
         (

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -153,12 +153,12 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// use std::io;
 /// use std::net::SocketAddr;
 ///
-/// use heph::actor::{self, context, NewActor};
+/// # use heph::actor::ThreadLocal;
 /// # use heph::actor::messages::Terminate;
 /// use heph::net::tcp::{server, TcpServer, TcpStream};
-/// use heph::supervisor::{Supervisor, SupervisorStrategy};
 /// use heph::rt::options::Priority;
-/// use heph::{rt, ActorOptions, Runtime, RuntimeRef};
+/// use heph::supervisor::{Supervisor, SupervisorStrategy};
+/// use heph::{rt, actor, NewActor, ActorOptions, Runtime, RuntimeRef};
 /// use log::error;
 ///
 /// fn main() -> Result<(), rt::Error> {
@@ -197,7 +197,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// where
 ///     // Trait bounds needed by `server::Setup`.
 ///     S: Supervisor<NA> + Clone + 'static,
-///     NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, Context = context::ThreadLocal> + Clone + 'static,
+///     NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, Context = ThreadLocal> + Clone + 'static,
 /// {
 ///     fn decide(&mut self, err: server::Error<!>) -> SupervisorStrategy<()> {
 ///         use server::Error::*;
@@ -247,14 +247,13 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// use std::io;
 /// use std::net::SocketAddr;
 ///
-/// # use heph::actor::context;
+/// # use heph::actor::ThreadLocal;
 /// use heph::actor::messages::Terminate;
-/// use heph::{actor, NewActor};
-/// use heph::net::{TcpServer, TcpStream};
 /// # use heph::net::tcp;
-/// use heph::supervisor::{Supervisor, SupervisorStrategy};
+/// use heph::net::{TcpServer, TcpStream};
 /// use heph::rt::options::Priority;
-/// use heph::{rt, ActorOptions, Runtime, RuntimeRef};
+/// use heph::supervisor::{Supervisor, SupervisorStrategy};
+/// use heph::{actor, NewActor, rt, ActorOptions, Runtime, RuntimeRef};
 /// use log::error;
 ///
 /// fn main() -> Result<(), rt::Error> {
@@ -287,7 +286,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// # impl<S, NA> Supervisor<tcp::server::Setup<S, NA>> for ServerSupervisor
 /// # where
 /// #     S: Supervisor<NA> + Clone + 'static,
-/// #     NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, Context = context::ThreadLocal> + Clone + 'static,
+/// #     NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, Context = ThreadLocal> + Clone + 'static,
 /// # {
 /// #     fn decide(&mut self, err: tcp::server::Error<!>) -> SupervisorStrategy<()> {
 /// #         use tcp::server::Error::*;
@@ -334,8 +333,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// use std::io;
 /// use std::net::SocketAddr;
 ///
-/// use heph::actor::{self, NewActor};
-/// use heph::actor::context::ThreadSafe;
+/// use heph::actor::{self, ThreadSafe, NewActor};
 /// # use heph::actor::messages::Terminate;
 /// use heph::net::tcp::{server, TcpServer, TcpStream};
 /// use heph::supervisor::{Supervisor, SupervisorStrategy};

--- a/src/rt/local/scheduler/mod.rs
+++ b/src/rt/local/scheduler/mod.rs
@@ -12,10 +12,10 @@ use std::pin::Pin;
 use inbox::Manager;
 use log::trace;
 
-use crate::actor::context;
+use crate::actor::{NewActor, ThreadLocal};
 use crate::rt::options::Priority;
 use crate::rt::process::{self, ActorProcess, ProcessId};
-use crate::{NewActor, Supervisor};
+use crate::Supervisor;
 
 mod inactive;
 
@@ -120,7 +120,7 @@ impl<'s> AddActor<'s> {
         is_ready: bool,
     ) where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Context = context::ThreadLocal> + 'static,
+        NA: NewActor<Context = ThreadLocal> + 'static,
     {
         #[allow(trivial_casts)]
         debug_assert!(

--- a/src/rt/local/scheduler/tests.rs
+++ b/src/rt/local/scheduler/tests.rs
@@ -6,7 +6,7 @@ use std::mem::{self, forget};
 use std::pin::Pin;
 use std::rc::Rc;
 
-use crate::actor::{self, context, NewActor};
+use crate::actor::{self, NewActor, ThreadLocal};
 use crate::rt::local::scheduler::{ProcessData, Scheduler};
 use crate::rt::options::Priority;
 use crate::rt::process::{Process, ProcessId, ProcessResult};
@@ -277,7 +277,7 @@ impl NewActor for TestAssertUnmovedNewActor {
     type Argument = ();
     type Actor = AssertUnmoved<Pending<Result<(), !>>>;
     type Error = !;
-    type Context = context::ThreadLocal;
+    type Context = ThreadLocal;
 
     fn new(
         &mut self,

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -19,8 +19,9 @@ use std::{io, task};
 use log::{debug, trace};
 use mio::{event, Interest, Token};
 
-use crate::actor::context::{ThreadLocal, ThreadSafe};
-use crate::actor::{self, AddActorError, NewActor, PrivateSpawn, Spawn, SyncActor};
+use crate::actor::{
+    self, AddActorError, NewActor, PrivateSpawn, Spawn, SyncActor, ThreadLocal, ThreadSafe,
+};
 use crate::actor_ref::{ActorGroup, ActorRef};
 use crate::supervisor::{Supervisor, SyncSupervisor};
 use crate::trace;

--- a/src/rt/process/actor.rs
+++ b/src/rt/process/actor.rs
@@ -6,8 +6,7 @@ use std::task::{self, Poll};
 
 use inbox::{Manager, Receiver};
 
-use crate::actor::context::{ThreadLocal, ThreadSafe};
-use crate::actor::{self, Actor, NewActor};
+use crate::actor::{self, Actor, NewActor, ThreadLocal, ThreadSafe};
 use crate::rt::process::{Process, ProcessId, ProcessResult};
 use crate::supervisor::SupervisorStrategy;
 use crate::{RuntimeRef, Supervisor};

--- a/src/rt/process/tests.rs
+++ b/src/rt/process/tests.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use mio::Token;
 
-use crate::actor::{self, context, Actor, NewActor};
+use crate::actor::{self, Actor, NewActor, ThreadLocal};
 use crate::rt::options::Priority;
 use crate::rt::process::{ActorProcess, Process, ProcessData, ProcessId, ProcessResult};
 use crate::rt::RuntimeRef;
@@ -263,7 +263,7 @@ impl NewActor for TestAssertUnmovedNewActor {
     type Argument = ();
     type Actor = AssertUnmoved<Pending<Result<(), !>>>;
     type Error = !;
-    type Context = context::ThreadLocal;
+    type Context = ThreadLocal;
 
     fn new(
         &mut self,

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -10,8 +10,7 @@ use std::{io, task};
 use log::{debug, error, trace};
 use mio::{event, Interest, Registry, Token};
 
-use crate::actor::context::ThreadSafe;
-use crate::actor::{self, AddActorError, NewActor};
+use crate::actor::{self, AddActorError, NewActor, ThreadSafe};
 use crate::actor_ref::ActorRef;
 use crate::rt::thread_waker::ThreadWaker;
 use crate::rt::timers::Timers;

--- a/src/rt/shared/scheduler/mod.rs
+++ b/src/rt/shared/scheduler/mod.rs
@@ -11,7 +11,7 @@ use std::sync::Mutex;
 use inbox::Manager;
 use log::trace;
 
-use crate::actor::{context, NewActor};
+use crate::actor::{NewActor, ThreadSafe};
 use crate::rt::options::Priority;
 use crate::rt::process::{self, ActorProcess, Process, ProcessId};
 use crate::Supervisor;
@@ -212,7 +212,7 @@ impl<'s> AddActor<'s> {
         is_ready: bool,
     ) where
         S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<Context = context::ThreadSafe> + Send + Sync + 'static,
+        NA: NewActor<Context = ThreadSafe> + Send + Sync + 'static,
         NA::Actor: Send + Sync + 'static,
         NA::Message: Send,
     {

--- a/src/rt/shared/scheduler/tests.rs
+++ b/src/rt/shared/scheduler/tests.rs
@@ -4,7 +4,7 @@ use std::future::{pending, Pending};
 use std::mem::size_of;
 use std::sync::{Arc, Mutex};
 
-use crate::actor::{self, context, NewActor};
+use crate::actor::{self, NewActor, ThreadSafe};
 use crate::rt::process::{ProcessId, ProcessResult};
 use crate::rt::shared::scheduler::{Priority, ProcessData, Scheduler};
 use crate::supervisor::NoSupervisor;
@@ -25,7 +25,7 @@ fn is_send() {
     assert_send::<Scheduler>();
 }
 
-async fn simple_actor(_: actor::Context<!, context::ThreadSafe>) {}
+async fn simple_actor(_: actor::Context<!, ThreadSafe>) {}
 
 #[test]
 fn adding_actor() {
@@ -108,7 +108,7 @@ fn scheduler_run_order() {
     let run_order = Arc::new(Mutex::new(Vec::new()));
 
     async fn order_actor(
-        _: actor::Context<!, context::ThreadSafe>,
+        _: actor::Context<!, ThreadSafe>,
         id: usize,
         order: Arc<Mutex<Vec<usize>>>,
     ) {
@@ -149,7 +149,7 @@ impl NewActor for TestAssertUnmovedNewActor {
     type Argument = ();
     type Actor = AssertUnmoved<Pending<Result<(), !>>>;
     type Error = !;
-    type Context = context::ThreadSafe;
+    type Context = ThreadSafe;
 
     fn new(
         &mut self,

--- a/src/test.rs
+++ b/src/test.rs
@@ -32,7 +32,7 @@ use getrandom::getrandom;
 use inbox::Manager;
 use log::warn;
 
-use crate::actor::{self, context, Actor, NewActor, SyncActor};
+use crate::actor::{self, Actor, NewActor, SyncActor, ThreadLocal, ThreadSafe};
 use crate::actor_ref::ActorRef;
 use crate::rt::shared::{waker, Scheduler};
 use crate::rt::sync_worker::SyncWorker;
@@ -92,7 +92,7 @@ pub fn init_local_actor<NA>(
     arg: NA::Argument,
 ) -> Result<(NA::Actor, ActorRef<NA::Message>), NA::Error>
 where
-    NA: NewActor<Context = context::ThreadLocal>,
+    NA: NewActor<Context = ThreadLocal>,
 {
     init_local_actor_with_inbox(new_actor, arg).map(|(actor, _, actor_ref)| (actor, actor_ref))
 }
@@ -104,7 +104,7 @@ pub fn init_actor<NA>(
     arg: NA::Argument,
 ) -> Result<(NA::Actor, ActorRef<NA::Message>), NA::Error>
 where
-    NA: NewActor<Context = context::ThreadSafe>,
+    NA: NewActor<Context = ThreadSafe>,
 {
     init_actor_with_inbox(new_actor, arg).map(|(actor, _, actor_ref)| (actor, actor_ref))
 }
@@ -116,7 +116,7 @@ pub(crate) fn init_local_actor_with_inbox<NA>(
     arg: NA::Argument,
 ) -> Result<(NA::Actor, Manager<NA::Message>, ActorRef<NA::Message>), NA::Error>
 where
-    NA: NewActor<Context = context::ThreadLocal>,
+    NA: NewActor<Context = ThreadLocal>,
 {
     let (manager, sender, receiver) = Manager::new_small_channel();
     let ctx = actor::Context::new_local(TEST_PID, receiver, runtime());
@@ -131,7 +131,7 @@ pub(crate) fn init_actor_with_inbox<NA>(
     arg: NA::Argument,
 ) -> Result<(NA::Actor, Manager<NA::Message>, ActorRef<NA::Message>), NA::Error>
 where
-    NA: NewActor<Context = context::ThreadSafe>,
+    NA: NewActor<Context = ThreadSafe>,
 {
     let (manager, sender, receiver) = Manager::new_small_channel();
     let ctx = actor::Context::new_shared(TEST_PID, receiver, SHARED_INTERNAL.clone());

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -16,7 +16,7 @@ use std::stream::Stream;
 use std::task::{self, Poll};
 use std::time::{Duration, Instant};
 
-use crate::actor::context::ThreadLocal;
+use crate::actor::ThreadLocal;
 use crate::rt::{self, PrivateAccess, ProcessId};
 use crate::{actor, RuntimeRef};
 
@@ -177,8 +177,7 @@ impl<K> actor::Bound<K> for Timer {
 /// use std::time::Duration;
 /// # use std::time::Instant;
 ///
-/// use heph::actor;
-/// use heph::actor::context::ThreadSafe;
+/// use heph::actor::{self, ThreadSafe};
 /// # use heph::supervisor::NoSupervisor;
 /// # use heph::{rt, ActorOptions, Runtime};
 /// use heph::timer::Deadline;

--- a/tests/functional/actor_context.rs
+++ b/tests/functional/actor_context.rs
@@ -5,8 +5,7 @@
 use std::pin::Pin;
 use std::task::Poll;
 
-use heph::actor::context::ThreadSafe;
-use heph::actor::{self, context, NoMessages, RecvError};
+use heph::actor::{self, NoMessages, RecvError, ThreadSafe};
 use heph::rt::{ActorOptions, Runtime, Signal};
 use heph::supervisor::NoSupervisor;
 use heph::test::{init_local_actor, poll_actor};
@@ -15,8 +14,8 @@ use crate::util::{assert_send, assert_sync};
 
 #[test]
 fn thread_safe_is_send_sync() {
-    assert_send::<actor::Context<(), context::ThreadSafe>>();
-    assert_sync::<actor::Context<(), context::ThreadSafe>>();
+    assert_send::<actor::Context<(), ThreadSafe>>();
+    assert_sync::<actor::Context<(), ThreadSafe>>();
 }
 
 async fn local_actor_context_actor(mut ctx: actor::Context<usize>) {

--- a/tests/functional/restart_supervisor.rs
+++ b/tests/functional/restart_supervisor.rs
@@ -10,8 +10,8 @@ use std::task::{self, Poll};
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::context::ThreadSafe;
-use heph::{actor, restart_supervisor, Actor, NewActor, Supervisor, SupervisorStrategy};
+use heph::actor::{self, ThreadSafe};
+use heph::{restart_supervisor, Actor, NewActor, Supervisor, SupervisorStrategy};
 
 // NOTE: keep in sync with the documentation.
 const DEFAULT_MAX_RESTARTS: usize = 5;

--- a/tests/functional/runtime.rs
+++ b/tests/functional/runtime.rs
@@ -7,8 +7,7 @@ use std::task::{self, Poll};
 use std::thread::{self, sleep};
 use std::time::Duration;
 
-use heph::actor::context::{ThreadLocal, ThreadSafe};
-use heph::actor::{self, SyncContext};
+use heph::actor::{self, SyncContext, ThreadLocal, ThreadSafe};
 use heph::rt::options::{ActorOptions, Priority, SyncActorOptions};
 use heph::rt::Runtime;
 use heph::supervisor::NoSupervisor;
@@ -35,12 +34,12 @@ fn auto_cpu_affinity() {
 
     use socket2::SockRef;
 
-    use heph::actor::context::ThreadLocal;
     use heph::actor::messages::Terminate;
+    use heph::actor::{self, ThreadLocal};
     use heph::net::tcp::server;
     use heph::net::{TcpServer, TcpStream};
     use heph::supervisor::{Supervisor, SupervisorStrategy};
-    use heph::{actor, ActorOptions, ActorRef, NewActor, RuntimeRef};
+    use heph::{ActorOptions, ActorRef, NewActor, RuntimeRef};
 
     fn cpu_affinity(stream: &TcpStream) -> io::Result<usize> {
         // TODO: do this better.

--- a/tests/functional/test.rs
+++ b/tests/functional/test.rs
@@ -4,8 +4,7 @@ use std::mem::size_of;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use heph::actor::context::ThreadLocal;
-use heph::actor::{self, Actor, NewActor};
+use heph::actor::{self, Actor, NewActor, ThreadLocal};
 use heph::test::{size_of_actor, size_of_actor_val};
 
 #[test]

--- a/tests/functional/udp.rs
+++ b/tests/functional/udp.rs
@@ -9,7 +9,7 @@ use std::task::Poll;
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, context, Actor, NewActor};
+use heph::actor::{self, Actor, NewActor, ThreadLocal};
 use heph::net::UdpSocket;
 use heph::test::{init_local_actor, poll_actor};
 
@@ -45,7 +45,7 @@ fn connected_ipv6() {
 
 fn test<NA>(local_address: SocketAddr, new_actor: NA)
 where
-    NA: NewActor<Argument = SocketAddr, Error = !, Context = context::ThreadLocal>,
+    NA: NewActor<Argument = SocketAddr, Error = !, Context = ThreadLocal>,
     <NA as NewActor>::Actor: Actor<Error = io::Error>,
 {
     let echo_socket = std::net::UdpSocket::bind(local_address).unwrap();
@@ -312,7 +312,7 @@ async fn connected_vectored_io_actor(
 
 fn test_vectored_io<NA>(local_address: SocketAddr, new_actor: NA)
 where
-    NA: NewActor<Argument = SocketAddr, Error = !, Context = context::ThreadLocal>,
+    NA: NewActor<Argument = SocketAddr, Error = !, Context = ThreadLocal>,
     <NA as NewActor>::Actor: Actor<Error = io::Error>,
 {
     let echo_socket = std::net::UdpSocket::bind(local_address).unwrap();


### PR DESCRIPTION
Removes the `actor::context` module.