### PR TITLE
Fix memory leak in shared::Scheduler

### DIFF
--- a/src/rt/shared/scheduler/inactive.rs
+++ b/src/rt/shared/scheduler/inactive.rs
@@ -481,13 +481,16 @@ impl Branch {
                     }
                 }
                 // Another thread changed the pointer.
-                Err(old) => old_ptr = old,
+                Err(old) => {
+                    // We failed to use `branch`, so we can use it again.
+                    w_branch = Some(branch);
+                    old_ptr = old
+                }
             }
 
             // Follow all branches created by other threads.
             while !as_ptr(old_ptr).is_null() && is_branch(old_ptr) {
                 let branch_ptr: *mut Branch = as_ptr(old_ptr).cast();
-                w_branch = Some(branch);
                 w_pid >>= LEVEL_SHIFT;
                 depth += 1;
                 debug_assert!(!branch_ptr.is_null());

--- a/tests/functional/actor_context.rs
+++ b/tests/functional/actor_context.rs
@@ -65,6 +65,9 @@ fn actor_ref() {
     assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
 }
 
+// NOTE: this actor leaks memory if used with the test runtime.
+// Because this adds its own actor reference to the test runtime (which is never
+// dropped) it also means that actor's channel is never dropped.
 async fn runtime_actor(mut ctx: actor::Context<Signal, ThreadLocal>) {
     let actor_ref = ctx.actor_ref();
     ctx.runtime().receive_signals(actor_ref);

--- a/tests/process_signals.rs
+++ b/tests/process_signals.rs
@@ -23,7 +23,11 @@ fn no_signal_handlers() {
     let runtime = Runtime::setup().build().unwrap();
     send_signal(process::id(), mio_signals::Signal::Interrupt).expect("failed to send signal");
     let err_str = runtime.start().unwrap_err().to_string();
-    assert!(err_str.contains("received process signal, but no receivers for it: stopping runtime"));
+    assert!(
+        err_str.contains("received process signal, but no receivers for it: stopping runtime"),
+        "got error '{}'",
+        err_str
+    );
 }
 
 /// Runtime with actors to receive the signal should not stop and relay the


### PR DESCRIPTION
In `Inactive::add_branches` it failed to reuse the branch if the
`compare_exchange` failed (to add the branch to the tree). The caused the
created `Branch` to be leaked.