### PR TITLE
Add Trace trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,6 @@ std-logger        = { version = "0.4.0", default-features = false, features = ["
 
 [workspace]
 members = [
-  "benches/timers_container"
+  "tools",
+  "benches/timers_container",
 ]

--- a/examples/8_tracing.rs
+++ b/examples/8_tracing.rs
@@ -10,6 +10,7 @@ use heph::actor_ref::{ActorRef, SendError};
 use heph::rt::{self, Runtime, RuntimeRef, ThreadLocal};
 use heph::spawn::{ActorOptions, SyncActorOptions};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
+use heph::trace::Trace;
 
 fn main() -> Result<(), rt::Error> {
     let mut runtime_setup = Runtime::setup();

--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -315,7 +315,7 @@ impl<M> Trace for SyncContext<M> {
         description: &str,
         attributes: &[(&str, &dyn trace::AttributeValue)],
     ) {
-        trace::finish(&mut self.trace_log, timing, description, attributes);
+        trace::finish(&mut self.trace_log, timing, 1, description, attributes);
     }
 }
 

--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -315,7 +315,7 @@ impl<M> Trace for SyncContext<M> {
         description: &str,
         attributes: &[(&str, &dyn trace::AttributeValue)],
     ) {
-        trace::finish(&mut self.trace_log, timing, 1, description, attributes);
+        trace::finish(self.trace_log.as_mut(), timing, 1, description, attributes);
     }
 }
 

--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -9,7 +9,7 @@ use std::thread::{self, Thread};
 use inbox::Receiver;
 
 use crate::actor::{NoMessages, RecvError};
-use crate::trace;
+use crate::trace::{self, Trace};
 
 /// Synchronous actor.
 ///
@@ -302,26 +302,14 @@ impl<M> SyncContext<M> {
             waker
         }
     }
+}
 
