### PR TITLE
Add shared Poll instance to shared::RuntimeInternals

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -46,9 +46,6 @@ use crate::supervisor::SyncSupervisor;
 
 pub(crate) const TEST_PID: ProcessId = ProcessId(0);
 
-static COORDINATOR_POLL: SyncLazy<mio::Poll> =
-    SyncLazy::new(|| mio::Poll::new().expect("failed to create `Poll` instance for test module"));
-
 pub(crate) static NOOP_WAKER: SyncLazy<ThreadWaker> = SyncLazy::new(|| {
     let poll = mio::Poll::new().expect("failed to create `Poll` instance for test module");
     let waker = mio::Waker::new(poll.registry(), mio::Token(0))
@@ -57,16 +54,14 @@ pub(crate) static NOOP_WAKER: SyncLazy<ThreadWaker> = SyncLazy::new(|| {
 });
 
 static SHARED_INTERNAL: SyncLazy<Arc<shared::RuntimeInternals>> = SyncLazy::new(|| {
-    let registry = COORDINATOR_POLL
-        .registry()
-        .try_clone()
-        .expect("failed to clone `Registry` for test module");
     let scheduler = Scheduler::new();
     let timers = Timers::new();
+    let setup = shared::RuntimeInternals::setup()
+        .expect("failed to setup runtime internals for test module");
     Arc::new_cyclic(|shared_internals| {
         let waker_id = waker::init(shared_internals.clone());
         let worker_wakers = vec![&*NOOP_WAKER].into_boxed_slice();
-        shared::RuntimeInternals::new(waker_id, worker_wakers, scheduler, registry, timers, None)
+        setup.complete(waker_id, worker_wakers, scheduler, timers, None)
     })
 });
 

--- a/tests/functional/tcp/listener.rs
+++ b/tests/functional/tcp/listener.rs
@@ -242,7 +242,6 @@ fn actor_bound() {
         stream.bind_to(&mut ctx).unwrap();
 
         let mut buf = Vec::with_capacity(DATA.len() + 1);
-        // FIXME: not receiving data.
         let n = stream.recv(&mut buf).await.unwrap();
         assert_eq!(n, DATA.len());
         assert_eq!(buf, DATA);

--- a/tests/regression/issue_294.rs
+++ b/tests/regression/issue_294.rs
@@ -28,5 +28,5 @@ fn issue_294() {
 }
 
 fn actor(mut ctx: SyncContext<()>) {
-    while let Ok(_msg) = ctx.receive_next() {}
+    while let Ok(()) = ctx.receive_next() {}
 }


### PR DESCRIPTION
This shared `Poll` instance allows us to register the shared I/O sources
with a single poll, but allows the worker threads to handle the events.
This means that coordinator no longer has to process any events for the
shared processes. This leaves the coordinator to watch over the worker
and sync worker threads.