### PR TITLE
Remove `Bytes` impl for arrays and slices

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -320,15 +320,6 @@ impl TcpStream {
         B: BytesVectored,
     {
         let mut dst = bufs.as_bufs();
-        // Remove all empty buffers from `bufs`, this is required for
-        // `RecvNVectored`.
-        let mut remove = 0;
-        for buf in dst.as_mut().iter() {
-            if !buf.is_empty() {
-                break;
-            }
-            remove += 1;
-        }
         debug_assert!(
             !dst.as_mut()[remove..].is_empty(),
             "called `UdpSocket::try_recv_vectored` with an empty buffer"

--- a/tests/functional/bytes.rs
+++ b/tests/functional/bytes.rs
@@ -1,7 +1,6 @@
 //! Tests for the [`Bytes`] trait.
 
 use std::cmp::min;
-use std::mem::MaybeUninit;
 use std::ptr;
 
 use heph::net::Bytes;
@@ -23,48 +22,6 @@ where
         buf.update_length(len);
     }
     len
-}
-
-/* TODO: this implementation is unsound, see issue #308.
-#[test]
-fn impl_for_slice() {
-    let mut buf = vec![0; DATA.len() * 2].into_boxed_slice();
-    let n = write_bytes(DATA, buf.as_mut());
-    assert_eq!(n, DATA.len());
-    assert_eq!(&buf[..n], DATA);
-}
-*/
-
-#[test]
-fn impl_for_maybe_uninit_slice() {
-    let mut buf = vec![MaybeUninit::new(0); DATA.len() * 2].into_boxed_slice();
-    let n = write_bytes(DATA, buf.as_mut());
-    assert_eq!(n, DATA.len());
-    assert_eq!(
-        unsafe { MaybeUninit::slice_assume_init_ref(&buf[..n]) },
-        DATA
-    );
-}
-
-/* TODO: this implementation is unsound, see issue #308.
-#[test]
-fn impl_for_array() {
-    let mut buf = [0; DATA.len() * 2];
-    let n = write_bytes(DATA, buf.as_mut());
-    assert_eq!(n, DATA.len());
-    assert_eq!(&buf[..n], DATA);
-}
-*/
-
-#[test]
-fn impl_for_maybe_uninit_array() {
-    let mut buf = [MaybeUninit::new(0); DATA.len() * 2];
-    let n = write_bytes(DATA, buf.as_mut());
-    assert_eq!(n, DATA.len());
-    assert_eq!(
-        unsafe { MaybeUninit::slice_assume_init_ref(&buf[..n]) },
-        DATA
-    );
 }
 
 #[test]


### PR DESCRIPTION
Removes the `Bytes` impl for arrays and slices

The `update_length` function was never correctly implemented for them
which causes issues with methods such as `TcpStream::recv_n`.

Closes #308 as this is no longer desidered.
Closes #408 as this is no longer possible.

Don't remove empty buffers in `TcpStream::try_recv_vectored`.

Closes #407.