### PR TITLE
Update process signals docs

### DIFF
--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -27,63 +27,6 @@ use crate::trace::{self, Trace};
 /// Synchronous actor can only be spawned before starting the runtime, see
 /// [`Runtime::spawn_sync_actor`].
 ///
-/// # Signal handling
-///
-/// [Process signals] are automatically send to synchronous actors if the
-/// [`Message`] type implements the required trait bound to convert the actor
-/// reference into mapped actor reference, see [`ActorRef::try_map`].
-///
-/// ```
-/// use heph::actor::SyncContext;
-/// # use heph::actor_ref::ActorRef;
-/// use heph::from_message;
-/// use heph::rt::{self, Runtime, Signal};
-/// use heph::spawn::SyncActorOptions;
-/// use heph::supervisor::NoSupervisor;
-///
-/// fn main() -> Result<(), rt::Error> {
-///     // Spawning synchronous actor works slightly differently than spawning
-///     // regular (asynchronous) actors. Mainly, synchronous actors need to be
-///     // spawned before the runtime is started.
-///     let mut runtime = Runtime::new()?;
-///
-///     // Spawn a new synchronous actor, returning an actor reference to it.
-///     let actor = actor as fn(_);
-///     let options = SyncActorOptions::default().with_name("My actor".to_string());
-///     let actor_ref = runtime.spawn_sync_actor(NoSupervisor, actor, (), options)?;
-///
-///     // Just like with any actor reference we can send the actor a message.
-///     actor_ref.try_send("Hello world".to_string()).unwrap();
-///     # let actor_ref: ActorRef<Signal> = actor_ref.try_map();
-///     # actor_ref.try_send(Signal::Interrupt).unwrap();
-///
-///     // And now we start the runtime.
-///     runtime.start()
-/// }
-///
-/// enum Message {
-///     Print(String),
-///     Signal(Signal),
-/// }
-///
-/// from_message!(Message::Print(String));
-/// // This implementation allows the sync actor to receive process signals.
-/// from_message!(Message::Signal(Signal));
-///
-/// fn actor(mut ctx: SyncContext<Message>) {
-///     while let Ok(msg) = ctx.receive_next() {
-///         match msg {
-///             Message::Print(msg) => println!("Got a message: {}", msg),
-///             Message::Signal(_signal) => break,
-///         }
-///     }
-/// }
-/// ```
-///
-/// [Process signals]: crate::rt::Signal
-/// [`Message`]: SyncActor::Message
-/// [`ActorRef::try_map`]: crate::actor_ref::ActorRef::try_map
-///
 /// # Panics
 ///
 /// Panics are not caught and will **not** be returned to the actor's

--- a/src/rt/local/timers.rs
+++ b/src/rt/local/timers.rs
@@ -2,7 +2,7 @@
 //!
 //! Also see the [shared timers implementation].
 //!
-//! [shared timers implementation]: crate::rt::shared::timers
+//! [shared timers implementation]: crate::rt::shared::Timers
 
 use std::cmp::{min, Ordering};
 use std::time::{Duration, Instant};
@@ -33,7 +33,7 @@ const NS_SLOT_MASK: u128 = (1 << NS_PER_SLOT_BITS) - 1;
 
 /// Time offset since the epoch of [`Timers::epoch`].
 ///
-/// Must fit [`MS_PER_SLOT`].
+/// Must fit [`NS_PER_SLOT`].
 type TimeOffset = u32;
 
 /// Timers.

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -170,7 +170,7 @@ impl RuntimeInternals {
         self.timers.change(from, deadline, to);
     }
 
-    /// See [`Timers::remove_deadline`].
+    /// See [`Timers::remove_next`].
     pub(crate) fn remove_next_deadline(&self, now: Instant) -> Option<ProcessId> {
         self.timers.remove_next(now)
     }

--- a/src/rt/shared/timers.rs
+++ b/src/rt/shared/timers.rs
@@ -2,7 +2,7 @@
 //!
 //! Also see the [local timers implementation].
 //!
-//! [local timers implementation]: crate::rt::local::timers
+//! [local timers implementation]: crate::rt::local::Timers
 
 use std::cmp::{min, Ordering};
 use std::sync::RwLock;
@@ -34,7 +34,7 @@ const NS_SLOT_MASK: u128 = (1 << NS_PER_SLOT_BITS) - 1;
 
 /// Time offset since the epoch of [`Timers::epoch`].
 ///
-/// Must fit [`MS_PER_SLOT`].
+/// Must fit [`NS_PER_SLOT`].
 type TimeOffset = u32;
 
 /// Timers.

--- a/src/rt/signal.rs
+++ b/src/rt/signal.rs
@@ -2,27 +2,25 @@ use std::fmt;
 
 /// Process signal.
 ///
-/// Asynchronous actors can receive signals by calling
+/// All actors can receive process signals by calling
 /// [`Runtime::receive_signals`] or [`RuntimeRef::receive_signals`] with their
-/// actor reference.
-///
-/// Synchronous actor receive signals automatically if they can receive them,
-/// i.e. if their [message type] implements [`TryFrom`]`<Signal>`. For more
-/// information see the [`SyncActor`] trait.
+/// actor reference. This causes all process signals to be relayed to the actor
+/// which should handle them accordingly.
 ///
 /// [`Runtime::receive_signals`]: crate::Runtime::receive_signals
 /// [`RuntimeRef::receive_signals`]: crate::RuntimeRef::receive_signals
-/// [message type]: crate::actor::SyncActor::Message
-/// [`TryFrom`]: std::convert::TryFrom
-/// [`SyncActor`]: crate::actor::SyncActor
 ///
 /// # Notes
 ///
-/// What happends to threads spawned outside of Heph's control, i.e. manually
+/// What happens to threads spawned outside of Heph's control, i.e. manually
 /// spawned, before calling [`rt::Setup::build`] is unspecified. They may still
 /// receive a process signal or they may not. This is due to platform
 /// limitations and differences. Any manually spawned threads spawned after
 /// calling build should not get a process signal.
+///
+/// The runtime will only attempt to send the process signal to the actor once.
+/// If the message can't be send it's **not** retried. Ensure that the inbox of
+/// the actor has enough room to receive the message.
 ///
 /// [`rt::Setup::build`]: crate::rt::Setup::build
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/spawn/mod.rs
+++ b/src/spawn/mod.rs
@@ -78,6 +78,8 @@ mod private {
     use crate::supervisor::Supervisor;
 
     /// Private version of the [`Spawn`]  trait.
+    ///
+    /// [`Spawn`]: super::Spawn
     pub trait PrivateSpawn<S, NA, RT> {
         /// Spawn an actor that needs to be initialised.
         ///


### PR DESCRIPTION
This still documented when sync actors received process signals
automatically, but this is no longer the case.

