### PR TITLE
Document all usages of atomics

### DIFF
--- a/src/actor_ref/mod.rs
+++ b/src/actor_ref/mod.rs
@@ -629,8 +629,9 @@ impl<M> ActorGroup<M> {
                 Ok(())
             }
             Delivery::ToOne => {
+                // Safety: this needs to sync itself.
                 // NOTE: this wraps around on overflow.
-                let idx = self.send_next.fetch_add(1, Ordering::Relaxed) % self.actor_refs.len();
+                let idx = self.send_next.fetch_add(1, Ordering::AcqRel) % self.actor_refs.len();
                 let actor_ref = &self.actor_refs[idx];
                 // TODO: try to send it to another actor on send failure?
                 actor_ref.try_send(msg)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@
     const_option,
     const_raw_ptr_to_usize_cast,
     drain_filter,
-    duration_zero,
     generic_associated_types,
     io_slice_advance,
     is_sorted,

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -263,6 +263,7 @@ impl RuntimeInternals {
         // [1]: https://en.wikipedia.org/wiki/Thundering_herd_problem
         // [2]: https://en.wikipedia.org/wiki/Round-robin_scheduling
         let n = min(n, self.worker_wakers.len());
+        // Safety: needs to sync with itself.
         let wake_worker_idx =
             self.wake_worker_idx.fetch_add(n, Ordering::AcqRel) % self.worker_wakers.len();
         let (wake_second, wake_first) = self.worker_wakers.split_at(wake_worker_idx);

--- a/src/rt/waker.rs
+++ b/src/rt/waker.rs
@@ -33,7 +33,7 @@ pub(crate) fn init(waker: mio::Waker, notifications: Sender<ProcessId>) -> Waker
     /// determines that.
     static THREAD_IDS: AtomicU8 = AtomicU8::new(0);
 
-    let thread_id = THREAD_IDS.fetch_add(1, Ordering::AcqRel);
+    let thread_id = THREAD_IDS.fetch_add(1, Ordering::SeqCst);
     if thread_id as usize >= MAX_THREADS {
         panic!("Created too many Heph worker threads");
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -233,6 +233,8 @@ pub fn set_message_loss(mut percent: u8) {
 
 /// Returns `true` if the message should be lost.
 pub(crate) fn should_lose_msg() -> bool {
+    // Safety: `Relaxed` is fine here as we'll get the update, sending a message
+    // when we're not supposed to isn't too bad.
     let loss = MSG_LOSS.load(Ordering::Relaxed);
     loss != 0 || random_percentage() < loss
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -181,6 +181,7 @@ impl CoordinatorLog {
 
     /// Returns the next stream counter.
     fn next_stream_count(&mut self) -> u32 {
+        // Safety: needs to sync with itself.
         self.shared.counter.fetch_add(1, atomic::Ordering::AcqRel)
     }
 }
@@ -355,6 +356,7 @@ impl<'a> TraceLog for &'a SharedLog {
 
         BUF.with(|buf| {
             let mut buf = buf.borrow_mut();
+            // Safety: needs to sync with itself.
             let stream_count = self.counter.fetch_add(1, atomic::Ordering::AcqRel);
             format_event(
                 &mut buf,


### PR DESCRIPTION
In the past the *correct* use of atomics is trickier than it first
seems. It often requires checking the assembly for correctness and it
requires knowing what other locations access the same memory.

This commit documents all atomic operations that don't use `SeqCst` why
the ordering doesn't need to be higher and with other point (in the
code) the operations need to synchronise.

Also increases atomic ordering in `ThreadWaker::wake`

For `ThreadWaker::wake` the `load` is increased from `Relaxed` to `Acquire` to
sync with the `store` in `ThreadWaker::mark_polling`.

