### PR TITLE
Add more runtime metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Install nightly compiler
-      run: .github/install.bash
     - name: Add rustfmt
       run: rustup component add rustfmt
     - name: Check formatting

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 #![feature(
     arc_new_cyclic,
     array_methods,
+    destructuring_assignment,
     async_stream,
     available_concurrency,
     binary_heap_retain,

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -254,6 +254,14 @@ impl Coordinator {
 ///
 /// Uses `uname(2)`.
 fn host_info() -> io::Result<(Box<str>, Box<str>)> {
+    // NOTE: we could also use `std::env::consts::OS`, but this looks better.
+    #[cfg(target_os = "linux")]
+    const OS: &str = "GNU/Linux";
+    #[cfg(target_os = "freebsd")]
+    const OS: &str = "FreeBSD";
+    #[cfg(target_os = "macos")]
+    const OS: &str = "macOS";
+
     let mut uname_info: MaybeUninit<libc::utsname> = MaybeUninit::uninit();
     if unsafe { libc::uname(uname_info.as_mut_ptr()) } == -1 {
         return Err(io::Error::last_os_error());
@@ -265,14 +273,6 @@ fn host_info() -> io::Result<(Box<str>, Box<str>)> {
     let release = unsafe { CStr::from_ptr(&uname_info.release as *const _).to_string_lossy() };
     let version = unsafe { CStr::from_ptr(&uname_info.version as *const _).to_string_lossy() };
     let nodename = unsafe { CStr::from_ptr(&uname_info.nodename as *const _).to_string_lossy() };
-
-    // NOTE: we could also use `std::env::consts::OS`, but this looks better.
-    #[cfg(target_os = "linux")]
-    const OS: &'static str = "GNU/Linux";
-    #[cfg(target_os = "freebsd")]
-    const OS: &'static str = "FreeBSD";
-    #[cfg(target_os = "macos")]
-    const OS: &'static str = "macOS";
 
     let os = format!("{} ({} {} {})", OS, sysname, release, version).into_boxed_str();
     let hostname = nodename.into_owned().into_boxed_str();

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -30,6 +30,8 @@ pub(super) struct Coordinator {
     os: Box<str>,
     /// Name of the host. `nodename` field from `uname(2)`.
     hostname: Box<str>,
+    /// Name of the application.
+    app_name: Box<str>,
     /// OS poll, used to poll the status of the (sync) worker threads and
     /// process `signals`.
     poll: Poll,
@@ -48,6 +50,7 @@ struct Metrics<'c, 'l> {
     os: &'c str,
     architecture: &'static str,
     hostname: &'c str,
+    app_name: &'c str,
     process_id: u32,
     parent_process_id: u32,
     uptime: Duration,
@@ -69,6 +72,7 @@ impl Coordinator {
     /// This must be called before creating the worker threads to properly catch
     /// process signals.
     pub(super) fn init(
+        app_name: Box<str>,
         worker_wakers: Box<[&'static ThreadWaker]>,
         trace_log: Option<Arc<trace::SharedLog>>,
     ) -> io::Result<Coordinator> {
@@ -87,6 +91,7 @@ impl Coordinator {
         Ok(Coordinator {
             os,
             hostname,
+            app_name,
             poll,
             signals,
             internals,
@@ -229,6 +234,7 @@ impl Coordinator {
             os: &*self.os,
             architecture: ARCH,
             hostname: &*self.hostname,
+            app_name: &*self.app_name,
             process_id: process::id(),
             parent_process_id: parent_id(),
             uptime: self.start.elapsed(),

--- a/src/rt/local/mod.rs
+++ b/src/rt/local/mod.rs
@@ -15,7 +15,7 @@ use crate::actor_ref::{ActorGroup, Delivery, SendError};
 use crate::rt::error::StringError;
 use crate::rt::process::ProcessId;
 use crate::rt::process::ProcessResult;
-use crate::rt::{self, shared, RuntimeRef, Signal, WakerId};
+use crate::rt::{self, cpu_usage, shared, RuntimeRef, Signal, WakerId};
 use crate::trace;
 
 mod scheduler;
@@ -694,6 +694,7 @@ pub(crate) struct Metrics {
     timers: timers::Metrics,
     process_signal_receivers: usize,
     cpu_affinity: Option<usize>,
+    cpu_time: Duration,
     trace_log: Option<trace::Metrics>,
 }
 
@@ -722,6 +723,7 @@ impl RuntimeInternals {
 
     /// Gather metrics about the runtime internals.
     fn metrics(&self) -> Metrics {
+        let cpu_time = cpu_usage(libc::CLOCK_THREAD_CPUTIME_ID);
         Metrics {
             id: self.id,
             scheduler: self.scheduler.borrow().metrics(),
@@ -729,6 +731,7 @@ impl RuntimeInternals {
             process_signal_receivers: self.signal_receivers.borrow().len(),
             cpu_affinity: self.cpu,
             trace_log: self.trace_log.borrow().as_ref().map(trace::Log::metrics),
+            cpu_time,
         }
     }
 }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -711,17 +711,17 @@ where
 }
 
 fn cpu_usage(clock_id: libc::clockid_t) -> Duration {
-    let mut dur = libc::timespec {
+    let mut duration = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    if unsafe { libc::clock_gettime(clock_id, &mut dur) } == -1 {
+    if unsafe { libc::clock_gettime(clock_id, &mut duration) } == -1 {
         warn!("error getting CPU time: {}", io::Error::last_os_error());
         Duration::ZERO
     } else {
         Duration::new(
-            dur.tv_sec.try_into().unwrap_or(0),
-            dur.tv_nsec.try_into().unwrap_or(u32::MAX),
+            duration.tv_sec.try_into().unwrap_or(0),
+            duration.tv_nsec.try_into().unwrap_or(u32::MAX),
         )
     }
 }

--- a/src/rt/setup.rs
+++ b/src/rt/setup.rs
@@ -207,14 +207,14 @@ impl Setup {
             workers,
             sync_actors: Vec::new(),
             signals: ActorGroup::empty(),
-            trace_log: trace_log,
+            trace_log,
         })
     }
 }
 
 /// Returns the name of the binary called (i.e. arg[0]) as name.
 fn default_app_name() -> String {
-    match env::args().nth(0) {
+    match env::args().next() {
         Some(mut bin_path) => {
             if let Some(idx) = bin_path.rfind('/') {
                 drop(bin_path.drain(..=idx));


### PR DESCRIPTION
Adds:
* Heph version.
* OS.
* Hostname.
* Architecture.
* Process ID.
* Parent process ID.
* Uptime.
* thread and process CPU usage

Also switches the CI to use stable rustfmt as the nightly version is sometimes not available.

