### PR TITLE
Catch panics in running spawn actors and Futures

### DIFF
--- a/src/rt/local/mod.rs
+++ b/src/rt/local/mod.rs
@@ -64,6 +64,25 @@ pub(crate) struct Runtime {
     started: bool,
 }
 
+/// Run a block of code, catching panics when testing or not otherwise.
+macro_rules! catch_in_test {
+    ($fmt: tt, $code: block) => {
+        #[cfg(any(test, feature = "test"))]
+        if let Err(err) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $code)) {
+            let msg = match err.downcast_ref::<&'static str>() {
+                Some(s) => *s,
+                None => match err.downcast_ref::<String>() {
+                    Some(s) => &**s,
+                    None => "<unknown>",
+                },
+            };
+            eprintln!($fmt, msg);
+        }
+        #[cfg(not(any(test, feature = "test")))]
+        $code
+    };
+}
+
 impl Runtime {
     /// Create a new local `Runtime`.
     #[allow(clippy::too_many_arguments)]
@@ -172,21 +191,23 @@ impl Runtime {
     fn run_local_process(&mut self, runtime_ref: &mut RuntimeRef) -> bool {
         let process = self.internals.scheduler.borrow_mut().next_process();
         if let Some(mut process) = process {
-            let timing = trace::start(&*self.internals.trace_log.borrow());
-            let pid = process.as_ref().id();
-            let name = process.as_ref().name();
-            match process.as_mut().run(runtime_ref) {
-                ProcessResult::Complete => {}
-                ProcessResult::Pending => {
-                    self.internals.scheduler.borrow_mut().add_process(process);
+            catch_in_test!("Thread-local actor panicked: '{}'", {
+                let timing = trace::start(&*self.internals.trace_log.borrow());
+                let pid = process.as_ref().id();
+                let name = process.as_ref().name();
+                match process.as_mut().run(runtime_ref) {
+                    ProcessResult::Complete => {}
+                    ProcessResult::Pending => {
+                        self.internals.scheduler.borrow_mut().add_process(process);
+                    }
                 }
-            }
-            trace::finish_rt(
-                self.internals.trace_log.borrow_mut().as_mut(),
-                timing,
-                "Running thread-local process",
-                &[("id", &pid.0), ("name", &name)],
-            );
+                trace::finish_rt(
+                    self.internals.trace_log.borrow_mut().as_mut(),
+                    timing,
+                    "Running thread-local process",
+                    &[("id", &pid.0), ("name", &name)],
+                );
+            });
             true
         } else {
             false
@@ -198,23 +219,25 @@ impl Runtime {
     fn run_shared_process(&mut self, runtime_ref: &mut RuntimeRef) -> bool {
         let process = self.internals.shared.remove_process();
         if let Some(mut process) = process {
-            let timing = trace::start(&*self.internals.trace_log.borrow());
-            let pid = process.as_ref().id();
-            let name = process.as_ref().name();
-            match process.as_mut().run(runtime_ref) {
-                ProcessResult::Complete => {
-                    self.internals.shared.complete(process);
+            catch_in_test!("Thread-safe actor panicked: '{}'", {
+                let timing = trace::start(&*self.internals.trace_log.borrow());
+                let pid = process.as_ref().id();
+                let name = process.as_ref().name();
+                match process.as_mut().run(runtime_ref) {
+                    ProcessResult::Complete => {
+                        self.internals.shared.complete(process);
+                    }
+                    ProcessResult::Pending => {
+                        self.internals.shared.add_process(process);
+                    }
                 }
-                ProcessResult::Pending => {
-                    self.internals.shared.add_process(process);
-                }
-            }
-            trace::finish_rt(
-                self.internals.trace_log.borrow_mut().as_mut(),
-                timing,
-                "Running thread-safe process",
-                &[("id", &pid.0), ("name", &name)],
-            );
+                trace::finish_rt(
+                    self.internals.trace_log.borrow_mut().as_mut(),
+                    timing,
+                    "Running thread-safe process",
+                    &[("id", &pid.0), ("name", &name)],
+                );
+            });
             true
         } else {
             false

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -3,6 +3,7 @@
 #![feature(
     async_stream,
     drain_filter,
+    future_poll_fn,
     maybe_uninit_slice,
     never_type,
     once_cell,

--- a/tests/functional/test.rs
+++ b/tests/functional/test.rs
@@ -1,12 +1,15 @@
 //! Tests for the `test` module.
 
+use std::future::poll_fn;
 use std::mem::size_of;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
 use heph::actor::{self, Actor, NewActor};
 use heph::rt::ThreadLocal;
-use heph::test::{size_of_actor, size_of_actor_val};
+use heph::spawn::{ActorOptions, FutureOptions};
+use heph::supervisor::NoSupervisor;
+use heph::test::{size_of_actor, size_of_actor_val, spawn_future, try_spawn, try_spawn_local};
 
 #[test]
 fn test_size_of_actor() {
@@ -52,4 +55,26 @@ fn test_size_of_actor() {
     assert_eq!(size_of::<A>(), 0);
     assert_eq!(size_of_actor::<Na>(), 0);
     assert_eq!(size_of_actor_val(&Na), 0);
+}
+
+async fn panic_actor<RT>(_: actor::Context<!, RT>) {
+    panic!("panic in actor");
+}
+
+#[test]
+fn catch_panics_spawned_local_actor() {
+    let actor = panic_actor as fn(_) -> _;
+    try_spawn_local(NoSupervisor, actor, (), ActorOptions::default()).unwrap();
+}
+
+#[test]
+fn catch_panics_spawned_actor() {
+    let actor = panic_actor as fn(_) -> _;
+    try_spawn(NoSupervisor, actor, (), ActorOptions::default()).unwrap();
+}
+
+#[test]
+fn catch_panics_spawned_future() {
+    let future = poll_fn(|_| panic!("panic in spawned Future"));
+    spawn_future(future, FutureOptions::default());
 }


### PR DESCRIPTION
This makes testing functions such as `try_spawn_local`, `try_spawn` and
`spawn_future` a lot more useful.