### PR TITLE
Add ability to spawn Futures to the runtime

### DIFF
--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -2,6 +2,7 @@
 //!
 //! [`rt::Access`]: crate::rt::Access
 
+use std::future::Future;
 use std::mem::replace;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -14,7 +15,7 @@ use crate::actor::{self, NewActor};
 use crate::actor_ref::ActorRef;
 use crate::rt::process::ProcessId;
 use crate::rt::{shared, RuntimeRef};
-use crate::spawn::{ActorOptions, AddActorError, PrivateSpawn, Spawn};
+use crate::spawn::{ActorOptions, AddActorError, FutureOptions, PrivateSpawn, Spawn};
 use crate::supervisor::Supervisor;
 
 /// Trait to indicate an API needs access to the Heph runtime.
@@ -198,6 +199,16 @@ pub struct ThreadSafe {
 impl ThreadSafe {
     pub(crate) const fn new(pid: ProcessId, rt: Arc<shared::RuntimeInternals>) -> ThreadSafe {
         ThreadSafe { pid, rt }
+    }
+
+    /// Spawn a thread-safe [`Future`].
+    ///
+    /// See [`RuntimeRef::spawn_future`] for more documentation.
+    pub fn spawn_future<Fut>(&mut self, future: Fut, options: FutureOptions)
+    where
+        Fut: Future<Output = ()> + Send + Sync + 'static,
+    {
+        self.rt.spawn_future(future, options)
     }
 }
 

--- a/src/rt/local/scheduler/mod.rs
+++ b/src/rt/local/scheduler/mod.rs
@@ -63,7 +63,7 @@ impl Scheduler {
         }
     }
 
-    pub(crate) fn add_future<Fut>(&mut self, future: Fut, priority: Priority, is_ready: bool)
+    pub(crate) fn add_future<Fut>(&mut self, future: Fut, priority: Priority)
     where
         Fut: Future<Output = ()> + 'static,
     {
@@ -75,11 +75,7 @@ impl Scheduler {
             "spawning thread-local future: pid={}",
             process.as_ref().id()
         );
-        if is_ready {
-            self.ready.push(process)
-        } else {
-            self.add_process(process)
-        }
+        self.ready.push(process)
     }
 
     /// Mark the process, with `pid`, as ready to run.

