### PR TITLE
Use release version of the inbox crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ test = ["getrandom"]
 
 [dependencies]
 crossbeam-channel = { version = "0.5.0", default-features = false, features = ["std"] }
-# FIXME: use released version.
-inbox             = { git = "https://github.com/Thomasdezeeuw/inbox", rev = "38ca9a6601a50d56c5719fac079ae5e7efc20874" }
+heph-inbox        = { version = "0.1.0", default-features = false }
 libc              = { version = "0.2.79", default-features = false }
 log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use inbox::{Receiver, RecvValue};
+use heph_inbox::{self as inbox, Receiver, RecvValue};
 
 use crate::actor_ref::ActorRef;
 

--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::task::{self, Poll};
 use std::thread::{self, Thread};
 
-use inbox::Receiver;
+use heph_inbox::Receiver;
 
 use crate::actor::{NoMessages, RecvError};
 use crate::trace::{self, Trace};

--- a/src/actor_ref/mod.rs
+++ b/src/actor_ref/mod.rs
@@ -115,7 +115,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{self, Poll};
 
-use inbox::Sender;
+use heph_inbox::{self as inbox, Sender};
 
 pub mod rpc;
 #[doc(no_inline)]

--- a/src/actor_ref/rpc.rs
+++ b/src/actor_ref/rpc.rs
@@ -162,7 +162,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use inbox::oneshot::{new_oneshot, RecvOnce, Sender};
+use heph_inbox::oneshot::{new_oneshot, RecvOnce, Sender};
 
 use crate::actor_ref::{ActorRef, SendError, SendValue};
 

--- a/src/rt/local/scheduler/mod.rs
+++ b/src/rt/local/scheduler/mod.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::mem::MaybeUninit;
 use std::pin::Pin;
 
-use inbox::Manager;
+use heph_inbox::Manager;
 use log::{debug, trace};
 
 use crate::actor::NewActor;

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -121,6 +121,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::{io, task};
 
+use heph_inbox as inbox;
 use log::{debug, trace};
 use mio::{event, Interest, Token};
 

--- a/src/rt/process/actor.rs
+++ b/src/rt/process/actor.rs
@@ -4,7 +4,7 @@
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use inbox::{Manager, Receiver};
+use heph_inbox::{Manager, Receiver};
 
 use crate::actor::{self, Actor, NewActor};
 use crate::rt::access::PrivateAccess;

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{io, task};
 
+use heph_inbox as inbox;
 use log::{debug, error, trace};
 use mio::{event, Interest, Registry, Token};
 

--- a/src/rt/shared/scheduler/mod.rs
+++ b/src/rt/shared/scheduler/mod.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 use std::mem::MaybeUninit;
 use std::pin::Pin;
 
-use inbox::Manager;
+use heph_inbox::Manager;
 use log::{debug, trace};
 
 use crate::actor::NewActor;

--- a/src/rt/sync_worker.rs
+++ b/src/rt/sync_worker.rs
@@ -3,7 +3,7 @@
 use std::io::{self, Write};
 use std::thread;
 
-use inbox::ReceiverConnected;
+use heph_inbox::{self as inbox, ReceiverConnected};
 use log::trace;
 use mio::{unix, Interest, Registry, Token};
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -29,7 +29,7 @@ use std::task::{self, Poll};
 use std::{io, slice, thread};
 
 use getrandom::getrandom;
-use inbox::Manager;
+use heph_inbox::Manager;
 use log::warn;
 
 use crate::actor::{self, Actor, NewActor, SyncActor};


### PR DESCRIPTION
It's now named heph-inbox, because I couldn't think of a better name
(that was not taken).

