### PR TITLE
Fix race between determining timeout and marking as polling

### DIFF
--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -437,6 +437,10 @@ where
         let arg = (self.map)(arg);
         self.new_actor.new(ctx, arg)
     }
+
+    fn name(&self) -> &'static str {
+        self.new_actor.name()
+    }
 }
 
 /// Macro to implement the [`NewActor`] trait on function pointers.

--- a/src/actor_ref/rpc.rs
+++ b/src/actor_ref/rpc.rs
@@ -83,8 +83,7 @@
 //! the message an `enum` as the example below shows. Furthermore synchronous
 //! actors are supported.
 //!
-// FIXME: doesn't stop on CI.
-//! ```ignore
+//! ```
 //! # #![feature(never_type)]
 //! #
 //! use heph::actor::{self, SyncContext};

--- a/src/rt/thread_waker.rs
+++ b/src/rt/thread_waker.rs
@@ -53,6 +53,6 @@ impl ThreadWaker {
     /// Mark the thread as currently polling (or not).
     pub(crate) fn mark_polling(&self, is_polling: bool) {
         let status = if is_polling { IS_POLLING } else { NOT_POLLING };
-        self.polling_status.store(status, Ordering::Release);
+        self.polling_status.store(status, Ordering::SeqCst);
     }
 }

--- a/tests/regression/issue_145.rs
+++ b/tests/regression/issue_145.rs
@@ -84,6 +84,7 @@ where
     fn second_restart_error(&mut self, _: io::Error) {}
 }
 
+#[allow(clippy::type_complexity)] // `servers` is too complex.
 async fn conn_actor(
     mut ctx: actor::Context<!, ThreadLocal>,
     mut stream: TcpStream,


### PR DESCRIPTION
This problem was highlighted by the example in `src/actor_ref/rpc`, line
86. However it had nothing to do with RPC or `ActorRef`s and everything to
do with a race in the use of `ThreadWaker`.

Before polling we first determine the timeout to use based on local and
shared resources, i.e. the schedulers, timers and wake-up mechanisms.
After we determined the timeout we mark ourselves as polling iff the
timeout is not zero.

However it could be that between those two calls (`determine_timeout`
and `mark_polling`) we received e.g. a wake-up event but didn't consider
it in `determine_timeout`. But because we didn't mark ourselves as
polling yet we also won't be awoken from polling, causing us to poll for
ever, missing the wake-up. That would look something like the following:

```
Thread 0                    | Thread 1
1. determine_timeout = None |
                            | 2. task::Waker: wake-up pid=1.
                            | 3. ThreadWaker: not polling -> no wakeup.
4. mark_polling(true)       |
5. poll(None)               |
6. Waiting for ever...      |
```

To fix this we need to check the timeout after marking ourselves as
polling to ensure we didn't miss any wake-ups/timers since we determined
the timeout and marked ourselves as polling.




Reverts commit bdbece7e2c31c456661b12007bc7ce16445ca1ec.