--- a/src/rt/local/scheduler/tests.rs
+++ b/src/rt/local/scheduler/tests.rs
@@ -343,7 +343,7 @@ fn assert_future_process_unmoved() {
     let mut runtime_ref = test::runtime();
 
     let future = AssertUnmoved::new(pending());
-    scheduler.add_future(future, Priority::NORMAL, true);
+    scheduler.add_future(future, Priority::NORMAL);
 
     // Run the process multiple times, ensure it's not moved in the process.
     let mut process = scheduler.next_process().unwrap();

--- a/src/rt/local/scheduler/tests.rs
+++ b/src/rt/local/scheduler/tests.rs
@@ -296,7 +296,7 @@ impl NewActor for TestAssertUnmovedNewActor {
 }
 
 #[test]
-fn assert_process_unmoved() {
+fn assert_actor_process_unmoved() {
     let mut scheduler = Scheduler::new();
     let mut runtime_ref = test::runtime();
 
@@ -315,6 +315,39 @@ fn assert_process_unmoved() {
 
     // Run the process multiple times, ensure it's not moved in the process.
     let mut process = scheduler.next_process().unwrap();
+    assert_eq!(
+        process.as_mut().run(&mut runtime_ref),
+        ProcessResult::Pending
+    );
+    scheduler.add_process(process);
+
+    scheduler.mark_ready(pid);
+    let mut process = scheduler.next_process().unwrap();
+    assert_eq!(
+        process.as_mut().run(&mut runtime_ref),
+        ProcessResult::Pending
+    );
+    scheduler.add_process(process);
+
+    scheduler.mark_ready(pid);
+    let mut process = scheduler.next_process().unwrap();
+    assert_eq!(
+        process.as_mut().run(&mut runtime_ref),
+        ProcessResult::Pending
+    );
+}
+
+#[test]
+fn assert_future_process_unmoved() {
+    let mut scheduler = Scheduler::new();
+    let mut runtime_ref = test::runtime();
+
+    let future = AssertUnmoved::new(pending());
+    scheduler.add_future(future, Priority::NORMAL, true);
+
+    // Run the process multiple times, ensure it's not moved in the process.
+    let mut process = scheduler.next_process().unwrap();
+    let pid = process.as_ref().id();
     assert_eq!(
         process.as_mut().run(&mut runtime_ref),
         ProcessResult::Pending

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -494,11 +494,10 @@ impl RuntimeRef {
     where
         Fut: Future<Output = ()> + 'static,
     {
-        self.internals.scheduler.borrow_mut().add_future(
-            future,
-            options.priority(),
-            options.is_ready(),
-        )
+        self.internals
+            .scheduler
+            .borrow_mut()
+            .add_future(future, options.priority())
     }
 
     /// Spawn a thread-safe [`Future`].

--- a/src/rt/process/actor.rs
+++ b/src/rt/process/actor.rs
@@ -25,7 +25,7 @@ pub(crate) struct ActorProcess<S, NA: NewActor> {
     actor: NA::Actor,
 }
 
-impl<'a, S, NA> ActorProcess<S, NA>
+impl<S, NA> ActorProcess<S, NA>
 where
     S: Supervisor<NA>,
     NA: NewActor,
@@ -97,7 +97,7 @@ where
     }
 }
 
-impl<'a, S, NA> Process for ActorProcess<S, NA>
+impl<S, NA> Process for ActorProcess<S, NA>
 where
     S: Supervisor<NA>,
     NA: NewActor,

--- a/src/rt/process/future.rs
+++ b/src/rt/process/future.rs
@@ -1,0 +1,49 @@
+//! Module containing the implementation of the [`Process`] trait for
+//! [`Future`]s.
+
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{self, Poll};
+
+use crate::rt::process::{Process, ProcessId, ProcessResult};
+use crate::rt::{self, RuntimeRef};
+
+/// A process that represent a [`Future`].
+pub(crate) struct FutureProcess<Fut, RT> {
+    future: Fut,
+    /// We need to know whether we need to create thread-local or thread-safe
+    /// waker.
+    _phantom: PhantomData<RT>,
+}
+
+impl<Fut, RT> FutureProcess<Fut, RT> {
+    pub(crate) const fn new(future: Fut) -> FutureProcess<Fut, RT> {
+        FutureProcess {
+            future,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Fut, RT> Process for FutureProcess<Fut, RT>
+where
+    Fut: Future<Output = ()>,
+    RT: rt::Access,
+{
+    fn name(&self) -> &'static str {
+        "Future"
+    }
+
+    fn run(self: Pin<&mut Self>, runtime_ref: &mut RuntimeRef, pid: ProcessId) -> ProcessResult {
+        // This is safe because we're not moving the future.
+        let future = unsafe { Pin::map_unchecked_mut(self, |this| &mut this.future) };
+
+        let waker = RT::new_task_waker(runtime_ref, pid);
+        let mut task_ctx = task::Context::from_waker(&waker);
+        match Future::poll(future, &mut task_ctx) {
+            Poll::Ready(()) => ProcessResult::Complete,
+            Poll::Pending => ProcessResult::Pending,
+        }
+    }
+}

--- a/src/rt/process/mod.rs
+++ b/src/rt/process/mod.rs
@@ -12,10 +12,12 @@ use crate::rt::RuntimeRef;
 use crate::spawn::options::Priority;
 
 mod actor;
+mod future;
 #[cfg(test)]
 mod tests;
 
 pub(crate) use actor::ActorProcess;
+pub(crate) use future::FutureProcess;
 
 /// Process id, or pid for short, is an identifier for a process in an
 /// [`Runtime`].

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -157,8 +157,7 @@ impl RuntimeInternals {
     where
         Fut: Future<Output = ()> + Send + Sync + 'static,
     {
-        self.scheduler
-            .add_future(future, options.priority(), options.is_ready())
+        self.scheduler.add_future(future, options.priority())
     }
 
     /// See [`Scheduler::mark_ready`].

--- a/src/rt/shared/scheduler/mod.rs
+++ b/src/rt/shared/scheduler/mod.rs
@@ -133,7 +133,7 @@ impl Scheduler {
         }
     }
 
-    pub(crate) fn add_future<Fut>(&self, future: Fut, priority: Priority, is_ready: bool)
+    pub(crate) fn add_future<Fut>(&self, future: Fut, priority: Priority)
     where
         Fut: Future<Output = ()> + Send + Sync + 'static,
     {
@@ -142,11 +142,7 @@ impl Scheduler {
             Box::pin(FutureProcess::<Fut, ThreadSafe>::new(future)),
         ));
         debug!("spawning thread-safe future: pid={}", process.as_ref().id());
-        if is_ready {
-            self.ready.add(process)
-        } else {
-            self.add_process(process)
-        }
+        self.ready.add(process)
     }
 
     /// Mark the process, with `pid`, as ready to run.

--- a/src/rt/shared/scheduler/tests.rs
+++ b/src/rt/shared/scheduler/tests.rs
@@ -210,7 +210,7 @@ fn assert_future_process_unmoved() {
     let mut runtime_ref = test::runtime();
 
     let future = AssertUnmoved::new(pending());
-    scheduler.add_future(future, Priority::NORMAL, true);
+    scheduler.add_future(future, Priority::NORMAL);
 
     // Run the process multiple times, ensure it's not moved in the
     // process.

--- a/src/rt/shared/scheduler/tests.rs
+++ b/src/rt/shared/scheduler/tests.rs
@@ -162,7 +162,7 @@ impl NewActor for TestAssertUnmovedNewActor {
 }
 
 #[test]
-fn assert_process_unmoved() {
+fn assert_actor_process_unmoved() {
     let scheduler = Scheduler::new();
     let mut runtime_ref = test::runtime();
 
@@ -182,6 +182,40 @@ fn assert_process_unmoved() {
     // Run the process multiple times, ensure it's not moved in the
     // process.
     let mut process = scheduler.remove().unwrap();
+    assert_eq!(
+        process.as_mut().run(&mut runtime_ref),
+        ProcessResult::Pending
+    );
+    scheduler.add_process(process);
+
+    scheduler.mark_ready(pid);
+    let mut process = scheduler.remove().unwrap();
+    assert_eq!(
+        process.as_mut().run(&mut runtime_ref),
+        ProcessResult::Pending
+    );
+    scheduler.add_process(process);
+
+    scheduler.mark_ready(pid);
+    let mut process = scheduler.remove().unwrap();
+    assert_eq!(
+        process.as_mut().run(&mut runtime_ref),
+        ProcessResult::Pending
+    );
+}
+
+#[test]
+fn assert_future_process_unmoved() {
+    let scheduler = Scheduler::new();
+    let mut runtime_ref = test::runtime();
+
+    let future = AssertUnmoved::new(pending());
+    scheduler.add_future(future, Priority::NORMAL, true);
+
+    // Run the process multiple times, ensure it's not moved in the
+    // process.
+    let mut process = scheduler.remove().unwrap();
+    let pid = process.as_ref().id();
     assert_eq!(
         process.as_mut().run(&mut runtime_ref),
         ProcessResult::Pending

--- a/src/rt/shared/waker.rs
+++ b/src/rt/shared/waker.rs
@@ -12,7 +12,7 @@ pub const MAX_RUNTIMES: usize = 1 << MAX_RUNTIMES_BITS;
 #[cfg(not(any(test, feature = "test")))]
 pub const MAX_RUNTIMES_BITS: usize = 0; // 1.
 #[cfg(any(test, feature = "test"))]
-pub const MAX_RUNTIMES_BITS: usize = 4; // 16.
+pub const MAX_RUNTIMES_BITS: usize = 5; // 32.
 
 /// An id for a waker.
 ///

--- a/src/spawn/mod.rs
+++ b/src/spawn/mod.rs
@@ -9,7 +9,7 @@ pub mod options;
 pub(crate) use private::{AddActorError, PrivateSpawn};
 
 #[doc(no_inline)]
-pub use options::{ActorOptions, SyncActorOptions};
+pub use options::{ActorOptions, FutureOptions, SyncActorOptions};
 
 /// The `Spawn` trait defines how new actors are added to the runtime.
 pub trait Spawn<S, NA, RT>: PrivateSpawn<S, NA, RT> {

--- a/src/spawn/options.rs
+++ b/src/spawn/options.rs
@@ -223,3 +223,77 @@ impl Default for SyncActorOptions {
         SyncActorOptions { thread_name: None }
     }
 }
+
+/// Options for spawning a [`Future`].
+///
+/// [`Future`]: std::future::Future
+///
+/// # Examples
+///
+/// Using the default options.
+///
+/// ```
+/// use heph::spawn::FutureOptions;
+///
+/// let opts = FutureOptions::default();
+/// # drop(opts); // Silence unused variable warning.
+/// ```
+///
+/// Giving an actor a high priority.
+///
+/// ```
+/// use heph::spawn::options::{FutureOptions, Priority};
+///
+/// let opts = FutureOptions::default().with_priority(Priority::HIGH);
+/// # drop(opts); // Silence unused variable warning.
+/// ```
+#[derive(Clone, Debug)]
+pub struct FutureOptions {
+    priority: Priority,
+    ready: bool,
+}
+
+impl FutureOptions {
+    /// Returns the priority set in the options.
+    pub const fn priority(&self) -> Priority {
+        self.priority
+    }
+
+    /// Set the scheduling priority.
+    pub const fn with_priority(mut self, priority: Priority) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Returns `true` if the actor is ready to run when spawned.
+    ///
+    /// See [`mark_ready`] for more information.
+    ///
+    /// [`mark_ready`]: FutureOptions::mark_ready
+    pub const fn is_ready(&self) -> bool {
+        self.ready
+    }
+
+    /// This option will marks the actor as ready to run (or not) when spawned.
+    ///
+    /// By default newly spawned actors will be considered to be ready to run
+    /// once they are spawned. However some actors might not want to run
+    /// immediately and wait for an external event before running. Such an
+    /// external event can for example be a [`TcpStream`] becoming ready to read
+    /// or write.
+    ///
+    /// [`TcpStream`]: crate::net::TcpStream
+    pub const fn mark_ready(mut self, ready: bool) -> Self {
+        self.ready = ready;
+        self
+    }
+}
+
+impl Default for FutureOptions {
+    fn default() -> FutureOptions {
+        FutureOptions {
+            priority: Priority::default(),
+            ready: true,
+        }
+    }
+}

--- a/src/spawn/options.rs
+++ b/src/spawn/options.rs
@@ -250,7 +250,6 @@ impl Default for SyncActorOptions {
 #[derive(Clone, Debug)]
 pub struct FutureOptions {
     priority: Priority,
-    ready: bool,
 }
 
 impl FutureOptions {
@@ -264,36 +263,12 @@ impl FutureOptions {
         self.priority = priority;
         self
     }
-
-    /// Returns `true` if the actor is ready to run when spawned.
-    ///
-    /// See [`mark_ready`] for more information.
-    ///
-    /// [`mark_ready`]: FutureOptions::mark_ready
-    pub const fn is_ready(&self) -> bool {
-        self.ready
-    }
-
-    /// This option will marks the actor as ready to run (or not) when spawned.
-    ///
-    /// By default newly spawned actors will be considered to be ready to run
-    /// once they are spawned. However some actors might not want to run
-    /// immediately and wait for an external event before running. Such an
-    /// external event can for example be a [`TcpStream`] becoming ready to read
-    /// or write.
-    ///
-    /// [`TcpStream`]: crate::net::TcpStream
-    pub const fn mark_ready(mut self, ready: bool) -> Self {
-        self.ready = ready;
-        self
-    }
 }
 
 impl Default for FutureOptions {
     fn default() -> FutureOptions {
         FutureOptions {
             priority: Priority::default(),
-            ready: true,
         }
     }
 }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -20,6 +20,7 @@ mod functional {
     mod actor_ref;
     mod bytes;
     mod from_message;
+    mod future;
     mod restart_supervisor;
     mod runtime;
     mod sync_actor;

--- a/tests/functional/future.rs
+++ b/tests/functional/future.rs
@@ -1,0 +1,89 @@
+//! Tests for spawning [`Future`]s.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{self, Poll};
+
+use heph::actor;
+use heph::rt::{Runtime, ThreadSafe};
+use heph::spawn::{ActorOptions, FutureOptions};
+use heph::supervisor::NoSupervisor;
+use heph::test::poll_future;
+
+use crate::util::{expect_pending, expect_ready};
+
+struct TestFuture {
+    wakes: usize,
+}
+
+const fn test_future() -> TestFuture {
+    TestFuture { wakes: 0 }
+}
+
+impl Future for TestFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        match self.wakes {
+            0 => {
+                ctx.waker().wake_by_ref();
+                self.wakes += 1;
+                Poll::Pending
+            }
+            1 => {
+                ctx.waker().clone().wake();
+                self.wakes += 1;
+                Poll::Pending
+            }
+            _ => Poll::Ready(()),
+        }
+    }
+}
+
+#[test]
+fn test_poll_future() {
+    let mut future = Box::pin(test_future());
+
+    expect_pending(poll_future(future.as_mut()));
+    expect_pending(poll_future(future.as_mut()));
+    expect_ready(poll_future(future.as_mut()), ());
+}
+
+#[test]
+fn thread_local_waking() {
+    let mut runtime = Runtime::new().unwrap();
+    runtime
+        .run_on_workers::<_, !>(|mut runtime_ref| {
+            runtime_ref.spawn_local_future(test_future(), FutureOptions::default());
+            Ok(())
+        })
+        .unwrap();
+    runtime.start().unwrap();
+}
+
+#[test]
+fn thread_safe_waking() {
+    async fn spawn_actor(mut ctx: actor::Context<!, ThreadSafe>) {
+        // Spawn on `ThreadSafe`.
+        ctx.runtime()
+            .spawn_future(test_future(), FutureOptions::default());
+    }
+
+    let mut runtime = Runtime::new().unwrap();
+    let _ = runtime.spawn(
+        NoSupervisor,
+        spawn_actor as fn(_) -> _,
+        (),
+        ActorOptions::default(),
+    );
+    // Spawn on `Runtime`.
+    runtime.spawn_future(test_future(), FutureOptions::default());
+    runtime
+        .run_on_workers::<_, !>(|mut runtime_ref| {
+            // Spawn on `Runtime_ref`.
+            runtime_ref.spawn_future(test_future(), FutureOptions::default());
+            Ok(())
+        })
+        .unwrap();
+    runtime.start().unwrap();
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -138,6 +138,17 @@ where
 }
 
 #[track_caller]
+pub fn expect_ready<T>(poll: Poll<T>, expected: T)
+where
+    T: fmt::Debug + PartialEq,
+{
+    match poll {
+        Poll::Pending => panic!("unexpected `Poll::Pending`"),
+        Poll::Ready(value) => assert_eq!(value, expected),
+    }
+}
+
+#[track_caller]
 pub fn expect_ready_ok<T, E>(poll: Poll<Result<T, E>>, expected: T)
 where
     T: fmt::Debug + PartialEq,
@@ -218,7 +229,7 @@ impl Future for PendingOnce {
 /// # Notes
 ///
 /// For streams it always returns the total number of polls, not the count
-/// inbetween return two items.
+/// in between return two items.
 pub const fn count_polls<T>(inner: T) -> CountPolls<T> {
     CountPolls { count: 0, inner }
 }


### PR DESCRIPTION
Adds the following methods:
 * Runtime::spawn_future
 * RuntimeRef::spawn_future
 * RuntimeRef::spawn_local_future
 * ThreadSafe::spawn_future

Adds `FutureOptions`: ptions for spawning a Future.
Adds `FutureProcess`: a `Process` implementation for `Future`s.

Closes #404.
