### PR TITLE
Cleanup work in runtime

### DIFF
--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -12,7 +12,7 @@ use crate::actor_ref::{ActorGroup, Delivery};
 use crate::rt::shared::{waker, Scheduler, Timers};
 use crate::rt::thread_waker::ThreadWaker;
 use crate::rt::{
-    self, shared, worker, Signal, SyncWorker, Worker, SYNC_WORKER_ID_END, SYNC_WORKER_ID_START,
+    self, shared, Signal, SyncWorker, Worker, SYNC_WORKER_ID_END, SYNC_WORKER_ID_START,
 };
 use crate::trace;
 
@@ -263,12 +263,6 @@ fn handle_worker_event(workers: &mut Vec<Worker>, event: &Event) -> Result<(), r
                 .join()
                 .map_err(rt::Error::worker_panic)
                 .and_then(|res| res)?;
-        } else if event.is_readable() {
-            let worker = &mut workers[i];
-            debug!("handling worker messages: id={}", worker.id());
-            worker
-                .handle_messages()
-                .map_err(|err| rt::Error::worker(worker::Error::RecvMsg(err)))?;
         }
     }
     Ok(())

--- a/src/rt/local/mod.rs
+++ b/src/rt/local/mod.rs
@@ -590,6 +590,18 @@ pub(crate) enum Control {
     Run(Box<dyn FnOnce(RuntimeRef) -> Result<(), String> + Send + 'static>),
 }
 
+impl fmt::Debug for Control {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Control::*;
+        f.write_str("Control::")?;
+        match self {
+            Started => f.write_str("Started"),
+            Signal(signal) => f.debug_tuple("Signal").field(&signal).finish(),
+            Run(..) => f.write_str("Run(..)"),
+        }
+    }
+}
+
 /// Error running a [`Runtime`].
 #[derive(Debug)]
 pub(crate) enum Error {

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -52,8 +52,6 @@ impl RuntimeSetup {
         self,
         shared_id: WakerId,
         worker_wakers: Box<[&'static ThreadWaker]>,
-        scheduler: Scheduler,
-        timers: Timers,
         trace_log: Option<Arc<trace::SharedLog>>,
     ) -> RuntimeInternals {
         // Needed by `RuntimeInternals::wake_workers`.
@@ -64,8 +62,8 @@ impl RuntimeSetup {
             wake_worker_idx: AtomicUsize::new(0),
             poll: Mutex::new(self.poll),
             registry: self.registry,
-            scheduler,
-            timers,
+            scheduler: Scheduler::new(),
+            timers: Timers::new(),
             trace_log,
         }
     }

--- a/src/rt/shared/waker.rs
+++ b/src/rt/shared/waker.rs
@@ -184,7 +184,7 @@ mod tests {
 
     use crate::rt::process::{Process, ProcessData, ProcessId, ProcessResult};
     use crate::rt::shared::waker::{self, WakerData};
-    use crate::rt::shared::{RuntimeInternals, Scheduler, Timers};
+    use crate::rt::shared::{RuntimeInternals, Scheduler};
     use crate::rt::RuntimeRef;
     use crate::spawn::options::Priority;
     use crate::test;
@@ -322,13 +322,11 @@ mod tests {
     }
 
     fn new_internals() -> Arc<RuntimeInternals> {
-        let scheduler = Scheduler::new();
-        let timers = Timers::new();
         let setup = RuntimeInternals::setup().unwrap();
         Arc::new_cyclic(|shared_internals| {
             let waker_id = waker::init(shared_internals.clone());
             let worker_wakers = vec![&*test::NOOP_WAKER].into_boxed_slice();
-            setup.complete(waker_id, worker_wakers, scheduler, timers, None)
+            setup.complete(waker_id, worker_wakers, None)
         })
     }
 

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -127,14 +127,6 @@ impl Worker {
         self.channel.try_send(Control::Run(f))
     }
 
-    /// Handle all incoming messages.
-    pub(super) fn handle_messages(&mut self) -> io::Result<()> {
-        while let Some(msg) = self.channel.try_recv()? {
-            match msg {}
-        }
-        Ok(())
-    }
-
     /// See [`thread::JoinHandle::join`].
     pub(super) fn join(self) -> thread::Result<Result<(), rt::Error>> {
         self.handle.join()

--- a/src/test.rs
+++ b/src/test.rs
@@ -34,7 +34,7 @@ use log::warn;
 use crate::actor::{self, Actor, NewActor, SyncActor};
 use crate::actor_ref::ActorRef;
 use crate::rt::local::Runtime;
-use crate::rt::shared::{waker, Scheduler, Timers};
+use crate::rt::shared::waker;
 use crate::rt::sync_worker::SyncWorker;
 use crate::rt::thread_waker::ThreadWaker;
 use crate::rt::{
@@ -54,14 +54,12 @@ pub(crate) static NOOP_WAKER: SyncLazy<ThreadWaker> = SyncLazy::new(|| {
 });
 
 static SHARED_INTERNAL: SyncLazy<Arc<shared::RuntimeInternals>> = SyncLazy::new(|| {
-    let scheduler = Scheduler::new();
-    let timers = Timers::new();
     let setup = shared::RuntimeInternals::setup()
         .expect("failed to setup runtime internals for test module");
     Arc::new_cyclic(|shared_internals| {
         let waker_id = waker::init(shared_internals.clone());
         let worker_wakers = vec![&*NOOP_WAKER].into_boxed_slice();
-        setup.complete(waker_id, worker_wakers, scheduler, timers, None)
+        setup.complete(waker_id, worker_wakers, None)
     })
 });
 


### PR DESCRIPTION
Has the following commits.

Change rt::channel to be a single direction channel

The previous implementation used two pipes and two in-memory channel to
be able to send messages between the coordinator and worker threads.
However so far it's not been needed to send a message from the worker to
the coordinator.

Since it's not needed simple remove on of the pipes and channels,
turning rt::channel into a single direction channel.


Implement fmt::Debug for local::Control message


Various small doc improvements to rt::coordinator


Move creation of Timers and Scheduler to shared::RuntimeInternals::new

Neither are used outside of the function, so might as well create them
in shared::RuntimeInternals::new


Remove Worker::handle_messages

Even though it was technically possible to call it served no purpose as
the type of message was ! (the never type), so it couldn't actually
receive any message. It was only there in case the worker thread needed
to communicate with the coordinator, but so far that hasn't been needed,
so we might as well remove the dead code.


Don't stop runtime when failing to relay process signal

This removes the coordinator::Error::SignalRelay variant and no longer
stops the runtime (well the coordinator) once a process signal can't be
relayed to a worker thread. Since this can really only happen if the
worker thread is shutdown or in the process of shutting down, it's more
useful to return the reason the worker thread shutdown, i.e. via
rt::Error::worker_panic, rather then a failure to relay the process
signal with an unknown reason.
