### PR TITLE
Fix Future impl for SendFileAll

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
     available_concurrency,
     binary_heap_retain,
     const_fn,
+    const_fn_trait_bound,
     const_option,
     const_raw_ptr_to_usize_cast,
     drain_filter,

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -911,8 +911,8 @@ where
     fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
         #[rustfmt::skip]
         let SendFileAll { stream, file, start, end } = Pin::into_inner(self);
-        let length = end.and_then(|end| NonZeroUsize::new(end.get() - *start));
         loop {
+            let length = end.and_then(|end| NonZeroUsize::new(end.get() - *start));
             match stream.try_send_file(*file, *start, length) {
                 // If zero bytes are send it means the entire file was send.
                 Ok(0) => break Poll::Ready(Ok(())),


### PR DESCRIPTION
The length was calculated once before the sendfile loop. However in the
loop the start variable was modified, on which the length depends. This
mean more bytes then wanted could be send as the start was updated, but
the length was not.

To fix this simply move the length calculation inside the loop.