### PR TITLE
Output runtime metrics on SIGUSR2 process signal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ heph-inbox        = { version = "0.1.1", default-features = false }
 libc              = { version = "0.2.79", default-features = false }
 log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }
-mio-signals       = { version = "0.1.2", default-features = false }
+mio-signals       = { version = "0.1.5", default-features = false }
 socket2           = { version = "0.4.0", default-features = false, features = ["all"] }
 
 # Optional dependencies, enabled by features.

--- a/examples/6_process_signals.rs
+++ b/examples/6_process_signals.rs
@@ -62,6 +62,7 @@ impl TryFrom<Signal> for Message {
     fn try_from(signal: Signal) -> Result<Self, Self::Error> {
         match signal {
             Signal::Interrupt | Signal::Terminate | Signal::Quit => Ok(Message::Terminate),
+            _ => Err(()),
         }
     }
 }

--- a/src/net/tcp/server.rs
+++ b/src/net/tcp/server.rs
@@ -577,6 +577,7 @@ impl TryFrom<Signal> for Message {
     fn try_from(signal: Signal) -> Result<Self, Self::Error> {
         match signal {
             Signal::Interrupt | Signal::Terminate | Signal::Quit => Ok(Message { inner: () }),
+            _ => Err(()),
         }
     }
 }

--- a/src/rt/local/scheduler/inactive.rs
+++ b/src/rt/local/scheduler/inactive.rs
@@ -57,6 +57,11 @@ impl Inactive {
         }
     }
 
+    /// Returns the number of processes in the inactive list.
+    pub(super) fn len(&self) -> usize {
+        self.length
+    }
+
     /// Returns `true` if the queue contains a process.
     pub(super) const fn has_process(&self) -> bool {
         self.length != 0

--- a/src/rt/local/scheduler/mod.rs
+++ b/src/rt/local/scheduler/mod.rs
@@ -34,12 +34,27 @@ pub(crate) struct Scheduler {
     inactive: Inactive,
 }
 
+/// Metrics for [`Scheduler`].
+#[derive(Debug)]
+pub(crate) struct Metrics {
+    ready: usize,
+    inactive: usize,
+}
+
 impl Scheduler {
     /// Create a new `Scheduler`.
     pub(crate) fn new() -> Scheduler {
         Scheduler {
             ready: BinaryHeap::new(),
             inactive: Inactive::empty(),
+        }
+    }
+
+    /// Gather metrics about the scheduler.
+    pub(crate) fn metrics(&self) -> Metrics {
+        Metrics {
+            ready: self.ready.len(),
+            inactive: self.inactive.len(),
         }
     }
 

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -96,12 +96,27 @@ pub(crate) struct RuntimeInternals {
     trace_log: Option<Arc<trace::SharedLog>>,
 }
 
+/// Metrics for [`RuntimeInternals`].
+#[derive(Debug)]
+pub(crate) struct Metrics {
+    scheduler: scheduler::Metrics,
+    timers: timers::Metrics,
+}
+
 impl RuntimeInternals {
     /// Setup new runtime internals.
     pub(crate) fn setup() -> io::Result<RuntimeSetup> {
         let poll = Poll::new()?;
         let registry = poll.registry().try_clone()?;
         Ok(RuntimeSetup { poll, registry })
+    }
+
+    /// Gather metrics about the shared runtime state.
+    pub(crate) fn metrics(&self) -> Metrics {
+        Metrics {
+            scheduler: self.scheduler.metrics(),
+            timers: self.timers.metrics(),
+        }
     }
 
     /// Returns a new [`task::Waker`] for the thread-safe actor with `pid`.

--- a/src/rt/shared/scheduler/inactive.rs
+++ b/src/rt/shared/scheduler/inactive.rs
@@ -62,6 +62,18 @@ impl Inactive {
         }
     }
 
+    /// Returns the number of processes in the inactive list.
+    pub(super) fn len(&self) -> usize {
+        let len = self.length.load(Ordering::Relaxed);
+        // The `length` can actually underflow quite easily, to not report a
+        // clearly incorrect value we'll report zero instead.
+        if len & (1 << 63) == 0 {
+            len
+        } else {
+            0
+        }
+    }
+
     /// Returns `true` if the queue contains a process.
     ///
     /// # Notes

--- a/src/rt/shared/scheduler/mod.rs
+++ b/src/rt/shared/scheduler/mod.rs
@@ -102,12 +102,27 @@ pub(super) struct Scheduler {
     inactive: Inactive,
 }
 
+/// Metrics for [`Scheduler`].
+#[derive(Debug)]
+pub(crate) struct Metrics {
+    ready: usize,
+    inactive: usize,
+}
+
 impl Scheduler {
     /// Create a new `Scheduler`.
     pub(super) fn new() -> Scheduler {
         Scheduler {
             ready: RunQueue::empty(),
             inactive: Inactive::empty(),
+        }
+    }
+
+    /// Gather metrics about the scheduler.
+    pub(crate) fn metrics(&self) -> Metrics {
+        Metrics {
+            ready: self.ready.len(),
+            inactive: self.inactive.len(),
         }
     }
 

--- a/src/rt/shared/scheduler/runqueue.rs
+++ b/src/rt/shared/scheduler/runqueue.rs
@@ -33,6 +33,18 @@ impl RunQueue {
         }
     }
 
+    /// Returns the number of processes in the queue.
+    ///
+    /// # Notes
+    ///
+    /// Don't call this often, it's terrible for performance.
+    pub(super) fn len(&self) -> usize {
+        match &mut *self.root.lock().unwrap() {
+            Some(branch) => branch.len(),
+            None => 0,
+        }
+    }
+
     /// Returns `true` if the queue contains any process.
     pub(super) fn has_process(&self) -> bool {
         self.root.lock().unwrap().is_some()
@@ -92,6 +104,18 @@ impl Node {
             left: None,
             right: None,
         })
+    }
+
+    /// Returns the number of processes in this node and it's descendants.
+    fn len(&self) -> usize {
+        let mut count = 1; // Count ourselves.
+        if let Some(branch) = self.left.as_ref() {
+            count += branch.len();
+        }
+        if let Some(branch) = self.right.as_ref() {
+            count += branch.len();
+        }
+        count
     }
 }
 

