### PR TITLE
Add NewActor::actor

### DIFF
--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -383,6 +383,20 @@ pub trait NewActor {
             _phantom: PhantomData,
         }
     }
+
+    /// Returns the name of the actor.
+    ///
+    /// The default implementation creates the name based on the type name of
+    /// the actor.
+    ///
+    /// # Notes
+    ///
+    /// This uses [`type_name`] under the hood which does not have a stable
+    /// output. Like the `type_name` function the default implementation is
+    /// provided on a best effort basis.
+    fn name(&self) -> &'static str {
+        format_name(type_name::<Self::Actor>())
+    }
 }
 
 /// See [`NewActor::map_arg`].
@@ -574,23 +588,6 @@ mod private {
             Ok(())
         }
     }
-}
-
-/// Returns the name of an actor based on its type name.
-///
-/// The generic parameter should be an [`Actor`] (or [`NewActor::Actor`]).
-/// [`SyncActor`]s converted into function pointers (using `fn(_) -> _)`) do
-/// **not** work, unconverted it does work.
-///
-/// [`SyncActor`]: sync::SyncActor
-///
-/// # Notes
-///
-/// This uses [`type_name`] under the hood which does not have a stable output.
-/// Like the `type_name` function is function is provided on a best effort
-/// basis.
-pub(crate) fn name<A>() -> &'static str {
-    format_name(type_name::<A>())
 }
 
 // NOTE: split for easier testing.

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -18,9 +18,9 @@ use crate::rt::{
 use crate::trace;
 
 /// Token used to receive process signals.
-const SIGNAL: Token = Token(usize::max_value());
+const SIGNAL: Token = Token(usize::MAX);
 /// Token used to wake-up the coordinator thread.
-pub(super) const WAKER: Token = Token(usize::max_value() - 1);
+pub(super) const WAKER: Token = Token(usize::MAX - 1);
 
 /// Stream id for the coordinator.
 pub(super) const TRACE_ID: u32 = 0;

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -574,7 +574,7 @@ impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for RuntimeRef {
         let mut scheduler = self.internals.scheduler.borrow_mut();
         let actor_entry = scheduler.add_actor();
         let pid = actor_entry.pid();
-        let name = actor::name::<NA::Actor>();
+        let name = new_actor.name();
         debug!("spawning thread-local actor: pid={}, name={}", pid, name);
 
         // Create our actor context and our actor with it.

--- a/src/rt/process/actor.rs
+++ b/src/rt/process/actor.rs
@@ -104,7 +104,7 @@ where
     C: ContextKind,
 {
     fn name(&self) -> &'static str {
-        actor::name::<NA::Actor>()
+        self.new_actor.name()
     }
 
     fn run(self: Pin<&mut Self>, runtime_ref: &mut RuntimeRef, pid: ProcessId) -> ProcessResult {

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -116,7 +116,7 @@ impl RuntimeInternals {
         // Setup adding a new process to the scheduler.
         let actor_entry = self.scheduler.add_actor();
         let pid = actor_entry.pid();
-        let name = actor::name::<NA::Actor>();
+        let name = new_actor.name();
         debug!("spawning thread-safe actor: pid={}, name={}", pid, name);
 
         // Create our actor context and our actor with it.

--- a/src/rt/signal.rs
+++ b/src/rt/signal.rs
@@ -75,8 +75,9 @@ impl fmt::Display for Signal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())?;
         if f.alternate() {
-            f.write_str(" ")?;
+            f.write_str(" (")?;
             f.write_str(self.as_posix())?;
+            f.write_str(")")?;
         }
         Ok(())
     }

--- a/src/rt/waker.rs
+++ b/src/rt/waker.rs
@@ -249,7 +249,7 @@ mod tests {
     #[test]
     fn thread_mask() {
         assert!(
-            (usize::max_value() & !THREAD_MASK).leading_zeros() as usize == THREAD_BITS,
+            (usize::MAX & !THREAD_MASK).leading_zeros() as usize == THREAD_BITS,
             "Incorrect THREAD_MASK"
         );
     }
@@ -277,7 +277,7 @@ mod tests {
         assert_eq!(wake_receiver.try_recv(), Ok(PID1));
         waker::mark_polling(waker_id, false);
 
-        let pid2 = ProcessId(usize::max_value() & !THREAD_MASK);
+        let pid2 = ProcessId(usize::MAX & !THREAD_MASK);
         let waker = waker::new(waker_id, pid2);
         waker::mark_polling(waker_id, true);
         waker.wake();

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -308,8 +308,8 @@ pub(crate) struct RunningRuntime {
 const RUN_POLL_RATIO: usize = 32;
 
 /// Id used for the awakener.
-const WAKER: Token = Token(usize::max_value());
-const COORDINATOR: Token = Token(usize::max_value() - 1);
+const WAKER: Token = Token(usize::MAX);
+const COORDINATOR: Token = Token(usize::MAX - 1);
 
 impl RunningRuntime {
     /// Create a new running runtime.


### PR DESCRIPTION
Returns the name of the actor.

The default implementation creates a name based on the type name,
something that was already used to log messages.

Closes #6 (already closed).
Updates #271.