### PR TITLE
Don't register both sides of the rt::channel

### DIFF
--- a/src/rt/channel.rs
+++ b/src/rt/channel.rs
@@ -51,12 +51,6 @@ impl<S, R> Handle<S, R> {
         }
     }
 
-    /// Register both ends of the Unix pipe of this channel.
-    pub(super) fn register(&mut self, registry: &Registry, token: Token) -> io::Result<()> {
-        registry.register(&mut self.send_pipe, token, Interest::WRITABLE)?;
-        registry.register(&mut self.recv_pipe, token, Interest::READABLE)
-    }
-
     /// Try to send a message onto the channel.
     pub(super) fn try_send(&mut self, msg: S) -> io::Result<()> {
         self.send_channel
@@ -108,6 +102,20 @@ impl<S, R> Handle<S, R> {
             // pipe).
             Ok(self.recv_channel.try_recv().ok())
         }
+    }
+}
+
+impl<R> Handle<!, R> {
+    /// Register the receiving end of the Unix pipe of this channel.
+    pub(super) fn register_recv(&mut self, registry: &Registry, token: Token) -> io::Result<()> {
+        registry.register(&mut self.recv_pipe, token, Interest::READABLE)
+    }
+}
+
+impl<S> Handle<S, !> {
+    /// Register the sending end of the Unix pipe of this channel.
+    pub(super) fn register_send(&mut self, registry: &Registry, token: Token) -> io::Result<()> {
+        registry.register(&mut self.send_pipe, token, Interest::WRITABLE)
     }
 }
 

--- a/src/rt/local/mod.rs
+++ b/src/rt/local/mod.rs
@@ -72,7 +72,7 @@ impl Runtime {
         cpu: Option<usize>,
     ) -> io::Result<Runtime> {
         // Register the channel to the coordinator.
-        channel.register(poll.registry(), COMMS)?;
+        channel.register_recv(poll.registry(), COMMS)?;
 
         // Finally create all the runtime internals.
         let internals = RuntimeInternals::new(shared_internals, waker_id, poll, cpu, trace_log);
@@ -99,7 +99,7 @@ impl Runtime {
         let waker_id = rt::waker::init(waker, waker_sender);
 
         let (_, mut channel) = rt::channel::new()?;
-        channel.register(poll.registry(), COMMS)?;
+        channel.register_recv(poll.registry(), COMMS)?;
 
         let internals = RuntimeInternals::new(shared_internals, waker_id, poll, None, None);
         Ok(Runtime {

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -106,7 +106,7 @@ impl Worker {
     /// Registers the channel used to communicate with the thread. Uses the
     /// [`Worker::id`] as [`Token`].
     pub(super) fn register(&mut self, registry: &Registry) -> io::Result<()> {
-        self.channel.register(registry, Token(self.id()))
+        self.channel.register_send(registry, Token(self.id()))
     }
 
     /// Send the worker thread a signal that the runtime has started.


### PR DESCRIPTION
Since the worker thread never sends a message to the coordinator there
is no point in it registering the receiving side, the same goes for the
worker with the sending side. This reduces the amount of events
generated.