### PR TITLE
Fix process signal handling on Linux

### DIFF
--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -47,10 +47,6 @@ fn test_4_sync_actor() {
 }
 
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "multi-threaded process signal handling is broken on Linux; tracked in #325"
-)]
 fn test_6_process_signals() {
     let child = run_example("6_process_signals");
     // Give the process some time to setup signal handling.


### PR DESCRIPTION
It turns out that on Linux, and possible other Unixes,
pthread_sigmask(3) must be called before spawning the worker threads to
ensure that the worker threads inherit the blocked signals.

On the BSDs, and other Unixes supporting kqueue(2), this isn't a problem
as Mio-signals uses sigaction(2) on those OSs.