### PR TITLE
Various commits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test = ["getrandom"]
 
 [dependencies]
 crossbeam-channel = { version = "0.5.0", default-features = false, features = ["std"] }
-heph-inbox        = { version = "0.1.0", default-features = false }
+heph-inbox        = { version = "0.1.1", default-features = false }
 libc              = { version = "0.2.79", default-features = false }
 log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Example value: `nightly-x86_64-apple-darwin`.
 RUSTUP_TOOLCHAIN ?= $(shell rustup show active-toolchain | cut -d' ' -f1)
 # Architecture target. Example value: `x86_64-apple-darwin`.
-RUSTUP_TARGET    ?= $(shell echo $(RUSTUP_TOOLCHAIN) | cut -d'-' -f2,3,4)
+RUSTUP_TARGET    ?= $(shell echo $(RUSTUP_TOOLCHAIN) | cut -d'-' -f2,3,4,5)
 # Location of LLVM tools, as install by `install_llvm_tools`.
 LLVM_BIN         ?= $(shell rustc --print sysroot)/lib/rustlib/$(RUSTUP_TARGET)/bin
 # To support `coverage` in workspaces we need to handle the single target

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,14 @@ RUN ?= test
 test:
 	cargo test --all-features
 
+# NOTE: Keep `RUSTFLAGS` and `RUSTDOCFLAGS` in sync to ensure the doc tests
+# compile correctly.
+test_sanitiser:
+	@if [ -z $${SAN+x} ]; then echo "Required '\$$SAN' variable is not set" 1>&2; exit 1; fi
+	RUSTFLAGS="-Z sanitizer=$$SAN -Z sanitizer-memory-track-origins" \
+	RUSTDOCFLAGS="-Z sanitizer=$$SAN -Z sanitizer-memory-track-origins" \
+	cargo test -Z build-std --all-features --target $(RUSTUP_TARGET)
+
 check:
 	cargo check --all-features --all-targets
 
@@ -110,4 +118,4 @@ doc_private:
 clean:
 	cargo clean
 
-.PHONY: test check check_all_targets dev clippy lint install_clippy coverage install_coverage install_llvm_tools doc doc_private clean
+.PHONY: test test_sanitiser check check_all_targets dev clippy lint install_clippy coverage install_coverage install_llvm_tools doc doc_private clean

--- a/src/rt/local/scheduler/tests.rs
+++ b/src/rt/local/scheduler/tests.rs
@@ -2,7 +2,7 @@
 
 use std::cell::RefCell;
 use std::future::{pending, Pending};
-use std::mem::{self, forget};
+use std::mem;
 use std::pin::Pin;
 use std::rc::Rc;
 
@@ -285,12 +285,9 @@ impl NewActor for TestAssertUnmovedNewActor {
 
     fn new(
         &mut self,
-        ctx: actor::Context<Self::Message, Self::RuntimeAccess>,
+        _: actor::Context<Self::Message, Self::RuntimeAccess>,
         _: Self::Argument,
     ) -> Result<Self::Actor, Self::Error> {
-        // In the test we need the access to the inbox, to achieve that we can't
-        // drop the context, so we forget about it here leaking the inbox.
-        forget(ctx);
         Ok(AssertUnmoved::new(pending()))
     }
 }

