### PR TITLE
Move actor::Thread{Safe,Local} to rt::access::Thread{Safe,Local}

### DIFF
--- a/examples/6_process_signals.rs
+++ b/examples/6_process_signals.rs
@@ -2,8 +2,8 @@
 
 use std::convert::TryFrom;
 
-use heph::actor::{self, SyncContext, ThreadSafe};
-use heph::rt::{self, ActorOptions, Runtime, RuntimeRef, Signal, SyncActorOptions};
+use heph::actor::{self, SyncContext};
+use heph::rt::{self, ActorOptions, Runtime, RuntimeRef, Signal, SyncActorOptions, ThreadSafe};
 use heph::supervisor::NoSupervisor;
 
 fn main() -> Result<(), rt::Error> {

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -9,10 +9,10 @@ use std::{fmt, io};
 use inbox::{Receiver, RecvValue};
 use mio::{event, Interest, Token};
 
-use crate::actor::{AddActorError, PrivateSpawn, Spawn};
+use crate::actor::{AddActorError, NewActor, PrivateSpawn, Spawn};
 use crate::actor_ref::ActorRef;
 use crate::rt::{self, ActorOptions, ProcessId, ThreadLocal};
-use crate::{NewActor, Supervisor};
+use crate::supervisor::Supervisor;
 
 /// The context in which an actor is executed.
 ///

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -11,7 +11,7 @@ use mio::{event, Interest, Token};
 
 use crate::actor::{AddActorError, PrivateSpawn, Spawn};
 use crate::actor_ref::ActorRef;
-use crate::rt::{self, ActorOptions, ProcessId, RuntimeRef, ThreadLocal, ThreadSafe};
+use crate::rt::{self, ActorOptions, ProcessId, RuntimeRef, ThreadLocal};
 use crate::{NewActor, Supervisor};
 
 /// The context in which an actor is executed.
@@ -26,6 +26,8 @@ use crate::{NewActor, Supervisor};
 /// * [`ThreadSafe`] is the flavour that allows the actor to be moved between
 ///   threads. Actor started with [`RuntimeRef::try_spawn`] will get this
 ///   flavour of context.
+///
+/// [`ThreadSafe`]: crate::rt::ThreadSafe
 #[derive(Debug)]
 pub struct Context<M, RT = ThreadLocal> {
     /// Process id of the actor, used as `Token` in registering things, e.g.
@@ -159,46 +161,6 @@ impl<M> Context<M, ThreadLocal> {
     /// Get a reference to the runtime this actor is running in.
     pub fn runtime(&mut self) -> &mut RuntimeRef {
         &mut self.rt
-    }
-}
-
-impl<M> Context<M, ThreadSafe> {
-    /// Attempt to spawn a new thead-safe actor.
-    ///
-    /// See the [`Spawn`] trait for more information.
-    pub fn try_spawn<S, NA>(
-        &mut self,
-        supervisor: S,
-        new_actor: NA,
-        arg: NA::Argument,
-        options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, NA::Error>
-    where
-        S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
-        NA::Actor: Send + Sync + 'static,
-        NA::Message: Send,
-    {
-        Spawn::try_spawn(self, supervisor, new_actor, arg, options)
-    }
-
-    /// Spawn a new thead-safe actor.
-    ///
-    /// See the [`Spawn`] trait for more information.
-    pub fn spawn<S, NA>(
-        &mut self,
-        supervisor: S,
-        new_actor: NA,
-        arg: NA::Argument,
-        options: ActorOptions,
-    ) -> ActorRef<NA::Message>
-    where
-        S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<Error = !, RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
-        NA::Actor: Send + Sync + 'static,
-        NA::Message: Send,
-    {
-        Spawn::spawn(self, supervisor, new_actor, arg, options)
     }
 }
 

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -11,7 +11,7 @@ use mio::{event, Interest, Token};
 
 use crate::actor::{AddActorError, PrivateSpawn, Spawn};
 use crate::actor_ref::ActorRef;
-use crate::rt::{self, ActorOptions, ProcessId, RuntimeRef, ThreadLocal};
+use crate::rt::{self, ActorOptions, ProcessId, ThreadLocal};
 use crate::{NewActor, Supervisor};
 
 /// The context in which an actor is executed.
@@ -27,7 +27,9 @@ use crate::{NewActor, Supervisor};
 ///   threads. Actor started with [`RuntimeRef::try_spawn`] will get this
 ///   flavour of context.
 ///
+/// [`RuntimeRef::try_spawn_local`]: crate::rt::RuntimeRef::try_spawn_local
 /// [`ThreadSafe`]: crate::rt::ThreadSafe
+/// [`RuntimeRef::try_spawn`]: crate::rt::RuntimeRef::try_spawn
 #[derive(Debug)]
 pub struct Context<M, RT = ThreadLocal> {
     /// Process id of the actor, used as `Token` in registering things, e.g.
@@ -146,6 +148,11 @@ impl<M, RT> Context<M, RT> {
         ActorRef::local(self.inbox.new_sender())
     }
 
+    /// Get access to the runtime this actor is running in.
+    pub fn runtime(&mut self) -> &mut RT {
+        &mut self.rt
+    }
+
     /// Get the pid of this actor.
     pub(crate) const fn pid(&self) -> ProcessId {
         self.pid
@@ -154,13 +161,6 @@ impl<M, RT> Context<M, RT> {
     /// Sets the waker of the inbox to `waker`.
     pub(crate) fn register_inbox_waker(&mut self, waker: &task::Waker) {
         let _ = self.inbox.register_waker(waker);
-    }
-}
-
-impl<M> Context<M, ThreadLocal> {
-    /// Get a reference to the runtime this actor is running in.
-    pub fn runtime(&mut self) -> &mut RuntimeRef {
-        &mut self.rt
     }
 }
 

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -51,6 +51,7 @@
 //! actors.
 //!
 //! [`RuntimeRef::try_spawn`]: crate::rt::RuntimeRef::try_spawn
+//! [`ThreadSafe`]: crate::rt::ThreadSafe
 //!
 //! ## Synchronous actors
 //!
@@ -148,7 +149,7 @@ mod sync;
 mod tests;
 
 #[doc(inline)]
-pub use context::{Context, NoMessages, ReceiveMessage, RecvError, ThreadSafe};
+pub use context::{Context, NoMessages, ReceiveMessage, RecvError};
 #[doc(inline)]
 pub use spawn::Spawn;
 #[doc(inline)]

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -33,6 +33,7 @@
 //! actors, Heph does not (for thread-local actor).
 //!
 //! [`RuntimeRef::try_spawn_local`]: crate::rt::RuntimeRef::try_spawn_local
+//! [`ThreadLocal`]: crate::rt::ThreadLocal
 //!
 //! ## Asynchronous thread-safe actors
 //!
@@ -76,7 +77,8 @@
 //! traits.
 //!
 //! ```
-//! use heph::actor::{self, NewActor, ThreadLocal};
+//! use heph::actor::{self, NewActor};
+//! use heph::rt::ThreadLocal;
 //!
 //! async fn actor(ctx: actor::Context<(), ThreadLocal>) {
 //! #   drop(ctx); // Use `ctx` to silence dead code warnings.
@@ -146,7 +148,7 @@ mod sync;
 mod tests;
 
 #[doc(inline)]
-pub use context::{Context, NoMessages, ReceiveMessage, RecvError, ThreadLocal, ThreadSafe};
+pub use context::{Context, NoMessages, ReceiveMessage, RecvError, ThreadSafe};
 #[doc(inline)]
 pub use spawn::Spawn;
 #[doc(inline)]
@@ -286,11 +288,11 @@ pub trait NewActor {
     /// use std::io;
     /// use std::net::SocketAddr;
     ///
-    /// # use heph::actor::ThreadLocal;
     /// # use heph::actor::messages::Terminate;
     /// # use heph::net::tcp::server;
     /// use heph::net::{TcpServer, TcpStream};
     /// # use heph::supervisor::{Supervisor, SupervisorStrategy};
+    /// # use heph::rt::ThreadLocal;
     /// use heph::{rt, actor, NewActor, ActorOptions, Runtime, RuntimeRef};
     /// # use log::error;
     ///

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -1,6 +1,9 @@
 //! Module with the [`Spawn`] trait.
 
-use crate::{actor, ActorOptions, ActorRef, NewActor, Supervisor};
+use crate::actor::{self, NewActor};
+use crate::actor_ref::ActorRef;
+use crate::rt::ActorOptions;
+use crate::supervisor::Supervisor;
 
 /// The `Spawn` trait defines how new actors are added to the runtime.
 pub trait Spawn<S, NA, RT>: PrivateSpawn<S, NA, RT> {

--- a/src/actor/spawn.rs
+++ b/src/actor/spawn.rs
@@ -3,7 +3,7 @@
 use crate::{actor, ActorOptions, ActorRef, NewActor, Supervisor};
 
 /// The `Spawn` trait defines how new actors are added to the runtime.
-pub trait Spawn<S, NA, C>: PrivateSpawn<S, NA, C> {
+pub trait Spawn<S, NA, RT>: PrivateSpawn<S, NA, RT> {
     /// Attempts to spawn an actor.
     ///
     /// Arguments:
@@ -29,7 +29,7 @@ pub trait Spawn<S, NA, C>: PrivateSpawn<S, NA, C> {
     ) -> Result<ActorRef<NA::Message>, NA::Error>
     where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Context = C> + 'static,
+        NA: NewActor<RuntimeAccess = RT> + 'static,
         NA::Actor: 'static,
     {
         self.try_spawn_setup(supervisor, new_actor, |_| Ok(arg), options)
@@ -54,7 +54,7 @@ pub trait Spawn<S, NA, C>: PrivateSpawn<S, NA, C> {
     ) -> ActorRef<NA::Message>
     where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Error = !, Context = C> + 'static,
+        NA: NewActor<Error = !, RuntimeAccess = RT> + 'static,
         NA::Actor: 'static,
     {
         self.try_spawn_setup(supervisor, new_actor, |_| Ok(arg), options)
@@ -63,7 +63,7 @@ pub trait Spawn<S, NA, C>: PrivateSpawn<S, NA, C> {
 }
 
 /// Private version of the [`Spawn`]  trait.
-pub trait PrivateSpawn<S, NA, C> {
+pub trait PrivateSpawn<S, NA, RT> {
     /// Spawn an actor that needs to be initialised.
     ///
     /// See the public [`Spawn`] trait for documentation on the arguments.
@@ -79,9 +79,9 @@ pub trait PrivateSpawn<S, NA, C> {
     ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
     where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Context = C> + 'static,
+        NA: NewActor<RuntimeAccess = RT> + 'static,
         NA::Actor: 'static,
-        ArgFn: FnOnce(&mut actor::Context<NA::Message, C>) -> Result<NA::Argument, ArgFnE>;
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, RT>) -> Result<NA::Argument, ArgFnE>;
 }
 
 /// Error returned by spawning a actor.

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -175,12 +175,12 @@ impl TcpListener {
     /// listener has a connection ready to be accepted.
     ///
     /// [bound]: crate::actor::Bound
-    pub fn bind<M, K>(
-        ctx: &mut actor::Context<M, K>,
+    pub fn bind<M, RT>(
+        ctx: &mut actor::Context<M, RT>,
         address: SocketAddr,
     ) -> io::Result<TcpListener>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         let mut socket = net::TcpListener::bind(address)?;
         let pid = ctx.pid();
@@ -270,9 +270,9 @@ pub struct UnboundTcpStream {
 
 impl UnboundTcpStream {
     /// Bind this TCP stream to the actor's `ctx`, allowing it to be used.
-    pub fn bind_to<M, K>(mut self, ctx: &mut actor::Context<M, K>) -> io::Result<TcpStream>
+    pub fn bind_to<M, RT>(mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<TcpStream>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         let pid = ctx.pid();
         ctx.register(
@@ -321,12 +321,12 @@ impl<'a> Stream for Incoming<'a> {
     }
 }
 
-impl<K> actor::Bound<K> for TcpListener {
+impl<RT> actor::Bound<RT> for TcpListener {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, K>) -> io::Result<()>
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         let pid = ctx.pid();
         ctx.reregister(&mut self.socket, pid.into(), Interest::READABLE)

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -333,12 +333,12 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// use std::io;
 /// use std::net::SocketAddr;
 ///
-/// use heph::actor::{self, ThreadSafe, NewActor};
+/// use heph::actor::{self, NewActor};
 /// # use heph::actor::messages::Terminate;
 /// use heph::net::tcp::{server, TcpServer, TcpStream};
 /// use heph::supervisor::{Supervisor, SupervisorStrategy};
 /// use heph::rt::options::Priority;
-/// use heph::{rt, ActorOptions, Runtime};
+/// use heph::rt::{self, Runtime, ThreadSafe, ActorOptions};
 /// use log::error;
 ///
 /// fn main() -> Result<(), rt::Error> {

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -410,10 +410,7 @@ impl<S, NA> Clone for Setup<S, NA> {
 ///     stream.send_all(b"Hello World").await
 /// }
 #[derive(Debug)]
-pub struct TcpServer<S, NA>
-where
-    NA: NewActor,
-{
+pub struct TcpServer<S, NA: NewActor> {
     /// Actor context in which this actor is running.
     ctx: actor::Context<Message, NA::RuntimeAccess>,
     /// Whether or not we set the waker for the inbox.

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -153,11 +153,11 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// use std::io;
 /// use std::net::SocketAddr;
 ///
-/// # use heph::actor::ThreadLocal;
 /// # use heph::actor::messages::Terminate;
 /// use heph::net::tcp::{server, TcpServer, TcpStream};
 /// use heph::rt::options::Priority;
 /// use heph::supervisor::{Supervisor, SupervisorStrategy};
+/// # use heph::rt::ThreadLocal;
 /// use heph::{rt, actor, NewActor, ActorOptions, Runtime, RuntimeRef};
 /// use log::error;
 ///
@@ -247,10 +247,10 @@ impl<S, NA> Clone for Setup<S, NA> {
 /// use std::io;
 /// use std::net::SocketAddr;
 ///
-/// # use heph::actor::ThreadLocal;
 /// use heph::actor::messages::Terminate;
 /// # use heph::net::tcp;
 /// use heph::net::{TcpServer, TcpStream};
+/// # use heph::rt::ThreadLocal;
 /// use heph::rt::options::Priority;
 /// use heph::supervisor::{Supervisor, SupervisorStrategy};
 /// use heph::{actor, NewActor, rt, ActorOptions, Runtime, RuntimeRef};

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -40,9 +40,12 @@ impl TcpStream {
     /// or write.
     ///
     /// [bound]: crate::actor::Bound
-    pub fn connect<M, K>(ctx: &mut actor::Context<M, K>, address: SocketAddr) -> io::Result<Connect>
+    pub fn connect<M, RT>(
+        ctx: &mut actor::Context<M, RT>,
+        address: SocketAddr,
+    ) -> io::Result<Connect>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         let mut socket = net::TcpStream::connect(address)?;
         let pid = ctx.pid();
@@ -780,12 +783,12 @@ where
     }
 }
 
-impl<K> actor::Bound<K> for TcpStream {
+impl<RT> actor::Bound<RT> for TcpStream {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, K>) -> io::Result<()>
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         let pid = ctx.pid();
         ctx.reregister(

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -147,12 +147,12 @@ impl UdpSocket {
     /// socket is ready to be read from or write to.
     ///
     /// [bound]: crate::actor::Bound
-    pub fn bind<M, K>(
-        ctx: &mut actor::Context<M, K>,
+    pub fn bind<M, RT>(
+        ctx: &mut actor::Context<M, RT>,
         local: SocketAddr,
     ) -> io::Result<UdpSocket<Unconnected>>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         let mut socket = net::UdpSocket::bind(local)?;
         let pid = ctx.pid();
@@ -849,12 +849,12 @@ impl<M> fmt::Debug for UdpSocket<M> {
     }
 }
 
-impl<K> actor::Bound<K> for UdpSocket {
+impl<RT> actor::Bound<RT> for UdpSocket {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, K>) -> io::Result<()>
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         ctx.reregister(
             &mut self.socket,

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -2,12 +2,17 @@
 //!
 //! [`rt::Access`]: crate::rt::Access
 
-use std::io;
+use std::ops::{Deref, DerefMut};
 use std::time::Instant;
+use std::{fmt, io};
 
 use mio::{event, Interest, Token};
 
-use crate::rt::ProcessId;
+use crate::actor::{self, AddActorError, NewActor, PrivateSpawn, Spawn};
+use crate::actor_ref::ActorRef;
+use crate::rt::process::ProcessId;
+use crate::rt::{ActorOptions, RuntimeRef};
+use crate::supervisor::Supervisor;
 
 /// Trait to indicate an API needs access to the Heph runtime.
 ///
@@ -18,8 +23,6 @@ use crate::rt::ProcessId;
 ///
 /// This trait can't be implemented by types outside of the Heph crate.
 pub trait Access: PrivateAccess {}
-
-impl<T> Access for T where T: PrivateAccess {}
 
 /// Actual trait behind [`rt::Access`].
 ///
@@ -40,4 +43,95 @@ pub trait PrivateAccess {
 
     /// Returns the CPU the thread is bound to, if any.
     fn cpu(&self) -> Option<usize>;
+}
+
+/// Provides access to the thread-local runtime.
+///
+/// This implements the [`Access`] trait, which is required by various APIs to
+/// get access to the runtime. Furthermore this gives access to a
+/// [`RuntimeRef`] for users.
+///
+/// This is usually a part of the [`actor::Context`], see it for more
+/// information.
+///
+/// This is an optimised version of [`ThreadSafe`], but doesn't allow the actor
+/// to move between threads.
+///
+/// [`actor::Context`]: crate::actor::Context
+pub struct ThreadLocal {
+    rt: RuntimeRef,
+}
+
+impl ThreadLocal {
+    pub(crate) const fn new(rt: RuntimeRef) -> ThreadLocal {
+        ThreadLocal { rt }
+    }
+}
+
+impl Deref for ThreadLocal {
+    type Target = RuntimeRef;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rt
+    }
+}
+
+impl DerefMut for ThreadLocal {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.rt
+    }
+}
+
+impl Access for ThreadLocal {}
+
+impl PrivateAccess for ThreadLocal {
+    fn register<S>(&mut self, source: &mut S, token: Token, interest: Interest) -> io::Result<()>
+    where
+        S: event::Source + ?Sized,
+    {
+        self.rt.register(source, token, interest)
+    }
+
+    fn reregister<S>(&mut self, source: &mut S, token: Token, interest: Interest) -> io::Result<()>
+    where
+        S: event::Source + ?Sized,
+    {
+        self.rt.reregister(source, token, interest)
+    }
+
+    fn add_deadline(&mut self, pid: ProcessId, deadline: Instant) {
+        self.rt.add_deadline(pid, deadline)
+    }
+
+    fn cpu(&self) -> Option<usize> {
+        self.rt.cpu()
+    }
+}
+
+impl<S, NA> Spawn<S, NA, ThreadLocal> for ThreadLocal {}
+
+impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for ThreadLocal {
+    fn try_spawn_setup<ArgFn, ArgFnE>(
+        &mut self,
+        supervisor: S,
+        new_actor: NA,
+        arg_fn: ArgFn,
+        options: ActorOptions,
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+    where
+        S: Supervisor<NA> + 'static,
+        NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
+        NA::Actor: 'static,
+        ArgFn:
+            FnOnce(&mut actor::Context<NA::Message, ThreadLocal>) -> Result<NA::Argument, ArgFnE>,
+    {
+        self.rt
+            .try_spawn_setup(supervisor, new_actor, arg_fn, options)
+    }
+}
+
+impl fmt::Debug for ThreadLocal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ThreadLocal")
+    }
 }

--- a/src/rt/local/scheduler/mod.rs
+++ b/src/rt/local/scheduler/mod.rs
@@ -119,7 +119,7 @@ impl<'s> AddActor<'s> {
         is_ready: bool,
     ) where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Context = ThreadLocal> + 'static,
+        NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
     {
         #[allow(trivial_casts)]
         debug_assert!(

--- a/src/rt/local/scheduler/mod.rs
+++ b/src/rt/local/scheduler/mod.rs
@@ -16,7 +16,7 @@ use crate::actor::NewActor;
 use crate::rt::options::Priority;
 use crate::rt::process::{self, ActorProcess, ProcessId};
 use crate::rt::ThreadLocal;
-use crate::Supervisor;
+use crate::supervisor::Supervisor;
 
 mod inactive;
 #[cfg(test)]

--- a/src/rt/local/scheduler/mod.rs
+++ b/src/rt/local/scheduler/mod.rs
@@ -12,9 +12,10 @@ use std::pin::Pin;
 use inbox::Manager;
 use log::trace;
 
-use crate::actor::{NewActor, ThreadLocal};
+use crate::actor::NewActor;
 use crate::rt::options::Priority;
 use crate::rt::process::{self, ActorProcess, ProcessId};
+use crate::rt::ThreadLocal;
 use crate::Supervisor;
 
 mod inactive;

--- a/src/rt/local/scheduler/tests.rs
+++ b/src/rt/local/scheduler/tests.rs
@@ -277,11 +277,11 @@ impl NewActor for TestAssertUnmovedNewActor {
     type Argument = ();
     type Actor = AssertUnmoved<Pending<Result<(), !>>>;
     type Error = !;
-    type Context = ThreadLocal;
+    type RuntimeAccess = ThreadLocal;
 
     fn new(
         &mut self,
-        ctx: actor::Context<Self::Message, Self::Context>,
+        ctx: actor::Context<Self::Message, Self::RuntimeAccess>,
         _: Self::Argument,
     ) -> Result<Self::Actor, Self::Error> {
         // In the test we need the access to the inbox, to achieve that we can't

--- a/src/rt/local/scheduler/tests.rs
+++ b/src/rt/local/scheduler/tests.rs
@@ -6,11 +6,11 @@ use std::mem::{self, forget};
 use std::pin::Pin;
 use std::rc::Rc;
 
-use crate::actor::{self, NewActor, ThreadLocal};
+use crate::actor::{self, NewActor};
 use crate::rt::local::scheduler::{ProcessData, Scheduler};
 use crate::rt::options::Priority;
 use crate::rt::process::{Process, ProcessId, ProcessResult};
-use crate::rt::RuntimeRef;
+use crate::rt::{RuntimeRef, ThreadLocal};
 use crate::supervisor::NoSupervisor;
 use crate::test::{self, init_local_actor_with_inbox, AssertUnmoved};
 

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -121,7 +121,7 @@ use std::{io, task};
 use log::{debug, trace};
 use mio::{event, Interest, Token};
 
-use crate::actor::{self, AddActorError, NewActor, PrivateSpawn, Spawn, SyncActor, ThreadSafe};
+use crate::actor::{self, AddActorError, NewActor, PrivateSpawn, Spawn, SyncActor};
 use crate::actor_ref::{ActorGroup, ActorRef};
 use crate::supervisor::{Supervisor, SyncSupervisor};
 use crate::trace;
@@ -146,7 +146,7 @@ pub(crate) use access::PrivateAccess;
 pub(crate) use process::ProcessId;
 pub(crate) use timers::Timers; // Needed by the `test` module.
 
-pub use access::{Access, ThreadLocal};
+pub use access::{Access, ThreadLocal, ThreadSafe};
 pub use error::Error;
 pub use options::{ActorOptions, SyncActorOptions};
 pub use setup::Setup;

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -231,7 +231,7 @@ impl Runtime {
     ) -> Result<ActorRef<NA::Message>, NA::Error>
     where
         S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<Context = ThreadSafe> + Sync + Send + 'static,
+        NA: NewActor<RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
         NA::Actor: Send + Sync + 'static,
         NA::Message: Send,
     {
@@ -250,7 +250,7 @@ impl Runtime {
     ) -> ActorRef<NA::Message>
     where
         S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<Error = !, Context = ThreadSafe> + Sync + Send + 'static,
+        NA: NewActor<Error = !, RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
         NA::Actor: Send + Sync + 'static,
         NA::Message: Send,
     {
@@ -353,7 +353,7 @@ impl Runtime {
 impl<S, NA> Spawn<S, NA, ThreadSafe> for Runtime
 where
     S: Send + Sync,
-    NA: NewActor<Context = ThreadSafe> + Send + Sync,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
     NA::Actor: Send + Sync,
     NA::Message: Send,
 {
@@ -362,7 +362,7 @@ where
 impl<S, NA> PrivateSpawn<S, NA, ThreadSafe> for Runtime
 where
     S: Send + Sync,
-    NA: NewActor<Context = ThreadSafe> + Send + Sync,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
     NA::Actor: Send + Sync,
     NA::Message: Send,
 {
@@ -375,7 +375,7 @@ where
     ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
     where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Context = ThreadSafe> + 'static,
+        NA: NewActor<RuntimeAccess = ThreadSafe> + 'static,
         NA::Actor: 'static,
         ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, ArgFnE>,
     {
@@ -409,7 +409,7 @@ impl RuntimeRef {
     ) -> Result<ActorRef<NA::Message>, NA::Error>
     where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Context = ThreadLocal> + 'static,
+        NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
         NA::Actor: 'static,
     {
         Spawn::try_spawn(self, supervisor, new_actor, arg, options)
@@ -427,7 +427,7 @@ impl RuntimeRef {
     ) -> ActorRef<NA::Message>
     where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Error = !, Context = ThreadLocal> + 'static,
+        NA: NewActor<Error = !, RuntimeAccess = ThreadLocal> + 'static,
         NA::Actor: 'static,
     {
         Spawn::spawn(self, supervisor, new_actor, arg, options)
@@ -445,7 +445,7 @@ impl RuntimeRef {
     ) -> Result<ActorRef<NA::Message>, NA::Error>
     where
         S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<Context = ThreadSafe> + Sync + Send + 'static,
+        NA: NewActor<RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
         NA::Actor: Send + Sync + 'static,
         NA::Message: Send,
     {
@@ -464,7 +464,7 @@ impl RuntimeRef {
     ) -> ActorRef<NA::Message>
     where
         S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<Error = !, Context = ThreadSafe> + Sync + Send + 'static,
+        NA: NewActor<Error = !, RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
         NA::Actor: Send + Sync + 'static,
         NA::Message: Send,
     {
@@ -566,7 +566,7 @@ impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for RuntimeRef {
     ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
     where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Context = ThreadLocal> + 'static,
+        NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
         NA::Actor: 'static,
         ArgFn:
             FnOnce(&mut actor::Context<NA::Message, ThreadLocal>) -> Result<NA::Argument, ArgFnE>,
@@ -603,7 +603,7 @@ impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for RuntimeRef {
 impl<S, NA> Spawn<S, NA, ThreadSafe> for RuntimeRef
 where
     S: Send + Sync,
-    NA: NewActor<Context = ThreadSafe> + Send + Sync,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
     NA::Actor: Send + Sync,
     NA::Message: Send,
 {
@@ -612,7 +612,7 @@ where
 impl<S, NA> PrivateSpawn<S, NA, ThreadSafe> for RuntimeRef
 where
     S: Send + Sync,
-    NA: NewActor<Context = ThreadSafe> + Send + Sync,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
     NA::Actor: Send + Sync,
     NA::Message: Send,
 {
@@ -625,7 +625,7 @@ where
     ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
     where
         S: Supervisor<NA> + 'static,
-        NA: NewActor<Context = ThreadSafe> + 'static,
+        NA: NewActor<RuntimeAccess = ThreadSafe> + 'static,
         NA::Actor: 'static,
         ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, ArgFnE>,
     {

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -121,9 +121,7 @@ use std::{io, task};
 use log::{debug, trace};
 use mio::{event, Interest, Token};
 
-use crate::actor::{
-    self, AddActorError, NewActor, PrivateSpawn, Spawn, SyncActor, ThreadLocal, ThreadSafe,
-};
+use crate::actor::{self, AddActorError, NewActor, PrivateSpawn, Spawn, SyncActor, ThreadSafe};
 use crate::actor_ref::{ActorGroup, ActorRef};
 use crate::supervisor::{Supervisor, SyncSupervisor};
 use crate::trace;
@@ -148,7 +146,7 @@ pub(crate) use access::PrivateAccess;
 pub(crate) use process::ProcessId;
 pub(crate) use timers::Timers; // Needed by the `test` module.
 
-pub use access::Access;
+pub use access::{Access, ThreadLocal};
 pub use error::Error;
 pub use options::{ActorOptions, SyncActorOptions};
 pub use setup::Setup;
@@ -581,7 +579,7 @@ impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for RuntimeRef {
         // Create our actor context and our actor with it.
         let (manager, sender, receiver) = inbox::Manager::new_small_channel();
         let actor_ref = ActorRef::local(sender);
-        let mut ctx = actor::Context::new_local(pid, receiver, self.clone());
+        let mut ctx = actor::Context::new(pid, receiver, ThreadLocal::new(self.clone()));
         // Create our actor argument, running any setup required by the caller.
         let arg = arg_fn(&mut ctx).map_err(AddActorError::ArgFn)?;
         let actor = new_actor.new(ctx, arg).map_err(AddActorError::NewActor)?;

--- a/src/rt/process/actor.rs
+++ b/src/rt/process/actor.rs
@@ -6,9 +6,9 @@ use std::task::{self, Poll};
 
 use inbox::{Manager, Receiver};
 
-use crate::actor::{self, Actor, NewActor, ThreadSafe};
+use crate::actor::{self, Actor, NewActor};
 use crate::rt::process::{Process, ProcessId, ProcessResult};
-use crate::rt::{RuntimeRef, ThreadLocal};
+use crate::rt::{RuntimeRef, ThreadLocal, ThreadSafe};
 use crate::supervisor::{Supervisor, SupervisorStrategy};
 
 /// A process that represent an [`Actor`].
@@ -185,6 +185,6 @@ impl RuntimeSupport for ThreadSafe {
         inbox: Receiver<M>,
         runtime_ref: &mut RuntimeRef,
     ) -> actor::Context<M, ThreadSafe> {
-        actor::Context::new_shared(pid, inbox, runtime_ref.clone_shared())
+        actor::Context::new(pid, inbox, ThreadSafe::new(runtime_ref.clone_shared()))
     }
 }

--- a/src/rt/process/actor.rs
+++ b/src/rt/process/actor.rs
@@ -6,10 +6,10 @@ use std::task::{self, Poll};
 
 use inbox::{Manager, Receiver};
 
-use crate::actor::{self, Actor, NewActor, ThreadLocal, ThreadSafe};
+use crate::actor::{self, Actor, NewActor, ThreadSafe};
 use crate::rt::process::{Process, ProcessId, ProcessResult};
-use crate::supervisor::SupervisorStrategy;
-use crate::{RuntimeRef, Supervisor};
+use crate::rt::{RuntimeRef, ThreadLocal};
+use crate::supervisor::{Supervisor, SupervisorStrategy};
 
 /// A process that represent an [`Actor`].
 pub(crate) struct ActorProcess<S, NA: NewActor> {
@@ -171,7 +171,7 @@ impl RuntimeSupport for ThreadLocal {
         inbox: Receiver<M>,
         runtime_ref: &mut RuntimeRef,
     ) -> actor::Context<M, ThreadLocal> {
-        actor::Context::new_local(pid, inbox, runtime_ref.clone())
+        actor::Context::new(pid, inbox, ThreadLocal::new(runtime_ref.clone()))
     }
 }
 

--- a/src/rt/process/mod.rs
+++ b/src/rt/process/mod.rs
@@ -9,7 +9,7 @@ use log::trace;
 use mio::Token;
 
 use crate::rt::options::Priority;
-use crate::RuntimeRef;
+use crate::rt::RuntimeRef;
 
 mod actor;
 #[cfg(test)]

--- a/src/rt/process/tests.rs
+++ b/src/rt/process/tests.rs
@@ -263,7 +263,7 @@ impl NewActor for TestAssertUnmovedNewActor {
     type Argument = ();
     type Actor = AssertUnmoved<Pending<Result<(), !>>>;
     type Error = !;
-    type Context = ThreadLocal;
+    type RuntimeAccess = ThreadLocal;
 
     fn new(
         &mut self,

--- a/src/rt/process/tests.rs
+++ b/src/rt/process/tests.rs
@@ -11,10 +11,10 @@ use std::time::Duration;
 
 use mio::Token;
 
-use crate::actor::{self, Actor, NewActor, ThreadLocal};
+use crate::actor::{self, Actor, NewActor};
 use crate::rt::options::Priority;
 use crate::rt::process::{ActorProcess, Process, ProcessData, ProcessId, ProcessResult};
-use crate::rt::RuntimeRef;
+use crate::rt::{RuntimeRef, ThreadLocal};
 use crate::supervisor::{NoSupervisor, Supervisor, SupervisorStrategy};
 use crate::test::{self, init_local_actor_with_inbox, AssertUnmoved, TEST_PID};
 

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -10,11 +10,11 @@ use std::{io, task};
 use log::{debug, error, trace};
 use mio::{event, Interest, Registry, Token};
 
-use crate::actor::{self, AddActorError, NewActor, ThreadSafe};
+use crate::actor::{self, AddActorError, NewActor};
 use crate::actor_ref::ActorRef;
 use crate::rt::thread_waker::ThreadWaker;
 use crate::rt::timers::Timers;
-use crate::rt::{ActorOptions, ProcessId};
+use crate::rt::{ActorOptions, ProcessId, ThreadSafe};
 use crate::supervisor::Supervisor;
 
 mod scheduler;
@@ -122,7 +122,7 @@ impl RuntimeInternals {
         // Create our actor context and our actor with it.
         let (manager, sender, receiver) = inbox::Manager::new_small_channel();
         let actor_ref = ActorRef::local(sender);
-        let mut ctx = actor::Context::new_shared(pid, receiver, self.clone());
+        let mut ctx = actor::Context::new(pid, receiver, ThreadSafe::new(self.clone()));
         let arg = arg_fn(&mut ctx).map_err(AddActorError::ArgFn)?;
         let actor = new_actor.new(ctx, arg).map_err(AddActorError::NewActor)?;
 

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -108,7 +108,7 @@ impl RuntimeInternals {
     ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
     where
         S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<Context = ThreadSafe> + Sync + Send + 'static,
+        NA: NewActor<RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
         ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, ArgFnE>,
         NA::Actor: Send + Sync + 'static,
         NA::Message: Send,

--- a/src/rt/shared/scheduler/mod.rs
+++ b/src/rt/shared/scheduler/mod.rs
@@ -211,7 +211,7 @@ impl<'s> AddActor<'s> {
         is_ready: bool,
     ) where
         S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<Context = ThreadSafe> + Send + Sync + 'static,
+        NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
         NA::Actor: Send + Sync + 'static,
         NA::Message: Send,
     {

--- a/src/rt/shared/scheduler/mod.rs
+++ b/src/rt/shared/scheduler/mod.rs
@@ -11,10 +11,11 @@ use std::sync::Mutex;
 use inbox::Manager;
 use log::trace;
 
+use crate::actor::NewActor;
 use crate::rt::options::Priority;
 use crate::rt::process::{self, ActorProcess, Process, ProcessId};
 use crate::rt::ThreadSafe;
-use crate::{NewActor, Supervisor};
+use crate::supervisor::Supervisor;
 
 mod inactive;
 mod runqueue;

--- a/src/rt/shared/scheduler/mod.rs
+++ b/src/rt/shared/scheduler/mod.rs
@@ -11,10 +11,10 @@ use std::sync::Mutex;
 use inbox::Manager;
 use log::trace;
 
-use crate::actor::{NewActor, ThreadSafe};
 use crate::rt::options::Priority;
 use crate::rt::process::{self, ActorProcess, Process, ProcessId};
-use crate::Supervisor;
+use crate::rt::ThreadSafe;
+use crate::{NewActor, Supervisor};
 
 mod inactive;
 mod runqueue;

--- a/src/rt/shared/scheduler/tests.rs
+++ b/src/rt/shared/scheduler/tests.rs
@@ -4,9 +4,10 @@ use std::future::{pending, Pending};
 use std::mem::size_of;
 use std::sync::{Arc, Mutex};
 
-use crate::actor::{self, NewActor, ThreadSafe};
+use crate::actor::{self, NewActor};
 use crate::rt::process::{ProcessId, ProcessResult};
 use crate::rt::shared::scheduler::{Priority, ProcessData, Scheduler};
+use crate::rt::ThreadSafe;
 use crate::supervisor::NoSupervisor;
 use crate::test::{self, init_actor_with_inbox, AssertUnmoved};
 

--- a/src/rt/shared/scheduler/tests.rs
+++ b/src/rt/shared/scheduler/tests.rs
@@ -149,11 +149,11 @@ impl NewActor for TestAssertUnmovedNewActor {
     type Argument = ();
     type Actor = AssertUnmoved<Pending<Result<(), !>>>;
     type Error = !;
-    type Context = ThreadSafe;
+    type RuntimeAccess = ThreadSafe;
 
     fn new(
         &mut self,
-        _: actor::Context<Self::Message, Self::Context>,
+        _: actor::Context<Self::Message, Self::RuntimeAccess>,
         _: Self::Argument,
     ) -> Result<Self::Actor, Self::Error> {
         Ok(AssertUnmoved::new(pending()))

--- a/src/rt/sync_worker.rs
+++ b/src/rt/sync_worker.rs
@@ -9,9 +9,10 @@ use mio::unix;
 use mio::{Interest, Registry, Token};
 
 use crate::actor::{SyncActor, SyncContext};
+use crate::actor_ref::ActorRef;
 use crate::rt::options::SyncActorOptions;
 use crate::supervisor::{SupervisorStrategy, SyncSupervisor};
-use crate::{trace, ActorRef};
+use crate::trace;
 
 /// Handle to a synchronous worker.
 #[derive(Debug)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,15 +31,15 @@ use getrandom::getrandom;
 use inbox::Manager;
 use log::warn;
 
-use crate::actor::{self, Actor, NewActor, SyncActor, ThreadSafe};
+use crate::actor::{self, Actor, NewActor, SyncActor};
 use crate::actor_ref::ActorRef;
 use crate::rt::local::Runtime;
 use crate::rt::shared::{waker, Scheduler};
 use crate::rt::sync_worker::SyncWorker;
 use crate::rt::thread_waker::ThreadWaker;
 use crate::rt::{
-    shared, ProcessId, RuntimeRef, SyncActorOptions, ThreadLocal, Timers, SYNC_WORKER_ID_END,
-    SYNC_WORKER_ID_START,
+    shared, ProcessId, RuntimeRef, SyncActorOptions, ThreadLocal, ThreadSafe, Timers,
+    SYNC_WORKER_ID_END, SYNC_WORKER_ID_START,
 };
 use crate::supervisor::SyncSupervisor;
 
@@ -131,7 +131,7 @@ where
     NA: NewActor<RuntimeAccess = ThreadSafe>,
 {
     let (manager, sender, receiver) = Manager::new_small_channel();
-    let ctx = actor::Context::new_shared(TEST_PID, receiver, SHARED_INTERNAL.clone());
+    let ctx = actor::Context::new(TEST_PID, receiver, ThreadSafe::new(SHARED_INTERNAL.clone()));
     let actor = new_actor.new(ctx, arg)?;
     Ok((actor, manager, ActorRef::local(sender)))
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -89,7 +89,7 @@ pub fn init_local_actor<NA>(
     arg: NA::Argument,
 ) -> Result<(NA::Actor, ActorRef<NA::Message>), NA::Error>
 where
-    NA: NewActor<Context = ThreadLocal>,
+    NA: NewActor<RuntimeAccess = ThreadLocal>,
 {
     init_local_actor_with_inbox(new_actor, arg).map(|(actor, _, actor_ref)| (actor, actor_ref))
 }
@@ -101,7 +101,7 @@ pub fn init_actor<NA>(
     arg: NA::Argument,
 ) -> Result<(NA::Actor, ActorRef<NA::Message>), NA::Error>
 where
-    NA: NewActor<Context = ThreadSafe>,
+    NA: NewActor<RuntimeAccess = ThreadSafe>,
 {
     init_actor_with_inbox(new_actor, arg).map(|(actor, _, actor_ref)| (actor, actor_ref))
 }
@@ -113,7 +113,7 @@ pub(crate) fn init_local_actor_with_inbox<NA>(
     arg: NA::Argument,
 ) -> Result<(NA::Actor, Manager<NA::Message>, ActorRef<NA::Message>), NA::Error>
 where
-    NA: NewActor<Context = ThreadLocal>,
+    NA: NewActor<RuntimeAccess = ThreadLocal>,
 {
     let (manager, sender, receiver) = Manager::new_small_channel();
     let ctx = actor::Context::new_local(TEST_PID, receiver, runtime());
@@ -128,7 +128,7 @@ pub(crate) fn init_actor_with_inbox<NA>(
     arg: NA::Argument,
 ) -> Result<(NA::Actor, Manager<NA::Message>, ActorRef<NA::Message>), NA::Error>
 where
-    NA: NewActor<Context = ThreadSafe>,
+    NA: NewActor<RuntimeAccess = ThreadSafe>,
 {
     let (manager, sender, receiver) = Manager::new_small_channel();
     let ctx = actor::Context::new_shared(TEST_PID, receiver, SHARED_INTERNAL.clone());
@@ -140,14 +140,14 @@ where
 ///
 /// This returns the thread handle for the thread the synchronous actor is
 /// running on and an actor reference to the actor.
-pub fn spawn_sync_actor<Sv, A, E, Arg, M>(
-    supervisor: Sv,
+pub fn spawn_sync_actor<S, A, E, Arg, M>(
+    supervisor: S,
     actor: A,
     arg: Arg,
     options: SyncActorOptions,
 ) -> io::Result<(thread::JoinHandle<()>, ActorRef<M>)>
 where
-    Sv: SyncSupervisor<A> + Send + 'static,
+    S: SyncSupervisor<A> + Send + 'static,
     A: SyncActor<Message = M, Argument = Arg, Error = E> + Send + 'static,
     Arg: Send + 'static,
     M: Send + 'static,

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,14 +31,14 @@ use getrandom::getrandom;
 use inbox::Manager;
 use log::warn;
 
-use crate::actor::{self, Actor, NewActor, SyncActor, ThreadLocal, ThreadSafe};
+use crate::actor::{self, Actor, NewActor, SyncActor, ThreadSafe};
 use crate::actor_ref::ActorRef;
 use crate::rt::local::Runtime;
 use crate::rt::shared::{waker, Scheduler};
 use crate::rt::sync_worker::SyncWorker;
 use crate::rt::thread_waker::ThreadWaker;
 use crate::rt::{
-    shared, ProcessId, RuntimeRef, SyncActorOptions, Timers, SYNC_WORKER_ID_END,
+    shared, ProcessId, RuntimeRef, SyncActorOptions, ThreadLocal, Timers, SYNC_WORKER_ID_END,
     SYNC_WORKER_ID_START,
 };
 use crate::supervisor::SyncSupervisor;
@@ -116,7 +116,7 @@ where
     NA: NewActor<RuntimeAccess = ThreadLocal>,
 {
     let (manager, sender, receiver) = Manager::new_small_channel();
-    let ctx = actor::Context::new_local(TEST_PID, receiver, runtime());
+    let ctx = actor::Context::new(TEST_PID, receiver, ThreadLocal::new(runtime()));
     let actor = new_actor.new(ctx, arg)?;
     Ok((actor, manager, ActorRef::local(sender)))
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -16,8 +16,7 @@ use std::stream::Stream;
 use std::task::{self, Poll};
 use std::time::{Duration, Instant};
 
-use crate::actor::ThreadLocal;
-use crate::rt::{self, PrivateAccess, ProcessId};
+use crate::rt::{self, PrivateAccess, ProcessId, ThreadLocal};
 use crate::{actor, RuntimeRef};
 
 /// Type returned when the deadline has passed.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -85,9 +85,9 @@ pub struct Timer {
 
 impl Timer {
     /// Create a new `Timer`.
-    pub fn at<M, K>(ctx: &mut actor::Context<M, K>, deadline: Instant) -> Timer
+    pub fn at<M, RT>(ctx: &mut actor::Context<M, RT>, deadline: Instant) -> Timer
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         let pid = ctx.pid();
         ctx.add_deadline(pid, deadline);
@@ -97,9 +97,9 @@ impl Timer {
     /// Create a new timer, based on a timeout.
     ///
     /// Same as calling `Timer::at(&mut ctx, Instant::now() + timeout)`.
-    pub fn after<M, K>(ctx: &mut actor::Context<M, K>, timeout: Duration) -> Timer
+    pub fn after<M, RT>(ctx: &mut actor::Context<M, RT>, timeout: Duration) -> Timer
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         Timer::at(ctx, Instant::now() + timeout)
     }
@@ -136,12 +136,12 @@ impl Future for Timer {
     }
 }
 
-impl<K> actor::Bound<K> for Timer {
+impl<RT> actor::Bound<RT> for Timer {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, K>) -> io::Result<()>
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         // We don't remove the original deadline and just let it expire, as
         // (currently) removing a deadline is an expensive operation.
@@ -224,9 +224,13 @@ pub struct Deadline<Fut> {
 
 impl<Fut> Deadline<Fut> {
     /// Create a new `Deadline`.
-    pub fn at<M, K>(ctx: &mut actor::Context<M, K>, deadline: Instant, future: Fut) -> Deadline<Fut>
+    pub fn at<M, RT>(
+        ctx: &mut actor::Context<M, RT>,
+        deadline: Instant,
+        future: Fut,
+    ) -> Deadline<Fut>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         let pid = ctx.pid();
         ctx.add_deadline(pid, deadline);
@@ -237,13 +241,13 @@ impl<Fut> Deadline<Fut> {
     ///
     /// Same as calling `Deadline::at(&mut ctx, Instant::now() + timeout,
     /// future)`.
-    pub fn after<M, K>(
-        ctx: &mut actor::Context<M, K>,
+    pub fn after<M, RT>(
+        ctx: &mut actor::Context<M, RT>,
         timeout: Duration,
         future: Fut,
     ) -> Deadline<Fut>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         Deadline::at(ctx, Instant::now() + timeout, future)
     }
@@ -313,12 +317,12 @@ where
     }
 }
 
-impl<Fut, K> actor::Bound<K> for Deadline<Fut> {
+impl<Fut, RT> actor::Bound<RT> for Deadline<Fut> {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, K>) -> io::Result<()>
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
     where
-        actor::Context<M, K>: rt::Access,
+        actor::Context<M, RT>: rt::Access,
     {
         // We don't remove the original deadline and just let it expire, as
         // (currently) removing a deadline is an expensive operation.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -176,8 +176,9 @@ impl<RT> actor::Bound<RT> for Timer {
 /// use std::time::Duration;
 /// # use std::time::Instant;
 ///
-/// use heph::actor::{self, ThreadSafe};
+/// use heph::actor;
 /// # use heph::supervisor::NoSupervisor;
+/// use heph::rt::ThreadSafe;
 /// # use heph::{rt, ActorOptions, Runtime};
 /// use heph::timer::Deadline;
 ///

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -16,8 +16,8 @@ use std::stream::Stream;
 use std::task::{self, Poll};
 use std::time::{Duration, Instant};
 
-use crate::rt::{self, PrivateAccess, ProcessId, ThreadLocal};
-use crate::{actor, RuntimeRef};
+use crate::actor;
+use crate::rt::{self, PrivateAccess, ProcessId, RuntimeRef, ThreadLocal};
 
 /// Type returned when the deadline has passed.
 ///

--- a/tests/functional/actor_context.rs
+++ b/tests/functional/actor_context.rs
@@ -5,7 +5,7 @@
 use std::pin::Pin;
 use std::task::Poll;
 
-use heph::actor::{self, NoMessages, RecvError};
+use heph::actor::{self, NoMessages, RecvError, Spawn};
 use heph::rt::{ActorOptions, Runtime, Signal, ThreadSafe};
 use heph::supervisor::NoSupervisor;
 use heph::test::{init_local_actor, poll_actor};

--- a/tests/functional/actor_context.rs
+++ b/tests/functional/actor_context.rs
@@ -5,8 +5,8 @@
 use std::pin::Pin;
 use std::task::Poll;
 
-use heph::actor::{self, NoMessages, RecvError, ThreadSafe};
-use heph::rt::{ActorOptions, Runtime, Signal};
+use heph::actor::{self, NoMessages, RecvError};
+use heph::rt::{ActorOptions, Runtime, Signal, ThreadSafe};
 use heph::supervisor::NoSupervisor;
 use heph::test::{init_local_actor, poll_actor};
 

--- a/tests/functional/restart_supervisor.rs
+++ b/tests/functional/restart_supervisor.rs
@@ -189,11 +189,11 @@ impl NewActor for NewActorImpl {
     type Argument = bool;
     type Actor = ActorImpl;
     type Error = &'static str;
-    type Context = ThreadSafe;
+    type RuntimeAccess = ThreadSafe;
 
     fn new(
         &mut self,
-        _: actor::Context<Self::Message, Self::Context>,
+        _: actor::Context<Self::Message, Self::RuntimeAccess>,
         _: Self::Argument,
     ) -> Result<Self::Actor, Self::Error> {
         unimplemented!()

--- a/tests/functional/restart_supervisor.rs
+++ b/tests/functional/restart_supervisor.rs
@@ -10,8 +10,8 @@ use std::task::{self, Poll};
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, ThreadSafe};
-use heph::{restart_supervisor, Actor, NewActor, Supervisor, SupervisorStrategy};
+use heph::rt::ThreadSafe;
+use heph::{actor, restart_supervisor, Actor, NewActor, Supervisor, SupervisorStrategy};
 
 // NOTE: keep in sync with the documentation.
 const DEFAULT_MAX_RESTARTS: usize = 5;

--- a/tests/functional/runtime.rs
+++ b/tests/functional/runtime.rs
@@ -7,9 +7,9 @@ use std::task::{self, Poll};
 use std::thread::{self, sleep};
 use std::time::Duration;
 
-use heph::actor::{self, SyncContext, ThreadLocal, ThreadSafe};
+use heph::actor::{self, SyncContext, ThreadSafe};
 use heph::rt::options::{ActorOptions, Priority, SyncActorOptions};
-use heph::rt::Runtime;
+use heph::rt::{Runtime, ThreadLocal};
 use heph::supervisor::NoSupervisor;
 
 use crate::util::temp_file;
@@ -35,11 +35,11 @@ fn auto_cpu_affinity() {
     use socket2::SockRef;
 
     use heph::actor::messages::Terminate;
-    use heph::actor::{self, ThreadLocal};
     use heph::net::tcp::server;
     use heph::net::{TcpServer, TcpStream};
+    use heph::rt::{ActorOptions, RuntimeRef, ThreadLocal};
     use heph::supervisor::{Supervisor, SupervisorStrategy};
-    use heph::{ActorOptions, ActorRef, NewActor, RuntimeRef};
+    use heph::{actor, ActorRef, NewActor};
 
     fn cpu_affinity(stream: &TcpStream) -> io::Result<usize> {
         // TODO: do this better.

--- a/tests/functional/runtime.rs
+++ b/tests/functional/runtime.rs
@@ -94,7 +94,7 @@ fn auto_cpu_affinity() {
     impl<S, NA> Supervisor<server::Setup<S, NA>> for ServerSupervisor
     where
         S: Supervisor<NA> + Clone + 'static,
-        NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, Context = ThreadLocal>
+        NA: NewActor<Argument = (TcpStream, SocketAddr), Error = !, RuntimeAccess = ThreadLocal>
             + Clone
             + 'static,
     {

--- a/tests/functional/runtime.rs
+++ b/tests/functional/runtime.rs
@@ -7,9 +7,9 @@ use std::task::{self, Poll};
 use std::thread::{self, sleep};
 use std::time::Duration;
 
-use heph::actor::{self, SyncContext, ThreadSafe};
+use heph::actor::{self, SyncContext};
 use heph::rt::options::{ActorOptions, Priority, SyncActorOptions};
-use heph::rt::{Runtime, ThreadLocal};
+use heph::rt::{Runtime, ThreadLocal, ThreadSafe};
 use heph::supervisor::NoSupervisor;
 
 use crate::util::temp_file;

--- a/tests/functional/test.rs
+++ b/tests/functional/test.rs
@@ -25,11 +25,11 @@ fn test_size_of_actor() {
         type Argument = ();
         type Actor = A;
         type Error = !;
-        type Context = ThreadLocal;
+        type RuntimeAccess = ThreadLocal;
 
         fn new(
             &mut self,
-            _: actor::Context<Self::Message, Self::Context>,
+            _: actor::Context<Self::Message, Self::RuntimeAccess>,
             _: Self::Argument,
         ) -> Result<Self::Actor, Self::Error> {
             Ok(A)

--- a/tests/functional/test.rs
+++ b/tests/functional/test.rs
@@ -4,7 +4,8 @@ use std::mem::size_of;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use heph::actor::{self, Actor, NewActor, ThreadLocal};
+use heph::actor::{self, Actor, NewActor};
+use heph::rt::ThreadLocal;
 use heph::test::{size_of_actor, size_of_actor_val};
 
 #[test]

--- a/tests/functional/udp.rs
+++ b/tests/functional/udp.rs
@@ -9,8 +9,9 @@ use std::task::Poll;
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, Actor, NewActor, ThreadLocal};
+use heph::actor::{self, Actor, NewActor};
 use heph::net::UdpSocket;
+use heph::rt::ThreadLocal;
 use heph::test::{init_local_actor, poll_actor};
 
 use crate::util::{any_local_address, any_local_ipv6_address};

--- a/tests/functional/udp.rs
+++ b/tests/functional/udp.rs
@@ -45,7 +45,7 @@ fn connected_ipv6() {
 
 fn test<NA>(local_address: SocketAddr, new_actor: NA)
 where
-    NA: NewActor<Argument = SocketAddr, Error = !, Context = ThreadLocal>,
+    NA: NewActor<Argument = SocketAddr, Error = !, RuntimeAccess = ThreadLocal>,
     <NA as NewActor>::Actor: Actor<Error = io::Error>,
 {
     let echo_socket = std::net::UdpSocket::bind(local_address).unwrap();
@@ -312,7 +312,7 @@ async fn connected_vectored_io_actor(
 
 fn test_vectored_io<NA>(local_address: SocketAddr, new_actor: NA)
 where
-    NA: NewActor<Argument = SocketAddr, Error = !, Context = ThreadLocal>,
+    NA: NewActor<Argument = SocketAddr, Error = !, RuntimeAccess = ThreadLocal>,
     <NA as NewActor>::Actor: Actor<Error = io::Error>,
 {
     let echo_socket = std::net::UdpSocket::bind(local_address).unwrap();


### PR DESCRIPTION
Renames `actor::Context` to `actor::RuntimeAccess`

The original Context name was quite misleading as it was just a part of
the `actor::Context`. The new runtime `RuntimeAccess`, with generic
parameter name RT, is a better fit as it indicates what kind of runtime
access the actor needs.

Renames `rt::process::ContextKind` to `RuntimeSupport`
Moves `actor::ThreadSafe` to `rt::access::ThreadSafe`.
Moves `actor::ThreadLocal` to `rt::access::ThreadLocal`.

Removes `actor::Context::(try_)spawn` for `ThreadSafe`

This is already implemented via the Spawn trait. So all users have to do
is `use heph::actor::Spawn` and they have the same functionality.

Finally it changes `actor::Context::runtime` to return the generic parameter

For `ThreadLocal` this doesn't change must as Deref(Mut)<Target = RuntimeRef> is
implemented for `ThreadLocal`.
