### PR TITLE
Implement Spawn<ThreadSafe> for ThreadLocal

### DIFF
--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -177,22 +177,29 @@ impl PrivateAccess for ThreadLocal {
     }
 }
 
-impl<S, NA> Spawn<S, NA, ThreadLocal> for ThreadLocal {}
+impl<S, NA> Spawn<S, NA, ThreadLocal> for ThreadLocal
+where
+    S: Supervisor<NA> + 'static,
+    NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
+    NA::Actor: 'static,
+{
+}
 
-impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for ThreadLocal {
-    fn try_spawn_setup<ArgFn, ArgFnE>(
+impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for ThreadLocal
+where
+    S: Supervisor<NA> + 'static,
+    NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
+    NA::Actor: 'static,
+{
+    fn try_spawn_setup<ArgFn, E>(
         &mut self,
         supervisor: S,
         new_actor: NA,
         arg_fn: ArgFn,
         options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
     where
-        S: Supervisor<NA> + 'static,
-        NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
-        NA::Actor: 'static,
-        ArgFn:
-            FnOnce(&mut actor::Context<NA::Message, ThreadLocal>) -> Result<NA::Argument, ArgFnE>,
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadLocal>) -> Result<NA::Argument, E>,
     {
         self.rt
             .try_spawn_setup(supervisor, new_actor, arg_fn, options)
@@ -300,32 +307,29 @@ impl PrivateAccess for ThreadSafe {
 
 impl<S, NA> Spawn<S, NA, ThreadSafe> for ThreadSafe
 where
-    S: Send + Sync,
-    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
-    NA::Actor: Send + Sync,
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+    NA::Actor: Send + Sync + 'static,
     NA::Message: Send,
 {
 }
 
 impl<S, NA> PrivateSpawn<S, NA, ThreadSafe> for ThreadSafe
 where
-    S: Send + Sync,
-    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
-    NA::Actor: Send + Sync,
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+    NA::Actor: Send + Sync + 'static,
     NA::Message: Send,
 {
-    fn try_spawn_setup<ArgFn, ArgFnE>(
+    fn try_spawn_setup<ArgFn, E>(
         &mut self,
         supervisor: S,
         new_actor: NA,
         arg_fn: ArgFn,
         options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
     where
-        S: Supervisor<NA> + 'static,
-        NA: NewActor<RuntimeAccess = ThreadSafe> + 'static,
-        NA::Actor: 'static,
-        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, ArgFnE>,
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, E>,
     {
         self.rt.spawn_setup(supervisor, new_actor, arg_fn, options)
     }

--- a/src/rt/access.rs
+++ b/src/rt/access.rs
@@ -206,6 +206,37 @@ where
     }
 }
 
+impl<S, NA> Spawn<S, NA, ThreadSafe> for ThreadLocal
+where
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+    NA::Actor: Send + Sync + 'static,
+    NA::Message: Send,
+{
+}
+
+impl<S, NA> PrivateSpawn<S, NA, ThreadSafe> for ThreadLocal
+where
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+    NA::Actor: Send + Sync + 'static,
+    NA::Message: Send,
+{
+    fn try_spawn_setup<ArgFn, E>(
+        &mut self,
+        supervisor: S,
+        new_actor: NA,
+        arg_fn: ArgFn,
+        options: ActorOptions,
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
+    where
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, E>,
+    {
+        self.rt
+            .try_spawn_setup(supervisor, new_actor, arg_fn, options)
+    }
+}
+
 impl fmt::Debug for ThreadLocal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("ThreadLocal")

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -360,32 +360,29 @@ impl Runtime {
 
 impl<S, NA> Spawn<S, NA, ThreadSafe> for Runtime
 where
-    S: Send + Sync,
-    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
-    NA::Actor: Send + Sync,
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+    NA::Actor: Send + Sync + 'static,
     NA::Message: Send,
 {
 }
 
 impl<S, NA> PrivateSpawn<S, NA, ThreadSafe> for Runtime
 where
-    S: Send + Sync,
-    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
-    NA::Actor: Send + Sync,
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+    NA::Actor: Send + Sync + 'static,
     NA::Message: Send,
 {
-    fn try_spawn_setup<ArgFn, ArgFnE>(
+    fn try_spawn_setup<ArgFn, E>(
         &mut self,
         supervisor: S,
         new_actor: NA,
         arg_fn: ArgFn,
         options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
     where
-        S: Supervisor<NA> + 'static,
-        NA: NewActor<RuntimeAccess = ThreadSafe> + 'static,
-        NA::Actor: 'static,
-        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, ArgFnE>,
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, E>,
     {
         self.coordinator
             .shared_internals()
@@ -625,22 +622,29 @@ impl RuntimeRef {
     }
 }
 
-impl<S, NA> Spawn<S, NA, ThreadLocal> for RuntimeRef {}
+impl<S, NA> Spawn<S, NA, ThreadLocal> for RuntimeRef
+where
+    S: Supervisor<NA> + 'static,
+    NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
+    NA::Actor: 'static,
+{
+}
 
-impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for RuntimeRef {
-    fn try_spawn_setup<ArgFn, ArgFnE>(
+impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for RuntimeRef
+where
+    S: Supervisor<NA> + 'static,
+    NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
+    NA::Actor: 'static,
+{
+    fn try_spawn_setup<ArgFn, E>(
         &mut self,
         supervisor: S,
         mut new_actor: NA,
         arg_fn: ArgFn,
         options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
     where
-        S: Supervisor<NA> + 'static,
-        NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
-        NA::Actor: 'static,
-        ArgFn:
-            FnOnce(&mut actor::Context<NA::Message, ThreadLocal>) -> Result<NA::Argument, ArgFnE>,
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadLocal>) -> Result<NA::Argument, E>,
     {
         // Setup adding a new process to the scheduler.
         let mut scheduler = self.internals.scheduler.borrow_mut();
@@ -673,32 +677,29 @@ impl<S, NA> PrivateSpawn<S, NA, ThreadLocal> for RuntimeRef {
 
 impl<S, NA> Spawn<S, NA, ThreadSafe> for RuntimeRef
 where
-    S: Send + Sync,
-    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
-    NA::Actor: Send + Sync,
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+    NA::Actor: Send + Sync + 'static,
     NA::Message: Send,
 {
 }
 
 impl<S, NA> PrivateSpawn<S, NA, ThreadSafe> for RuntimeRef
 where
-    S: Send + Sync,
-    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync,
-    NA::Actor: Send + Sync,
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+    NA::Actor: Send + Sync + 'static,
     NA::Message: Send,
 {
-    fn try_spawn_setup<ArgFn, ArgFnE>(
+    fn try_spawn_setup<ArgFn, E>(
         &mut self,
         supervisor: S,
         new_actor: NA,
         arg_fn: ArgFn,
         options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
     where
-        S: Supervisor<NA> + 'static,
-        NA: NewActor<RuntimeAccess = ThreadSafe> + 'static,
-        NA::Actor: 'static,
-        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, ArgFnE>,
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, E>,
     {
         self.internals
             .shared

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -160,17 +160,17 @@ impl RuntimeInternals {
     }
 
     #[allow(clippy::needless_pass_by_value)] // For `ActorOptions`.
-    pub(crate) fn spawn_setup<S, NA, ArgFn, ArgFnE>(
+    pub(crate) fn spawn_setup<S, NA, ArgFn, E>(
         self: &Arc<Self>,
         supervisor: S,
         mut new_actor: NA,
         arg_fn: ArgFn,
         options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
     where
         S: Supervisor<NA> + Send + Sync + 'static,
         NA: NewActor<RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
-        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, ArgFnE>,
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, ThreadSafe>) -> Result<NA::Argument, E>,
         NA::Actor: Send + Sync + 'static,
         NA::Message: Send,
     {

--- a/src/spawn/mod.rs
+++ b/src/spawn/mod.rs
@@ -37,9 +37,8 @@ pub trait Spawn<S, NA, RT>: PrivateSpawn<S, NA, RT> {
         options: ActorOptions,
     ) -> Result<ActorRef<NA::Message>, NA::Error>
     where
-        S: Supervisor<NA> + 'static,
-        NA: NewActor<RuntimeAccess = RT> + 'static,
-        NA::Actor: 'static,
+        S: Supervisor<NA>,
+        NA: NewActor<RuntimeAccess = RT>,
     {
         self.try_spawn_setup(supervisor, new_actor, |_| Ok(arg), options)
             .map_err(|err| match err {
@@ -62,9 +61,8 @@ pub trait Spawn<S, NA, RT>: PrivateSpawn<S, NA, RT> {
         options: ActorOptions,
     ) -> ActorRef<NA::Message>
     where
-        S: Supervisor<NA> + 'static,
-        NA: NewActor<Error = !, RuntimeAccess = RT> + 'static,
-        NA::Actor: 'static,
+        S: Supervisor<NA>,
+        NA: NewActor<Error = !, RuntimeAccess = RT>,
     {
         self.try_spawn_setup(supervisor, new_actor, |_| Ok(arg), options)
             .unwrap_or_else(|_: AddActorError<!, !>| unreachable!())
@@ -87,18 +85,17 @@ mod private {
         ///
         /// [`Spawn`]: super::Spawn
         #[allow(clippy::type_complexity)] // Not part of the public API, so it's OK.
-        fn try_spawn_setup<ArgFn, ArgFnE>(
+        fn try_spawn_setup<ArgFn, E>(
             &mut self,
             supervisor: S,
             new_actor: NA,
             arg_fn: ArgFn,
             options: ActorOptions,
-        ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+        ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
         where
-            S: Supervisor<NA> + 'static,
-            NA: NewActor<RuntimeAccess = RT> + 'static,
-            NA::Actor: 'static,
-            ArgFn: FnOnce(&mut actor::Context<NA::Message, RT>) -> Result<NA::Argument, ArgFnE>;
+            S: Supervisor<NA>,
+            NA: NewActor<RuntimeAccess = RT>,
+            ArgFn: FnOnce(&mut actor::Context<NA::Message, RT>) -> Result<NA::Argument, E>;
     }
 
     /// Error returned by spawning a actor.
@@ -117,18 +114,17 @@ impl<M, RT, S, NA> PrivateSpawn<S, NA, RT> for actor::Context<M, RT>
 where
     RT: PrivateSpawn<S, NA, RT>,
 {
-    fn try_spawn_setup<ArgFn, ArgFnE>(
+    fn try_spawn_setup<ArgFn, E>(
         &mut self,
         supervisor: S,
         new_actor: NA,
         arg_fn: ArgFn,
         options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, ArgFnE>>
+    ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
     where
-        S: Supervisor<NA> + 'static,
-        NA: NewActor<RuntimeAccess = RT> + 'static,
-        NA::Actor: 'static,
-        ArgFn: FnOnce(&mut actor::Context<NA::Message, RT>) -> Result<NA::Argument, ArgFnE>,
+        S: Supervisor<NA>,
+        NA: NewActor<RuntimeAccess = RT>,
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, RT>) -> Result<NA::Argument, E>,
     {
         self.runtime()
             .try_spawn_setup(supervisor, new_actor, arg_fn, options)

--- a/src/spawn/mod.rs
+++ b/src/spawn/mod.rs
@@ -108,11 +108,11 @@ mod private {
     }
 }
 
-impl<M, RT, S, NA> Spawn<S, NA, RT> for actor::Context<M, RT> where RT: Spawn<S, NA, RT> {}
+impl<M, RT, S, NA, RT2> Spawn<S, NA, RT2> for actor::Context<M, RT> where RT: Spawn<S, NA, RT2> {}
 
-impl<M, RT, S, NA> PrivateSpawn<S, NA, RT> for actor::Context<M, RT>
+impl<M, RT, S, NA, RT2> PrivateSpawn<S, NA, RT2> for actor::Context<M, RT>
 where
-    RT: PrivateSpawn<S, NA, RT>,
+    RT: PrivateSpawn<S, NA, RT2>,
 {
     fn try_spawn_setup<ArgFn, E>(
         &mut self,
@@ -123,8 +123,8 @@ where
     ) -> Result<ActorRef<NA::Message>, AddActorError<NA::Error, E>>
     where
         S: Supervisor<NA>,
-        NA: NewActor<RuntimeAccess = RT>,
-        ArgFn: FnOnce(&mut actor::Context<NA::Message, RT>) -> Result<NA::Argument, E>,
+        NA: NewActor<RuntimeAccess = RT2>,
+        ArgFn: FnOnce(&mut actor::Context<NA::Message, RT2>) -> Result<NA::Argument, E>,
     {
         self.runtime()
             .try_spawn_setup(supervisor, new_actor, arg_fn, options)

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -24,6 +24,7 @@ mod functional {
     mod future;
     mod restart_supervisor;
     mod runtime;
+    mod spawn;
     mod sync_actor;
     mod tcp;
     mod test;

--- a/tests/functional/spawn.rs
+++ b/tests/functional/spawn.rs
@@ -1,0 +1,72 @@
+//! Tests to check what types implement the Spawn trait.
+
+use std::future::Pending;
+use std::marker::PhantomData;
+
+use heph::actor::{self, NewActor};
+use heph::rt::{Runtime, RuntimeRef, ThreadLocal, ThreadSafe};
+use heph::spawn::Spawn;
+use heph::supervisor::NoSupervisor;
+
+struct TestNewActor<RT>(PhantomData<RT>);
+
+impl<RT> NewActor for TestNewActor<RT> {
+    type Message = !;
+    type Argument = ();
+    type Actor = Pending<Result<(), !>>;
+    type Error = !;
+    type RuntimeAccess = RT;
+
+    fn new(
+        &mut self,
+        _: actor::Context<Self::Message, Self::RuntimeAccess>,
+        _: Self::Argument,
+    ) -> Result<Self::Actor, Self::Error> {
+        todo!()
+    }
+}
+
+fn can_spawn_thread_local<T>()
+where
+    T: Spawn<NoSupervisor, TestNewActor<ThreadLocal>, ThreadLocal>,
+{
+}
+
+fn can_spawn_thread_safe<T>()
+where
+    T: Spawn<NoSupervisor, TestNewActor<ThreadSafe>, ThreadSafe>,
+{
+}
+
+#[test]
+fn runtime() {
+    can_spawn_thread_safe::<Runtime>();
+}
+
+#[test]
+fn runtime_ref() {
+    can_spawn_thread_local::<RuntimeRef>();
+    can_spawn_thread_safe::<RuntimeRef>();
+}
+
+#[test]
+fn thread_local_actor_context() {
+    can_spawn_thread_local::<actor::Context<(), ThreadLocal>>();
+    can_spawn_thread_safe::<actor::Context<(), ThreadLocal>>();
+}
+
+#[test]
+fn thread_safe_actor_context() {
+    can_spawn_thread_safe::<actor::Context<(), ThreadSafe>>();
+}
+
+#[test]
+fn thread_local() {
+    can_spawn_thread_local::<ThreadLocal>();
+    can_spawn_thread_safe::<ThreadLocal>();
+}
+
+#[test]
+fn thread_safe() {
+    can_spawn_thread_safe::<ThreadSafe>();
+}


### PR DESCRIPTION
 This allows thread-local actor to spawn thread-safe actors directly from
their `actor::Context`. Note that this was already possible by first
access the `RuntimeRef`.

Updates #311.