### PR TITLE
Enabled RPC example

### DIFF
--- a/examples/4_sync_actor.rs
+++ b/examples/4_sync_actor.rs
@@ -1,5 +1,3 @@
-#![feature(never_type)]
-
 use heph::actor::SyncContext;
 use heph::rt::{self, Runtime};
 use heph::spawn::SyncActorOptions;

--- a/src/actor/messages.rs
+++ b/src/actor/messages.rs
@@ -18,8 +18,6 @@
 //! Implementing `From<Message>` to allow for easy sending of messages.
 //!
 //! ```
-//! #![feature(never_type)]
-//!
 //! use heph::actor::messages::Ack;
 //!
 //! #[derive(Debug, Eq, PartialEq)]

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -100,8 +100,6 @@
 //! Spawning and runing a synchronous actor using a regular function.
 //!
 //! ```
-//! #![feature(never_type)]
-//!
 //! use heph::actor::SyncContext;
 //! use heph::rt::{self, Runtime};
 //! use heph::spawn::SyncActorOptions;

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -97,7 +97,7 @@
 //! }
 //! ```
 //!
-//! Spawning and runing a synchronous actor using a regular function.
+//! Spawning and running a synchronous actor using a regular function.
 //!
 //! ```
 //! use heph::actor::SyncContext;

--- a/src/actor_ref/rpc.rs
+++ b/src/actor_ref/rpc.rs
@@ -25,9 +25,7 @@
 //! #
 //! use heph::actor;
 //! use heph::actor_ref::{ActorRef, RpcMessage};
-//! use heph::rt::{self, Runtime, ThreadLocal};
-//! use heph::spawn::ActorOptions;
-//! use heph::supervisor::NoSupervisor;
+//! use heph::rt::{self, ThreadLocal};
 //!
 //! /// Message type for [`counter`].
 //! struct Add(RpcMessage<usize, usize>);
@@ -65,6 +63,9 @@
 //! }
 //!
 //! # fn main() -> Result<(), rt::Error> {
+//! #    use heph::rt::Runtime;
+//! #    use heph::spawn::ActorOptions;
+//! #    use heph::supervisor::NoSupervisor;
 //! #    let mut runtime = Runtime::new()?;
 //! #    runtime.run_on_workers(|mut runtime_ref| -> Result<(), !> {
 //! #        let counter = counter as fn(_) -> _;
@@ -82,15 +83,13 @@
 //! the message an `enum` as the example below shows. Furthermore synchronous
 //! actors are supported.
 //!
-// FIXME: doesn't stop on CI.
-//! ```ignore
+//! ```
 //! # #![feature(never_type)]
 //! #
 //! use heph::actor::{self, SyncContext};
 //! use heph::actor_ref::{ActorRef, RpcMessage};
 //! use heph::from_message;
-//! use heph::rt::{self, Runtime, ActorOptions, SyncActorOptions};
-//! use heph::supervisor::NoSupervisor;
+//! use heph::rt::{self, ThreadLocal};
 //!
 //! /// Message type for [`counter`].
 //! enum Message {
@@ -126,7 +125,7 @@
 //! }
 //!
 //! /// Sending actor of the RPC.
-//! async fn requester(_: actor::Context<!>, actor_ref: ActorRef<Message>) {
+//! async fn requester(_: actor::Context<!, ThreadLocal>, actor_ref: ActorRef<Message>) {
 //!     // Increase the counter by ten.
 //!     // NOTE: do handle the errors correctly in practice, this is just an
 //!     // example.
@@ -140,6 +139,10 @@
 //! }
 //!
 //! # fn main() -> Result<(), rt::Error> {
+//! #    use heph::rt::Runtime;
+//! #    use heph::spawn::{ActorOptions, SyncActorOptions};
+//! #    use heph::supervisor::NoSupervisor;
+//! #
 //! #    let mut runtime = Runtime::new()?;
 //! #    let counter = counter as fn(_) -> _;
 //! #    let options = SyncActorOptions::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,6 @@
 //! asynchronous function looks like this:
 //!
 //! ```
-//! # #![feature(never_type)]
-//! #
 //! # use heph::actor;
 //! # use heph::rt::ThreadLocal;
 //! #

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -95,7 +95,7 @@ use crate::rt::{self, PrivateAccess};
 /// Accepting multiple [`TcpStream`]s, using [`TcpListener::incoming`].
 ///
 /// ```
-/// #![feature(async_closure, never_type)]
+/// #![feature(never_type)]
 ///
 /// use std::io;
 /// use std::net::SocketAddr;

--- a/src/quick_start.rs
+++ b/src/quick_start.rs
@@ -163,6 +163,7 @@
 //!
 //! ```
 //! # #![feature(never_type)]
+//! #
 //! # use heph::rt::{self, Runtime, RuntimeRef};
 //! fn main() -> Result<(), rt::Error> {
 //!     // First we setup the runtime and configure it.

--- a/src/rt/sync_worker.rs
+++ b/src/rt/sync_worker.rs
@@ -134,7 +134,7 @@ fn main<S, A>(
     }
 
     trace!("stopping synchronous actor: pid={}, name='{}'", id, name);
-    // First drop all values as this might take an arbiterary time.
+    // First drop all values as this might take an arbitrary time.
     drop(actor);
     drop(supervisor);
     drop(inbox);

--- a/src/test.rs
+++ b/src/test.rs
@@ -271,8 +271,6 @@ where
 /// # Examples
 ///
 /// ```
-/// # #![feature(never_type)]
-/// #
 /// use heph::actor;
 /// use heph::test::size_of_actor_val;
 /// use heph::rt::ThreadLocal;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -40,8 +40,8 @@ impl From<DeadlinePassed> for io::Error {
 /// # Examples
 ///
 /// ```
-/// #![feature(never_type)]
-///
+/// # #![feature(never_type)]
+/// #
 /// use std::time::Duration;
 /// # use std::time::Instant;
 ///
@@ -182,8 +182,6 @@ impl<RT: rt::Access> Drop for Timer<RT> {
 /// Setting a timeout for a future.
 ///
 /// ```
-/// #![feature(never_type)]
-///
 /// use std::io;
 /// # use std::future::Future;
 /// # use std::pin::Pin;
@@ -380,8 +378,8 @@ impl<Fut, RT: rt::Access> Drop for Deadline<Fut, RT> {
 /// milliseconds.
 ///
 /// ```
-/// #![feature(never_type)]
-///
+/// # #![feature(never_type)]
+/// #
 /// use std::time::Duration;
 /// # use std::time::Instant;
 ///

--- a/tests/message_loss.rs
+++ b/tests/message_loss.rs
@@ -5,7 +5,6 @@
 //! This function needs to be in it's own binary since `set_message_loss` is set
 //! globally.
 
-#![feature(never_type)]
 #![cfg(feature = "test")]
 
 use std::pin::Pin;


### PR DESCRIPTION
It was too flaky in the CI so it was disabled in commit bdbece7, this is
tracked in issue #374.

Closes #374.