--- a/src/rt/shared/scheduler/inactive.rs
+++ b/src/rt/shared/scheduler/inactive.rs
@@ -109,7 +109,7 @@ impl Inactive {
                 match node.branches[w_pid & LEVEL_MASK].compare_exchange(
                     tagged_pid,
                     ptr::null_mut(),
-                    Ordering::SeqCst,
+                    Ordering::AcqRel,
                     Ordering::Acquire,
                 ) {
                     Ok(_) => {
@@ -223,7 +223,7 @@ impl Branch {
                 match node.branches[w_pid & LEVEL_MASK].compare_exchange(
                     ptr::null_mut(),
                     process,
-                    Ordering::SeqCst,
+                    Ordering::AcqRel,
                     Ordering::Acquire,
                 ) {
                     Ok(_) => return changed + 1,
@@ -247,7 +247,7 @@ impl Branch {
                 match node.branches[w_pid & LEVEL_MASK].compare_exchange(
                     old_ptr,
                     ptr::null_mut(),
-                    Ordering::SeqCst,
+                    Ordering::AcqRel,
                     Ordering::Acquire,
                 ) {
                     Ok(old) => {
@@ -272,7 +272,7 @@ impl Branch {
                 match node.branches[w_pid & LEVEL_MASK].compare_exchange(
                     old_ptr,
                     ptr::null_mut(),
-                    Ordering::SeqCst,
+                    Ordering::AcqRel,
                     Ordering::Acquire,
                 ) {
                     Ok(other_process) => {
@@ -340,7 +340,7 @@ impl Branch {
                 match node.branches[w_pid & LEVEL_MASK].compare_exchange(
                     old_ptr,
                     marker,
-                    Ordering::SeqCst,
+                    Ordering::AcqRel,
                     Ordering::Acquire,
                 ) {
                     Ok(_) => return changed,
@@ -366,7 +366,7 @@ impl Branch {
                 match node.branches[w_pid & LEVEL_MASK].compare_exchange(
                     old_ptr,
                     ptr::null_mut(),
-                    Ordering::SeqCst,
+                    Ordering::AcqRel,
                     Ordering::Acquire,
                 ) {
                     Ok(_) => {
@@ -388,7 +388,7 @@ impl Branch {
                 match node.branches[w_pid & LEVEL_MASK].compare_exchange(
                     old_ptr,
                     ptr::null_mut(),
-                    Ordering::SeqCst,
+                    Ordering::AcqRel,
                     Ordering::Acquire,
                 ) {
                     Ok(other_process) => {
@@ -452,7 +452,7 @@ impl Branch {
             match node.branches[w_pid & LEVEL_MASK].compare_exchange(
                 old_ptr,
                 branch,
-                Ordering::SeqCst,
+                Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
                 // Success move to next depth.

--- a/src/test.rs
+++ b/src/test.rs
@@ -17,7 +17,6 @@
 //! features = ["test"]
 //! ```
 
-use std::cell::RefCell;
 use std::future::Future;
 use std::lazy::SyncLazy;
 use std::mem::size_of;
@@ -73,15 +72,15 @@ static SHARED_INTERNAL: SyncLazy<Arc<shared::RuntimeInternals>> = SyncLazy::new(
 
 thread_local! {
     /// Per thread runtime.
-    static TEST_RT: RefCell<Runtime> = {
-        RefCell::new(Runtime::new_test(SHARED_INTERNAL.clone())
-            .expect("failed to create local `Runtime` for test module"))
+    static TEST_RT: Runtime = {
+        Runtime::new_test(SHARED_INTERNAL.clone())
+            .expect("failed to create local `Runtime` for test module")
     };
 }
 
 /// Returns a reference to the *test* runtime.
 pub fn runtime() -> RuntimeRef {
-    TEST_RT.with(|runtime| runtime.borrow().create_ref())
+    TEST_RT.with(Runtime::create_ref)
 }
 
 /// Initialise a thread-local actor.

--- a/tests/functional/actor_context.rs
+++ b/tests/functional/actor_context.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::Poll;
 
 use heph::actor::{self, NoMessages, RecvError};
-use heph::rt::{Runtime, Signal, ThreadLocal, ThreadSafe};
+use heph::rt::{Runtime, ThreadLocal, ThreadSafe};
 use heph::spawn::{ActorOptions, Spawn};
 use heph::supervisor::NoSupervisor;
 use heph::test::{init_local_actor, poll_actor};
@@ -59,24 +59,6 @@ async fn actor_ref_actor(mut ctx: actor::Context<usize, ThreadLocal>) {
 fn actor_ref() {
     let actor_ref_actor = actor_ref_actor as fn(_) -> _;
     let (actor, actor_ref) = init_local_actor(actor_ref_actor, ()).unwrap();
-    let mut actor = Box::pin(actor);
-
-    drop(actor_ref);
-    assert_eq!(poll_actor(Pin::as_mut(&mut actor)), Poll::Ready(Ok(())));
-}
-
-// NOTE: this actor leaks memory if used with the test runtime.
-// Because this adds its own actor reference to the test runtime (which is never
-// dropped) it also means that actor's channel is never dropped.
-async fn runtime_actor(mut ctx: actor::Context<Signal, ThreadLocal>) {
-    let actor_ref = ctx.actor_ref();
-    ctx.runtime().receive_signals(actor_ref);
-}
-
-#[test]
-fn runtime() {
-    let runtime_actor = runtime_actor as fn(_) -> _;
-    let (actor, actor_ref) = init_local_actor(runtime_actor, ()).unwrap();
     let mut actor = Box::pin(actor);
 
     drop(actor_ref);


### PR DESCRIPTION
Commits:
* Removes the `actor_context::runtime` test. It leak memory and didn't actually test much.
* Removed unneeded `RefCell` from test `Runtime`. We only need an immutable reference to it in runtime.
* Don't leak `actor::Context` in `assert_actor_process_unmoved` test.
* Reduce load strength of atomic store operations in `shared::Inactive`, from `SeqCst` to `AcqRel`.
* Update heph-inbox to v0.1.1.
* Fix `RUSTUP_TARGET` var in Makefile.
    Although it's often referred to as a target-"triple", in some case it's
    actually four fields. For example for GNU/Linux the value is
    "x86_64-unknown-linux-gnu".
    This change include the last part (-gnu) in the RUSTUP_TARGET variable,
    but keeps working for targets with only three parts, such as
    "x86_64-apple-darwin".
* Add `test_sanitiser` Make target. This runs the tests with a sanitiser enabled.
 * Fix testing of examples with --target specified.    
    The previous version of run_example expected the examples binaries to be
    in the target/debug directory, but when --target is specified this is
    not the case.
    The solution is not pretty, but adds the paths for the supported
    targets. It should do this by getting the target triple from
    cargo/rustc, but currently this is not possible without a build script.
    So the paths are hardcoded based on cfg(target_os).
