### PR TITLE
Add nanosecond granularity to trace converter

### DIFF
--- a/tools/src/bin/convert_trace.rs
+++ b/tools/src/bin/convert_trace.rs
@@ -48,7 +48,8 @@ fn main() {
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_micros();
-        let duration = event.end.duration_since(event.start).unwrap().as_micros();
+        let duration = event.end.duration_since(event.start).unwrap().as_nanos();
+        let duration = (duration as f64) / 1000.0; // Microsecond granularity.
 
         write!(
             output,


### PR DESCRIPTION
Although Chrome's Trace Event Format uses microsecond granularity is
does support floating point numbers. So with that we can increase the
granularity from microseconds to nanoseconds.