### PR TITLE
Improve timer usability

### DIFF
--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -222,6 +222,10 @@ where
         self.rt.remove_deadline(pid, deadline)
     }
 
+    fn change_deadline(&mut self, from: ProcessId, to: ProcessId, deadline: Instant) {
+        self.rt.change_deadline(from, to, deadline);
+    }
+
     fn cpu(&self) -> Option<usize> {
         self.rt.cpu()
     }

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -218,6 +218,10 @@ where
         self.rt.add_deadline(pid, deadline)
     }
 
+    fn remove_deadline(&mut self, pid: ProcessId, deadline: Instant) {
+        self.rt.remove_deadline(pid, deadline)
+    }
+
     fn cpu(&self) -> Option<usize> {
         self.rt.cpu()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@
     array_methods,
     async_stream,
     available_concurrency,
+    binary_heap_retain,
     const_fn,
     const_option,
     const_raw_ptr_to_usize_cast,

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -45,6 +45,9 @@ pub trait PrivateAccess {
     /// Remove a deadline for `pid` at `deadline`.
     fn remove_deadline(&mut self, pid: ProcessId, deadline: Instant);
 
+    /// Changes the pid `from` `to` another, keeping the same deadline.
+    fn change_deadline(&mut self, from: ProcessId, to: ProcessId, deadline: Instant);
+
     /// Returns the CPU the thread is bound to, if any.
     fn cpu(&self) -> Option<usize>;
 }
@@ -110,6 +113,10 @@ impl PrivateAccess for ThreadLocal {
 
     fn remove_deadline(&mut self, pid: ProcessId, deadline: Instant) {
         self.rt.remove_deadline(pid, deadline);
+    }
+
+    fn change_deadline(&mut self, from: ProcessId, to: ProcessId, deadline: Instant) {
+        self.rt.change_deadline(from, to, deadline);
     }
 
     fn cpu(&self) -> Option<usize> {
@@ -188,6 +195,10 @@ impl PrivateAccess for ThreadSafe {
 
     fn remove_deadline(&mut self, pid: ProcessId, deadline: Instant) {
         self.rt.remove_deadline(pid, deadline);
+    }
+
+    fn change_deadline(&mut self, from: ProcessId, to: ProcessId, deadline: Instant) {
+        self.rt.change_deadline(from, to, deadline);
     }
 
     fn cpu(&self) -> Option<usize> {

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -42,6 +42,9 @@ pub trait PrivateAccess {
     /// Add a deadline for `pid` at `deadline`.
     fn add_deadline(&mut self, pid: ProcessId, deadline: Instant);
 
+    /// Remove a deadline for `pid` at `deadline`.
+    fn remove_deadline(&mut self, pid: ProcessId, deadline: Instant);
+
     /// Returns the CPU the thread is bound to, if any.
     fn cpu(&self) -> Option<usize>;
 }
@@ -103,6 +106,10 @@ impl PrivateAccess for ThreadLocal {
 
     fn add_deadline(&mut self, pid: ProcessId, deadline: Instant) {
         self.rt.add_deadline(pid, deadline)
+    }
+
+    fn remove_deadline(&mut self, pid: ProcessId, deadline: Instant) {
+        self.rt.remove_deadline(pid, deadline);
     }
 
     fn cpu(&self) -> Option<usize> {
@@ -177,6 +184,10 @@ impl PrivateAccess for ThreadSafe {
 
     fn add_deadline(&mut self, pid: ProcessId, deadline: Instant) {
         self.rt.add_deadline(pid, deadline)
+    }
+
+    fn remove_deadline(&mut self, pid: ProcessId, deadline: Instant) {
+        self.rt.remove_deadline(pid, deadline);
     }
 
     fn cpu(&self) -> Option<usize> {

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -59,6 +59,7 @@ pub trait PrivateAccess {
 /// to move between threads.
 ///
 /// [`actor::Context`]: crate::actor::Context
+#[derive(Clone)]
 pub struct ThreadLocal {
     rt: RuntimeRef,
 }
@@ -146,6 +147,7 @@ impl fmt::Debug for ThreadLocal {
 /// information.
 ///
 /// [`actor::Context`]: crate::actor::Context
+#[derive(Clone)]
 pub struct ThreadSafe {
     rt: Arc<shared::RuntimeInternals>,
 }

--- a/src/rt/local/mod.rs
+++ b/src/rt/local/mod.rs
@@ -323,7 +323,7 @@ impl Runtime {
         let timing = trace::start(&self.trace_log);
 
         let mut amount = 0;
-        while let Some(pid) = self.internals.shared.remove_deadline(Instant::now()) {
+        while let Some(pid) = self.internals.shared.remove_next_deadline(Instant::now()) {
             self.internals.shared.mark_ready(pid);
             amount += 1;
         }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -532,7 +532,7 @@ impl RuntimeRef {
     }
 
     /// Add a deadline.
-    pub(crate) fn add_deadline(&mut self, pid: ProcessId, deadline: Instant) {
+    fn add_deadline(&mut self, pid: ProcessId, deadline: Instant) {
         trace!("adding deadline: pid={}, deadline={:?}", pid, deadline);
         self.internals
             .timers
@@ -547,6 +547,20 @@ impl RuntimeRef {
             .timers
             .borrow_mut()
             .remove_deadline(pid, deadline);
+    }
+
+    /// Change the `ProcessId` of a deadline.
+    fn change_deadline(&mut self, from: ProcessId, to: ProcessId, deadline: Instant) {
+        trace!(
+            "changing deadline: new_pid={}, old_pid={}, deadline={:?}",
+            from,
+            to,
+            deadline
+        );
+        self.internals
+            .timers
+            .borrow_mut()
+            .change_deadline(from, to, deadline);
     }
 
     /// Returns a copy of the shared internals.

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -531,15 +531,22 @@ impl RuntimeRef {
         self.internals.shared.new_task_waker(pid)
     }
 
-    /// Add a deadline to the event sources.
-    ///
-    /// This is used in the `timer` crate.
+    /// Add a deadline.
     pub(crate) fn add_deadline(&mut self, pid: ProcessId, deadline: Instant) {
         trace!("adding deadline: pid={}, deadline={:?}", pid, deadline);
         self.internals
             .timers
             .borrow_mut()
             .add_deadline(pid, deadline);
+    }
+
+    /// Remove a deadline.
+    fn remove_deadline(&mut self, pid: ProcessId, deadline: Instant) {
+        trace!("removing deadline: pid={}, deadline={:?}", pid, deadline);
+        self.internals
+            .timers
+            .borrow_mut()
+            .remove_deadline(pid, deadline);
     }
 
     /// Returns a copy of the shared internals.

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -94,12 +94,19 @@ impl RuntimeInternals {
         self.registry.reregister(source, token, interest)
     }
 
-    pub(crate) fn add_deadline(&self, pid: ProcessId, deadline: Instant) {
+    pub(super) fn add_deadline(&self, pid: ProcessId, deadline: Instant) {
         self.timers.lock().unwrap().add_deadline(pid, deadline);
     }
 
-    pub(crate) fn remove_deadline(&self, pid: ProcessId, deadline: Instant) {
+    pub(super) fn remove_deadline(&self, pid: ProcessId, deadline: Instant) {
         self.timers.lock().unwrap().remove_deadline(pid, deadline);
+    }
+
+    pub(super) fn change_deadline(&self, from: ProcessId, to: ProcessId, deadline: Instant) {
+        self.timers
+            .lock()
+            .unwrap()
+            .change_deadline(from, to, deadline);
     }
 
     #[allow(clippy::needless_pass_by_value)] // For `ActorOptions`.

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -98,6 +98,10 @@ impl RuntimeInternals {
         self.timers.lock().unwrap().add_deadline(pid, deadline);
     }
 
+    pub(crate) fn remove_deadline(&self, pid: ProcessId, deadline: Instant) {
+        self.timers.lock().unwrap().remove_deadline(pid, deadline);
+    }
+
     #[allow(clippy::needless_pass_by_value)] // For `ActorOptions`.
     pub(crate) fn spawn_setup<S, NA, ArgFn, ArgFnE>(
         self: &Arc<Self>,
@@ -230,7 +234,7 @@ impl RuntimeInternals {
     }
 
     /// See [`Timers::remove_deadline`].
-    pub(crate) fn remove_deadline(&self, now: Instant) -> Option<ProcessId> {
-        self.timers.lock().unwrap().remove_deadline(now)
+    pub(crate) fn remove_next_deadline(&self, now: Instant) -> Option<ProcessId> {
+        self.timers.lock().unwrap().remove_next_deadline(now)
     }
 }

--- a/src/rt/timers.rs
+++ b/src/rt/timers.rs
@@ -57,6 +57,12 @@ impl Timers {
         });
     }
 
+    /// Change the `ProcessId` of a previously added deadline.
+    pub(super) fn change_deadline(&mut self, from: ProcessId, to: ProcessId, deadline: Instant) {
+        self.remove_deadline(from, deadline);
+        self.add_deadline(to, deadline);
+    }
+
     /// Returns all deadlines that have expired (i.e. deadline < now).
     pub(super) fn deadlines(&mut self) -> Deadlines<'_> {
         Deadlines {

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,6 +22,7 @@ use std::future::Future;
 use std::lazy::SyncLazy;
 use std::mem::size_of;
 use std::pin::Pin;
+use std::stream::Stream;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{self, Poll};
@@ -179,6 +180,23 @@ where
     let waker = runtime().new_local_task_waker(TEST_PID);
     let mut ctx = task::Context::from_waker(&waker);
     Future::poll(future, &mut ctx)
+}
+
+/// Poll a stream.
+///
+/// The [`task::Context`] will be provided by the *test* runtime.
+///
+/// # Notes
+///
+/// Wake notifications will be ignored, if this is required run an end to end
+/// test with a completely functional runtime instead.
+pub fn poll_next<S>(stream: Pin<&mut S>) -> Poll<Option<S::Item>>
+where
+    S: Stream + ?Sized,
+{
+    let waker = runtime().new_local_task_waker(TEST_PID);
+    let mut ctx = task::Context::from_waker(&waker);
+    Stream::poll_next(stream, &mut ctx)
 }
 
 /// Poll an actor.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -151,6 +151,8 @@ impl<RT: rt::Access> Future for Timer<RT> {
     }
 }
 
+impl<RT: rt::Access> Unpin for Timer<RT> {}
+
 impl<RT: rt::Access> actor::Bound<RT> for Timer<RT> {
     type Error = io::Error;
 
@@ -353,6 +355,8 @@ where
     }
 }
 
+impl<Fut: Unpin, RT: rt::Access> Unpin for Deadline<Fut, RT> {}
+
 impl<Fut, RT: rt::Access> actor::Bound<RT> for Deadline<Fut, RT> {
     type Error = io::Error;
 
@@ -460,10 +464,7 @@ impl<RT: rt::Access> Interval<RT> {
     }
 }
 
-impl<RT: rt::Access> Stream for Interval<RT>
-where
-    RT: Unpin,
-{
+impl<RT: rt::Access> Stream for Interval<RT> {
     type Item = DeadlinePassed;
 
     fn poll_next(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
@@ -479,6 +480,8 @@ where
         }
     }
 }
+
+impl<RT: rt::Access> Unpin for Interval<RT> {}
 
 impl<RT: rt::Access> actor::Bound<RT> for Interval<RT> {
     type Error = !;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -400,7 +400,7 @@ impl Interval {
     /// Create a new `Interval`.
     pub fn every<M>(ctx: &mut actor::Context<M>, interval: Duration) -> Interval {
         let deadline = Instant::now() + interval;
-        let mut runtime_ref = ctx.runtime().clone();
+        let mut runtime_ref = (**ctx.runtime()).clone();
         let pid = ctx.pid();
         runtime_ref.add_deadline(pid, deadline);
         Interval {
@@ -441,7 +441,7 @@ impl actor::Bound<ThreadLocal> for Interval {
         // We don't remove the original deadline and just let it expire, as
         // (currently) removing a deadline is an expensive operation.
         let pid = ctx.pid();
-        let mut runtime_ref = ctx.runtime().clone();
+        let mut runtime_ref = (**ctx.runtime()).clone();
         runtime_ref.add_deadline(pid, self.deadline);
         self.pid = pid;
         self.runtime_ref = runtime_ref;

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1,6 +1,12 @@
 //! Functional tests.
 
-#![feature(drain_filter, never_type, maybe_uninit_slice, write_all_vectored)]
+#![feature(
+    async_stream,
+    drain_filter,
+    maybe_uninit_slice,
+    never_type,
+    write_all_vectored
+)]
 
 #[path = "util/mod.rs"] // rustfmt can't find the file.
 #[macro_use]

--- a/tests/functional/tcp/listener.rs
+++ b/tests/functional/tcp/listener.rs
@@ -76,9 +76,9 @@ fn ttl() {
 
 const DATA: &[u8] = b"Hello world";
 
-async fn stream_actor<K>(mut ctx: actor::Context<SocketAddr, K>)
+async fn stream_actor<RT>(mut ctx: actor::Context<SocketAddr, RT>)
 where
-    actor::Context<SocketAddr, K>: rt::Access,
+    actor::Context<SocketAddr, RT>: rt::Access,
 {
     let address = ctx.receive_next().await.unwrap();
     let mut stream = TcpStream::connect(&mut ctx, address)
@@ -207,19 +207,19 @@ fn incoming() {
 
 #[test]
 fn actor_bound() {
-    async fn listener_actor1<K>(mut ctx: actor::Context<!, K>, actor_ref: ActorRef<TcpListener>)
+    async fn listener_actor1<RT>(mut ctx: actor::Context<!, RT>, actor_ref: ActorRef<TcpListener>)
     where
-        actor::Context<!, K>: rt::Access,
+        actor::Context<!, RT>: rt::Access,
     {
         let listener = TcpListener::bind(&mut ctx, any_local_address()).unwrap();
         actor_ref.send(listener).await.unwrap();
     }
 
-    async fn listener_actor2<K>(
-        mut ctx: actor::Context<TcpListener, K>,
+    async fn listener_actor2<RT>(
+        mut ctx: actor::Context<TcpListener, RT>,
         actor_ref: ActorRef<SocketAddr>,
     ) where
-        actor::Context<TcpListener, K>: rt::Access,
+        actor::Context<TcpListener, RT>: rt::Access,
     {
         let mut listener = ctx.receive_next().await.unwrap();
         listener.bind_to(&mut ctx).unwrap();

--- a/tests/functional/tcp/server.rs
+++ b/tests/functional/tcp/server.rs
@@ -55,9 +55,9 @@ where
     }
 }
 
-async fn actor<K>(_: actor::Context<!, K>, mut stream: TcpStream, _: SocketAddr)
+async fn actor<RT>(_: actor::Context<!, RT>, mut stream: TcpStream, _: SocketAddr)
 where
-    actor::Context<SocketAddr, K>: rt::Access,
+    actor::Context<SocketAddr, RT>: rt::Access,
 {
     let mut buf = Vec::with_capacity(DATA.len() + 1);
     let n = stream.recv(&mut buf).await.unwrap();
@@ -67,12 +67,12 @@ where
 
 const DATA: &[u8] = b"Hello world";
 
-async fn stream_actor<K>(
-    mut ctx: actor::Context<!, K>,
+async fn stream_actor<RT>(
+    mut ctx: actor::Context<!, RT>,
     address: SocketAddr,
     actor_ref: ActorRef<server::Message>,
 ) where
-    actor::Context<!, K>: rt::Access,
+    actor::Context<!, RT>: rt::Access,
 {
     let mut stream = TcpStream::connect(&mut ctx, address)
         .unwrap()
@@ -183,11 +183,11 @@ fn new_actor_error() {
         }
     }
 
-    struct NewActorErrorGenerator<K>(PhantomData<*const K>);
+    struct NewActorErrorGenerator<RT>(PhantomData<*const RT>);
 
-    impl<K> Copy for NewActorErrorGenerator<K> {}
+    impl<RT> Copy for NewActorErrorGenerator<RT> {}
 
-    impl<K> Clone for NewActorErrorGenerator<K> {
+    impl<RT> Clone for NewActorErrorGenerator<RT> {
         fn clone(&self) -> Self {
             *self
         }
@@ -255,9 +255,9 @@ fn new_actor_error() {
     let (server_actor, _) = init_local_actor(server, ()).unwrap();
     let server_actor: Box<dyn Actor<Error = !>> = Box::new(ServerWrapper(server_actor));
 
-    async fn stream_actor<K>(mut ctx: actor::Context<!, K>, address: SocketAddr)
+    async fn stream_actor<RT>(mut ctx: actor::Context<!, RT>, address: SocketAddr)
     where
-        actor::Context<!, K>: rt::Access,
+        actor::Context<!, RT>: rt::Access,
     {
         let stream = TcpStream::connect(&mut ctx, address)
             .unwrap()

--- a/tests/functional/timer.rs
+++ b/tests/functional/timer.rs
@@ -138,7 +138,7 @@ fn triggered_timers_run_actors() {
 
     async fn deadline_actor<RT>(mut ctx: actor::Context<!, RT>)
     where
-        actor::Context<!, RT>: rt::Access,
+        RT: rt::Access + Clone,
     {
         let future = AlwaysPending;
         let deadline = Deadline::after(&mut ctx, TIMEOUT, future);
@@ -215,18 +215,18 @@ fn timers_actor_bound() {
 
     async fn deadline_actor1<RT>(
         mut ctx: actor::Context<!, RT>,
-        actor_ref: ActorRef<Deadline<AlwaysPending>>,
+        actor_ref: ActorRef<Deadline<AlwaysPending, RT>>,
     ) where
-        actor::Context<!, RT>: rt::Access,
+        RT: rt::Access + Clone,
     {
         let future = AlwaysPending;
         let deadline = Deadline::after(&mut ctx, TIMEOUT, future);
         actor_ref.send(deadline).await.unwrap();
     }
 
-    async fn deadline_actor2<RT>(mut ctx: actor::Context<Deadline<AlwaysPending>, RT>)
+    async fn deadline_actor2<RT>(mut ctx: actor::Context<Deadline<AlwaysPending, RT>, RT>)
     where
-        actor::Context<Deadline<AlwaysPending>, RT>: rt::Access,
+        RT: rt::Access,
     {
         let mut deadline = ctx.receive_next().await.unwrap();
         deadline.bind_to(&mut ctx).unwrap();

--- a/tests/functional/timer.rs
+++ b/tests/functional/timer.rs
@@ -128,17 +128,17 @@ fn interval() {
 
 #[test]
 fn triggered_timers_run_actors() {
-    async fn timer_actor<K>(mut ctx: actor::Context<!, K>)
+    async fn timer_actor<RT>(mut ctx: actor::Context<!, RT>)
     where
-        actor::Context<!, K>: rt::Access,
+        actor::Context<!, RT>: rt::Access,
     {
         let timer = Timer::after(&mut ctx, TIMEOUT);
         let _ = timer.await;
     }
 
-    async fn deadline_actor<K>(mut ctx: actor::Context<!, K>)
+    async fn deadline_actor<RT>(mut ctx: actor::Context<!, RT>)
     where
-        actor::Context<!, K>: rt::Access,
+        actor::Context<!, RT>: rt::Access,
     {
         let future = AlwaysPending;
         let deadline = Deadline::after(&mut ctx, TIMEOUT, future);
@@ -196,37 +196,37 @@ fn triggered_timers_run_actors() {
 
 #[test]
 fn timers_actor_bound() {
-    async fn timer_actor1<K>(mut ctx: actor::Context<!, K>, actor_ref: ActorRef<Timer>)
+    async fn timer_actor1<RT>(mut ctx: actor::Context<!, RT>, actor_ref: ActorRef<Timer>)
     where
-        actor::Context<!, K>: rt::Access,
+        actor::Context<!, RT>: rt::Access,
     {
         let timer = Timer::after(&mut ctx, TIMEOUT);
         actor_ref.send(timer).await.unwrap();
     }
 
-    async fn timer_actor2<K>(mut ctx: actor::Context<Timer, K>)
+    async fn timer_actor2<RT>(mut ctx: actor::Context<Timer, RT>)
     where
-        actor::Context<Timer, K>: rt::Access,
+        actor::Context<Timer, RT>: rt::Access,
     {
         let mut timer = ctx.receive_next().await.unwrap();
         timer.bind_to(&mut ctx).unwrap();
         let _ = timer.await;
     }
 
-    async fn deadline_actor1<K>(
-        mut ctx: actor::Context<!, K>,
+    async fn deadline_actor1<RT>(
+        mut ctx: actor::Context<!, RT>,
         actor_ref: ActorRef<Deadline<AlwaysPending>>,
     ) where
-        actor::Context<!, K>: rt::Access,
+        actor::Context<!, RT>: rt::Access,
     {
         let future = AlwaysPending;
         let deadline = Deadline::after(&mut ctx, TIMEOUT, future);
         actor_ref.send(deadline).await.unwrap();
     }
 
-    async fn deadline_actor2<K>(mut ctx: actor::Context<Deadline<AlwaysPending>, K>)
+    async fn deadline_actor2<RT>(mut ctx: actor::Context<Deadline<AlwaysPending>, RT>)
     where
-        actor::Context<Deadline<AlwaysPending>, K>: rt::Access,
+        actor::Context<Deadline<AlwaysPending>, RT>: rt::Access,
     {
         let mut deadline = ctx.receive_next().await.unwrap();
         deadline.bind_to(&mut ctx).unwrap();

--- a/tests/functional/timer.rs
+++ b/tests/functional/timer.rs
@@ -130,7 +130,7 @@ fn interval() {
 fn triggered_timers_run_actors() {
     async fn timer_actor<RT>(mut ctx: actor::Context<!, RT>)
     where
-        actor::Context<!, RT>: rt::Access,
+        RT: rt::Access + Clone,
     {
         let timer = Timer::after(&mut ctx, TIMEOUT);
         let _ = timer.await;
@@ -196,17 +196,17 @@ fn triggered_timers_run_actors() {
 
 #[test]
 fn timers_actor_bound() {
-    async fn timer_actor1<RT>(mut ctx: actor::Context<!, RT>, actor_ref: ActorRef<Timer>)
+    async fn timer_actor1<RT>(mut ctx: actor::Context<!, RT>, actor_ref: ActorRef<Timer<RT>>)
     where
-        actor::Context<!, RT>: rt::Access,
+        RT: rt::Access + Clone,
     {
         let timer = Timer::after(&mut ctx, TIMEOUT);
         actor_ref.send(timer).await.unwrap();
     }
 
-    async fn timer_actor2<RT>(mut ctx: actor::Context<Timer, RT>)
+    async fn timer_actor2<RT>(mut ctx: actor::Context<Timer<RT>, RT>)
     where
-        actor::Context<Timer, RT>: rt::Access,
+        RT: rt::Access + Clone,
     {
         let mut timer = ctx.receive_next().await.unwrap();
         timer.bind_to(&mut ctx).unwrap();


### PR DESCRIPTION
TODO:

* [x] Tests that the timers don't trigger after dropping, for `Timer`, `Deadline` and `Interval`.
* [x] Tests that the timers don't trigger after binding to another actor, for `Timer`, `Deadline` and `Interval`.
* [x] Review testing of `Timer::wrap`, now it's a bit more complex.

Changes:

* Implements `Clone` for `ThreadLocal` and `ThreadSafe`.
* Remove timer from `Timer`, `Deadline` and `Interval` on `Drop`.
* Add support for thread-safe actors in `Interval`.

Adds  `rt::PrivateAccess::change_deadline` for changing an existing deadline, as
using by the `actor::Bound` implementations in the `timer` module. The current
implementation is removing and than adding the timer, but in the future this can
be improved.

Closes #315.
Closes #282.