--- a/src/rt/signal.rs
+++ b/src/rt/signal.rs
@@ -49,6 +49,14 @@ pub enum Signal {
     ///
     /// Corresponds to POSIX signal `SIGQUIT`.
     Quit,
+    /// User-defined signal 1.
+    ///
+    /// Corresponds to POSIX signal `SIGUSR1`.
+    User1,
+    /// User-defined signal 2.
+    ///
+    /// Corresponds to POSIX signal `SIGUSR2`.
+    User2,
 }
 
 impl Signal {
@@ -58,13 +66,17 @@ impl Signal {
             mio_signals::Signal::Interrupt => Signal::Interrupt,
             mio_signals::Signal::Terminate => Signal::Terminate,
             mio_signals::Signal::Quit => Signal::Quit,
+            mio_signals::Signal::User1 => Signal::User1,
+            mio_signals::Signal::User2 => Signal::User2,
         }
     }
 
     /// Whether or not the `Signal` is considered a "stopping" signal.
-    #[allow(clippy::unused_self)] // When more signals are added `self` is needed.
     pub(super) const fn should_stop(self) -> bool {
-        true
+        match self {
+            Signal::Interrupt | Signal::Terminate | Signal::Quit => true,
+            Signal::User1 | Signal::User2 => false,
+        }
     }
 
     /// Returns a human readable name for the signal.
@@ -73,6 +85,8 @@ impl Signal {
             Signal::Interrupt => "interrupt",
             Signal::Terminate => "terminate",
             Signal::Quit => "quit",
+            Signal::User1 => "user-1",
+            Signal::User2 => "user-2",
         }
     }
 
@@ -82,6 +96,8 @@ impl Signal {
             Signal::Interrupt => "SIGINT",
             Signal::Terminate => "SIGTERM",
             Signal::Quit => "SIGQUIT",
+            Signal::User1 => "SIGUSR1",
+            Signal::User2 => "SIGUSR2",
         }
     }
 }

--- a/src/rt/signal.rs
+++ b/src/rt/signal.rs
@@ -56,6 +56,11 @@ pub enum Signal {
     /// User-defined signal 2.
     ///
     /// Corresponds to POSIX signal `SIGUSR2`.
+    ///
+    /// # Notes
+    ///
+    /// The runtime will output various metrics about itself when it receives
+    /// this signal.
     User2,
 }
 

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -150,6 +150,7 @@ fn main(
     };
 
     let mut runtime = Runtime::new(
+        setup.id,
         setup.poll,
         setup.waker_id,
         setup.waker_events,


### PR DESCRIPTION
Adds `rt::Signal::{User1, User2}` to support the `SIGUSR1` and `SIGUSR2` process signals.

Changes the runtime to dump metrics about the runtime when it receives a SIGUSR2 signal. This done using `kill -USR2 $PID`.

The output is ugly and needs improvement, but it's a start.