-    /// Start timing an event if tracing is enabled.
-    ///
-    /// To finish the trace call [`finish_trace`]. See the [`trace`] module for
-    /// more information.
-    ///
-    /// [`finish_trace`]: SyncContext::finish_trace
-    /// [`trace`]: crate::trace
-    pub fn start_trace(&self) -> Option<trace::EventTiming> {
+impl<M> Trace for SyncContext<M> {
+    fn start_trace(&self) -> Option<trace::EventTiming> {
         trace::start(&self.trace_log)
     }
 
-    /// Finish tracing an event, partner function to [`start_trace`].
-    ///
-    /// See the [`trace`] module for more information, e.g. what each argument
-    /// means.
-    ///
-    /// [`start_trace`]: SyncContext::start_trace
-    /// [`trace`]: crate::trace
-    pub fn finish_trace(
+    fn finish_trace(
         &mut self,
         timing: Option<trace::EventTiming>,
         description: &str,

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -21,9 +21,6 @@ const SIGNAL: Token = Token(usize::MAX);
 /// Token used to wake-up the coordinator thread.
 pub(super) const WAKER: Token = Token(usize::MAX - 1);
 
-/// Stream id for the coordinator.
-pub(super) const TRACE_ID: u32 = 0;
-
 #[derive(Debug)]
 pub(super) struct Coordinator {
     /// OS poll, used to poll the status of the (sync) worker threads and
@@ -71,7 +68,7 @@ impl Coordinator {
         mut workers: Vec<Worker>,
         mut sync_workers: Vec<SyncWorker>,
         mut signal_refs: ActorGroup<Signal>,
-        mut trace_log: Option<trace::Log>,
+        mut trace_log: Option<trace::CoordinatorLog>,
     ) -> Result<(), rt::Error> {
         debug_assert!(workers.is_sorted_by_key(Worker::id));
         debug_assert!(sync_workers.is_sorted_by_key(SyncWorker::id));

--- a/src/rt/local/mod.rs
+++ b/src/rt/local/mod.rs
@@ -179,7 +179,7 @@ impl Runtime {
                 }
             }
             trace::finish_rt(
-                &mut *self.internals.trace_log.borrow_mut(),
+                self.internals.trace_log.borrow_mut().as_mut(),
                 timing,
                 "Running thread-local process",
                 &[("id", &pid.0), ("name", &name)],
@@ -207,7 +207,7 @@ impl Runtime {
                 }
             }
             trace::finish_rt(
-                &mut *self.internals.trace_log.borrow_mut(),
+                self.internals.trace_log.borrow_mut().as_mut(),
                 timing,
                 "Running thread-safe process",
                 &[("id", &pid.0), ("name", &name)],
@@ -235,7 +235,7 @@ impl Runtime {
             amount += self.schedule_from_shared_timers(now, amount);
         }
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Scheduling processes",
             &[("amount", &amount)],
@@ -269,7 +269,7 @@ impl Runtime {
             }
         }
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Handling OS events",
             &[],
@@ -297,7 +297,7 @@ impl Runtime {
         }
 
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Scheduling thread-local processes based on wake-up events",
             &[("amount", &amount)],
@@ -318,7 +318,7 @@ impl Runtime {
         }
 
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Scheduling thread-local processes based on timers",
             &[("amount", &amount)],
@@ -338,7 +338,7 @@ impl Runtime {
         }
 
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Scheduling thread-safe processes based on timers",
             &[("amount", &amount)],
@@ -357,7 +357,7 @@ impl Runtime {
             let timing = trace::start(&*self.internals.trace_log.borrow());
             self.internals.shared.wake_workers(wake_n);
             trace::finish_rt(
-                &mut *self.internals.trace_log.borrow_mut(),
+                self.internals.trace_log.borrow_mut().as_mut(),
                 timing,
                 "Waking worker thread based on shared timers",
                 &[("amount", &wake_n)],
@@ -397,7 +397,7 @@ impl Runtime {
         }
 
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Polling for OS events",
             &[],
@@ -444,7 +444,7 @@ impl Runtime {
             }
         }
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Processing communication message(s)",
             &[],
@@ -467,7 +467,7 @@ impl Runtime {
         };
 
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Relaying process signal to actors",
             &[("signal", &signal.as_str())],
@@ -485,7 +485,7 @@ impl Runtime {
         let runtime_ref = self.create_ref();
         let res = f(runtime_ref).map_err(|err| Error::UserFunction(err.into()));
         trace::finish_rt(
-            &mut *self.internals.trace_log.borrow_mut(),
+            self.internals.trace_log.borrow_mut().as_mut(),
             timing,
             "Running user function",
             &[],
@@ -566,7 +566,7 @@ pub(super) struct RuntimeInternals {
     /// CPU affinity of the worker thread, or `None` if not set.
     pub(super) cpu: Option<usize>,
     /// Log used for tracing, `None` is tracing is disabled.
-    trace_log: RefCell<Option<trace::Log>>,
+    pub(super) trace_log: RefCell<Option<trace::Log>>,
 }
 
 impl RuntimeInternals {

--- a/src/rt/local/mod.rs
+++ b/src/rt/local/mod.rs
@@ -183,7 +183,7 @@ impl Runtime {
                     self.internals.scheduler.borrow_mut().add_process(process);
                 }
             }
-            trace::finish(
+            trace::finish_rt(
                 &mut self.trace_log,
                 timing,
                 "Running thread-local process",
@@ -211,7 +211,7 @@ impl Runtime {
                     self.internals.shared.add_process(process);
                 }
             }
-            trace::finish(
+            trace::finish_rt(
                 &mut self.trace_log,
                 timing,
                 "Running thread-safe process",
@@ -239,7 +239,7 @@ impl Runtime {
             // that worker thread we need check the shared timers.
             amount += self.schedule_from_shared_timers(now, amount);
         }
-        trace::finish(
+        trace::finish_rt(
             &mut self.trace_log,
             timing,
             "Scheduling processes",
@@ -273,7 +273,7 @@ impl Runtime {
                 }
             }
         }
-        trace::finish(&mut self.trace_log, timing, "Handling OS events", &[]);
+        trace::finish_rt(&mut self.trace_log, timing, "Handling OS events", &[]);
 
         if check_comms {
             // Don't need this anymore.
@@ -296,7 +296,7 @@ impl Runtime {
             amount += 1;
         }
 
-        trace::finish(
+        trace::finish_rt(
             &mut self.trace_log,
             timing,
             "Scheduling thread-local processes based on wake-up events",
@@ -317,7 +317,7 @@ impl Runtime {
             amount += 1;
         }
 
-        trace::finish(
+        trace::finish_rt(
             &mut self.trace_log,
             timing,
             "Scheduling thread-local processes based on timers",
@@ -337,7 +337,7 @@ impl Runtime {
             amount += 1;
         }
 
-        trace::finish(
+        trace::finish_rt(
             &mut self.trace_log,
             timing,
             "Scheduling thread-safe processes based on timers",
@@ -356,7 +356,7 @@ impl Runtime {
             trace!("waking {} worker threads based on shared timers", wake_n);
             let timing = trace::start(&self.trace_log);
             self.internals.shared.wake_workers(wake_n);
-            trace::finish(
+            trace::finish_rt(
                 &mut self.trace_log,
                 timing,
                 "Waking worker thread based on shared timers",
@@ -396,7 +396,7 @@ impl Runtime {
             self.internals.shared.timers_woke_from_polling();
         }
 
-        trace::finish(&mut self.trace_log, timing, "Polling for OS events", &[]);
+        trace::finish_rt(&mut self.trace_log, timing, "Polling for OS events", &[]);
         res.map(|()| from_timers)
     }
 
@@ -438,7 +438,7 @@ impl Runtime {
                 Control::Run(f) => self.run_user_function(f)?,
             }
         }
-        trace::finish(
+        trace::finish_rt(
             &mut self.trace_log,
             timing,
             "Processing communication message(s)",
@@ -461,7 +461,7 @@ impl Runtime {
             Err(SendError) => Ok(()),
         };
 
-        trace::finish(
+        trace::finish_rt(
             &mut self.trace_log,
             timing,
             "Relaying process signal to actors",
@@ -479,7 +479,7 @@ impl Runtime {
         trace!("running user function");
         let runtime_ref = self.create_ref();
         let res = f(runtime_ref).map_err(|err| Error::UserFunction(err.into()));
-        trace::finish(&mut self.trace_log, timing, "Running user function", &[]);
+        trace::finish_rt(&mut self.trace_log, timing, "Running user function", &[]);
         res
     }
 }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -604,6 +604,26 @@ impl RuntimeRef {
     pub(crate) fn cpu(&self) -> Option<usize> {
         self.internals.cpu
     }
+
+    fn start_trace(&self) -> Option<trace::EventTiming> {
+        trace::start(&*self.internals.trace_log.borrow())
+    }
+
+    fn finish_trace(
+        &mut self,
+        timing: Option<trace::EventTiming>,
+        pid: ProcessId,
+        description: &str,
+        attributes: &[(&str, &dyn trace::AttributeValue)],
+    ) {
+        trace::finish(
+            (&mut *self.internals.trace_log.borrow_mut()).as_mut(),
+            timing,
+            pid.0 as u64,
+            description,
+            attributes,
+        )
+    }
 }
 
 impl<S, NA> Spawn<S, NA, ThreadLocal> for RuntimeRef {}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -194,7 +194,7 @@ pub struct Runtime {
     /// List of actor references that want to receive process signals.
     signals: ActorGroup<Signal>,
     /// Trace log.
-    trace_log: Option<trace::Log>,
+    trace_log: Option<trace::CoordinatorLog>,
 }
 
 impl Runtime {
@@ -284,11 +284,8 @@ impl Runtime {
 
         let trace_log = if let Some(trace_log) = &self.trace_log {
             #[allow(clippy::cast_possible_truncation)]
-            let trace_log = trace_log
-                // Safety: MAX_THREADS always fits in u32.
-                .new_stream(id as u32)
-                .map_err(Error::start_sync_actor)?;
-            Some(trace_log)
+            // Safety: MAX_THREADS always fits in u32.
+            Some(trace_log.new_stream(id as u32))
         } else {
             None
         };

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -282,13 +282,12 @@ impl Runtime {
             None => debug!("spawning synchronous actor: pid={}", id),
         }
 
-        let trace_log = if let Some(trace_log) = &self.trace_log {
-            #[allow(clippy::cast_possible_truncation)]
-            // Safety: MAX_THREADS always fits in u32.
-            Some(trace_log.new_stream(id as u32))
-        } else {
-            None
-        };
+        #[allow(clippy::cast_possible_truncation)]
+        // Safety: MAX_THREADS always fits in u32.
+        let trace_log = self
+            .trace_log
+            .as_ref()
+            .map(|trace_log| trace_log.new_stream(id as u32));
         SyncWorker::start(id, supervisor, actor, arg, options, trace_log)
             .map(|(worker, actor_ref)| {
                 self.sync_actors.push(worker);

--- a/src/rt/setup.rs
+++ b/src/rt/setup.rs
@@ -9,7 +9,7 @@ use std::{io, thread};
 use log::{debug, warn};
 
 use crate::actor_ref::ActorGroup;
-use crate::rt::coordinator::{self, Coordinator};
+use crate::rt::coordinator::Coordinator;
 use crate::rt::{worker, Error, Runtime, Worker, MAX_THREADS};
 use crate::trace;
 
@@ -26,7 +26,7 @@ pub struct Setup {
     /// Whether or not to automatically set CPU affinity.
     auto_cpu_affinity: bool,
     /// Optional trace log.
-    trace_log: Option<trace::Log>,
+    trace_log: Option<trace::CoordinatorLog>,
 }
 
 impl Setup {
@@ -114,7 +114,7 @@ impl Setup {
     /// Returns an error if a file at `path` already exists or can't create the
     /// file.
     pub fn enable_tracing<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
-        match trace::Log::open(path.as_ref(), coordinator::TRACE_ID) {
+        match trace::CoordinatorLog::open(path.as_ref()) {
             Ok(trace_log) => {
                 self.trace_log = Some(trace_log);
                 Ok(())
@@ -154,7 +154,7 @@ impl Setup {
                 #[allow(clippy::manual_map)]
                 let trace_log = if let Some(trace_log) = &self.trace_log {
                     #[allow(clippy::cast_possible_truncation)]
-                    Some(trace_log.new_stream(worker_setup.id() as u32)?)
+                    Some(trace_log.new_stream(worker_setup.id() as u32))
                 } else {
                     None
                 };

--- a/src/rt/setup.rs
+++ b/src/rt/setup.rs
@@ -167,7 +167,7 @@ impl Setup {
             .collect::<io::Result<Vec<Worker>>>()
             .map_err(Error::start_worker)?;
 
-        trace::finish(
+        trace::finish_rt(
             &mut self.trace_log,
             timing,
             "Spawning worker threads",

--- a/src/rt/setup.rs
+++ b/src/rt/setup.rs
@@ -144,7 +144,9 @@ impl Setup {
 
         // Create the coordinator to oversee all workers.
         let thread_wakers = thread_wakers.into_boxed_slice();
-        let coordinator = Coordinator::init(thread_wakers).map_err(Error::init_coordinator)?;
+        let shared_trace_log = self.trace_log.as_ref().map(|l| l.clone_shared());
+        let coordinator =
+            Coordinator::init(thread_wakers, shared_trace_log).map_err(Error::init_coordinator)?;
 
         // Spawn the worker threads.
         let workers = worker_setups
@@ -168,7 +170,7 @@ impl Setup {
             .map_err(Error::start_worker)?;
 
         trace::finish_rt(
-            &mut self.trace_log,
+            self.trace_log.as_mut(),
             timing,
             "Spawning worker threads",
             &[("amount", &self.threads)],

--- a/src/rt/shared/waker.rs
+++ b/src/rt/shared/waker.rs
@@ -331,7 +331,7 @@ mod tests {
         Arc::new_cyclic(|shared_internals| {
             let waker_id = waker::init(shared_internals.clone());
             let worker_wakers = vec![&*test::NOOP_WAKER].into_boxed_slice();
-            RuntimeInternals::new(waker_id, worker_wakers, scheduler, registry, timers)
+            RuntimeInternals::new(waker_id, worker_wakers, scheduler, registry, timers, None)
         })
     }
 

--- a/src/rt/sync_worker.rs
+++ b/src/rt/sync_worker.rs
@@ -107,11 +107,16 @@ fn main<S, A>(
         let timing = trace::start(&trace_log);
         let receiver = inbox.new_receiver().unwrap_or_else(inbox_failure);
         let ctx = SyncContext::new(receiver, trace_log.clone());
-        trace::finish_rt(&mut trace_log, timing, "setting up synchronous actor", &[]);
+        trace::finish_rt(
+            trace_log.as_mut(),
+            timing,
+            "setting up synchronous actor",
+            &[],
+        );
 
         let timing = trace::start(&trace_log);
         let res = actor.run(ctx, arg);
-        trace::finish_rt(&mut trace_log, timing, "running synchronous actor", &[]);
+        trace::finish_rt(trace_log.as_mut(), timing, "running synchronous actor", &[]);
 
         match res {
             Ok(()) => break,
@@ -122,14 +127,19 @@ fn main<S, A>(
                         trace!("restarting synchronous actor: pid={}, name='{}'", id, name);
                         arg = new_arg;
                         trace::finish_rt(
-                            &mut trace_log,
+                            trace_log.as_mut(),
                             timing,
                             "restarting synchronous actor",
                             &[],
                         );
                     }
                     SupervisorStrategy::Stop => {
-                        trace::finish_rt(&mut trace_log, timing, "stopping synchronous actor", &[]);
+                        trace::finish_rt(
+                            trace_log.as_mut(),
+                            timing,
+                            "stopping synchronous actor",
+                            &[],
+                        );
                         break;
                     }
                 }

--- a/src/rt/sync_worker.rs
+++ b/src/rt/sync_worker.rs
@@ -107,11 +107,11 @@ fn main<S, A>(
         let timing = trace::start(&trace_log);
         let receiver = inbox.new_receiver().unwrap_or_else(inbox_failure);
         let ctx = SyncContext::new(receiver, trace_log.clone());
-        trace::finish(&mut trace_log, timing, "setting up synchronous actor", &[]);
+        trace::finish_rt(&mut trace_log, timing, "setting up synchronous actor", &[]);
 
         let timing = trace::start(&trace_log);
         let res = actor.run(ctx, arg);
-        trace::finish(&mut trace_log, timing, "running synchronous actor", &[]);
+        trace::finish_rt(&mut trace_log, timing, "running synchronous actor", &[]);
 
         match res {
             Ok(()) => break,
@@ -121,10 +121,15 @@ fn main<S, A>(
                     SupervisorStrategy::Restart(new_arg) => {
                         trace!("restarting synchronous actor: pid={}, name='{}'", id, name);
                         arg = new_arg;
-                        trace::finish(&mut trace_log, timing, "restarting synchronous actor", &[]);
+                        trace::finish_rt(
+                            &mut trace_log,
+                            timing,
+                            "restarting synchronous actor",
+                            &[],
+                        );
                     }
                     SupervisorStrategy::Stop => {
-                        trace::finish(&mut trace_log, timing, "stopping synchronous actor", &[]);
+                        trace::finish_rt(&mut trace_log, timing, "stopping synchronous actor", &[]);
                         break;
                     }
                 }

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -169,7 +169,7 @@ fn main(
     .map_err(|err| rt::Error::worker(Error::Init(err)))?;
 
     trace::finish_rt(
-        &mut *runtime.trace_log(),
+        (&mut *runtime.trace_log()).as_mut(),
         timing,
         "Initialising the worker thread",
         &[],

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -169,7 +169,7 @@ fn main(
     .map_err(|err| rt::Error::worker(Error::Init(err)))?;
 
     trace::finish_rt(
-        runtime.trace_log(),
+        &mut *runtime.trace_log(),
         timing,
         "Initialising the worker thread",
         &[],

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -168,7 +168,7 @@ fn main(
     )
     .map_err(|err| rt::Error::worker(Error::Init(err)))?;
 
-    trace::finish(
+    trace::finish_rt(
         runtime.trace_log(),
         timing,
         "Initialising the worker thread",

--- a/src/spawn/mod.rs
+++ b/src/spawn/mod.rs
@@ -111,16 +111,10 @@ mod private {
     }
 }
 
-impl<M, RT, S, NA> Spawn<S, NA, RT> for actor::Context<M, RT>
-where
-    NA: NewActor<RuntimeAccess = RT>,
-    RT: Spawn<S, NA, RT>,
-{
-}
+impl<M, RT, S, NA> Spawn<S, NA, RT> for actor::Context<M, RT> where RT: Spawn<S, NA, RT> {}
 
 impl<M, RT, S, NA> PrivateSpawn<S, NA, RT> for actor::Context<M, RT>
 where
-    NA: NewActor<RuntimeAccess = RT>,
     RT: PrivateSpawn<S, NA, RT>,
 {
     fn try_spawn_setup<ArgFn, ArgFnE>(

--- a/src/test.rs
+++ b/src/test.rs
@@ -67,7 +67,7 @@ static SHARED_INTERNAL: SyncLazy<Arc<shared::RuntimeInternals>> = SyncLazy::new(
     Arc::new_cyclic(|shared_internals| {
         let waker_id = waker::init(shared_internals.clone());
         let worker_wakers = vec![&*NOOP_WAKER].into_boxed_slice();
-        shared::RuntimeInternals::new(waker_id, worker_wakers, scheduler, registry, timers)
+        shared::RuntimeInternals::new(waker_id, worker_wakers, scheduler, registry, timers, None)
     })
 });
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -300,6 +300,8 @@ impl TraceLog for CoordinatorLog {
             self.shared.epoch,
             COORDINATOR_STREAM_ID,
             stream_count,
+            // TODO: add substream id.
+            0,
             event,
         );
         // TODO: buffer events? If buf.len() + packet_size >= 4k -> write first?
@@ -315,6 +317,8 @@ impl TraceLog for Log {
             self.shared.epoch,
             self.stream_id,
             stream_count,
+            // TODO: add substream id.
+            0,
             event,
         );
         // TODO: buffer events? If buf.len() + packet_size >= 4k -> write first?
@@ -328,6 +332,7 @@ fn format_event(
     epoch: Instant,
     stream_id: u32,
     stream_count: u32,
+    substream_id: u64,
     event: &Event<'_>,
 ) {
     #[allow(clippy::unreadable_literal)]
@@ -345,6 +350,7 @@ fn format_event(
     buf.extend_from_slice(&0_u32.to_be_bytes()); // Written later.
     buf.extend_from_slice(&stream_id.to_be_bytes());
     buf.extend_from_slice(&stream_count.to_be_bytes());
+    buf.extend_from_slice(&substream_id.to_be_bytes());
     buf.extend_from_slice(&start_nanos.to_be_bytes());
     buf.extend_from_slice(&end_nanos.to_be_bytes());
     buf.extend_from_slice(&description_len.to_be_bytes());

--- a/tools/src/bin/convert_trace.rs
+++ b/tools/src/bin/convert_trace.rs
@@ -53,9 +53,10 @@ fn main() {
 
         write!(
             output,
-            "{}\t\t{{\"tid\": {}, \"ts\": {}, \"dur\": {}, \"name\": \"{}\"",
+            "{}\t\t{{\"pid\": {}, \"tid\": {}, \"ts\": {}, \"dur\": {}, \"name\": \"{}\"",
             if first { "" } else { ",\n" },
             event.stream_id,
+            event.substream_id,
             timestamp,
             duration,
             event.description,
@@ -89,7 +90,7 @@ fn main() {
                 .expect("failed to write event to output");
         }
         output
-            .write_all(b", \"ph\": \"X\", \"cat\": \"\", \"pid\": 0}")
+            .write_all(b", \"ph\": \"X\", \"cat\": \"\"}")
             .expect("failed to write event to output");
     }
 
@@ -291,6 +292,7 @@ where
 
         let (left, stream_id) = parse_u32(&left[..packet_size - 8]);
         let (left, stream_counter) = parse_u32(left);
+        let (left, substream_id) = parse_u64(left);
         let (left, start) = parse_timestamp(left, trace.epoch);
         let (left, end) = parse_timestamp(left, trace.epoch);
         let (left, description) = match parse_string(left) {
@@ -368,6 +370,7 @@ where
         Ok(Event {
             stream_id,
             stream_counter,
+            substream_id,
             start,
             end,
             description,
@@ -533,6 +536,7 @@ impl fmt::Display for ParseError {
 pub struct Event {
     stream_id: u32,
     stream_counter: u32,
+    substream_id: u64,
     start: SystemTime,
     end: SystemTime,
     description: String,


### PR DESCRIPTION
This trait allows actors to create their own trace events. It's implemented for
actor::Context and SyncContext. Removes the existing SyncContext::start_trace
and SyncContext::finish_trace methods.

To support trace events from async actors that don't interfere with the events
from the runtime this adds substreams to the trace format.

In the convertion to Chrome's Trace Event Format we'll now start using
pids (process ids) for the threads and tid (thread ids) for the actors.
This way we don't have trace events that block each other, e.g. from two
actors who are multiplexed on the same worker thread.

Also implements trace::AttributeValue for NonZero* integers.

The commits have more details.

Closes #345.
Closes #31.