### PR TITLE
Remove trait requirement from actor::Bound

### DIFF
--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -139,8 +139,6 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use crate::rt;
-
 mod context;
 pub mod messages;
 mod spawn;
@@ -709,7 +707,5 @@ pub trait Bound<RT> {
     type Error;
 
     /// Bind a type to the [`Actor`] that owns the `ctx`.
-    fn bind_to<M>(&mut self, ctx: &mut Context<M, RT>) -> Result<(), Self::Error>
-    where
-        Context<M, RT>: rt::Access;
+    fn bind_to<M>(&mut self, ctx: &mut Context<M, RT>) -> Result<(), Self::Error>;
 }

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -321,13 +321,10 @@ impl<'a> Stream for Incoming<'a> {
     }
 }
 
-impl<RT> actor::Bound<RT> for TcpListener {
+impl<RT: rt::Access> actor::Bound<RT> for TcpListener {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
-    where
-        actor::Context<M, RT>: rt::Access,
-    {
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {
         let pid = ctx.pid();
         ctx.reregister(&mut self.socket, pid.into(), Interest::READABLE)
     }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -783,13 +783,10 @@ where
     }
 }
 
-impl<RT> actor::Bound<RT> for TcpStream {
+impl<RT: rt::Access> actor::Bound<RT> for TcpStream {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
-    where
-        actor::Context<M, RT>: rt::Access,
-    {
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {
         let pid = ctx.pid();
         ctx.reregister(
             &mut self.socket,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -849,13 +849,10 @@ impl<M> fmt::Debug for UdpSocket<M> {
     }
 }
 
-impl<RT> actor::Bound<RT> for UdpSocket {
+impl<RT: rt::Access> actor::Bound<RT> for UdpSocket {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
-    where
-        actor::Context<M, RT>: rt::Access,
-    {
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {
         ctx.reregister(
             &mut self.socket,
             ctx.pid().into(),

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -156,10 +156,7 @@ impl<RT: rt::Access> Unpin for Timer<RT> {}
 impl<RT: rt::Access> actor::Bound<RT> for Timer<RT> {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
-    where
-        actor::Context<M, RT>: rt::Access,
-    {
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {
         let old = replace(&mut self.pid, ctx.pid());
         self.rt.change_deadline(old, self.pid, self.deadline);
         Ok(())
@@ -360,10 +357,7 @@ impl<Fut: Unpin, RT: rt::Access> Unpin for Deadline<Fut, RT> {}
 impl<Fut, RT: rt::Access> actor::Bound<RT> for Deadline<Fut, RT> {
     type Error = io::Error;
 
-    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()>
-    where
-        actor::Context<M, RT>: rt::Access,
-    {
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {
         let old = replace(&mut self.pid, ctx.pid());
         self.rt.change_deadline(old, self.pid, self.deadline);
         Ok(())

--- a/tests/functional/tcp/listener.rs
+++ b/tests/functional/tcp/listener.rs
@@ -219,7 +219,7 @@ fn actor_bound() {
         mut ctx: actor::Context<TcpListener, RT>,
         actor_ref: ActorRef<SocketAddr>,
     ) where
-        actor::Context<TcpListener, RT>: rt::Access,
+        RT: rt::Access,
     {
         let mut listener = ctx.receive_next().await.unwrap();
         listener.bind_to(&mut ctx).unwrap();


### PR DESCRIPTION
This is now moved to the implementation sites.

This is another step in removing references to the rt module from the
actor module.