### PR TITLE
Add host id to Coordinator metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ test = ["getrandom"]
 [dependencies]
 crossbeam-channel = { version = "0.5.0", default-features = false, features = ["std"] }
 heph-inbox        = { version = "0.2.1", default-features = false }
-libc              = { version = "0.2.79", default-features = false }
+libc              = { version = "0.2.96", default-features = false }
 log               = { version = "0.4.8", default-features = false }
 mio               = { version = "0.7.5", default-features = false, features = ["os-poll", "tcp", "udp", "pipe"] }
 mio-signals       = { version = "0.1.5", default-features = false }

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -302,6 +302,7 @@ fn host_info() -> io::Result<(Box<str>, Box<str>)> {
 
 /// Get the host id by reading `/etc/machine-id` on Linux or `/etc/hostid` on
 /// FreeBSD.
+#[allow(clippy::doc_markdown)] // Remove after https://github.com/rust-lang/rust-clippy/pull/7334 is released.
 #[cfg(any(target_os = "freebsd", target_os = "linux"))]
 fn host_id() -> io::Result<Uuid> {
     use std::fs::File;

--- a/src/rt/coordinator.rs
+++ b/src/rt/coordinator.rs
@@ -29,7 +29,8 @@ pub(super) struct Coordinator {
     /// OS name and version, from `uname(2)`.
     os: Box<str>,
     /// Name of the host. `nodename` field from `uname(2)`.
-    hostname: Box<str>,
+    host_name: Box<str>,
+    host_id: Uuid,
     /// Name of the application.
     app_name: Box<str>,
     /// OS poll, used to poll the status of the (sync) worker threads and
@@ -49,7 +50,8 @@ struct Metrics<'c, 'l> {
     heph_version: &'static str,
     os: &'c str,
     architecture: &'static str,
-    hostname: &'c str,
+    host_name: &'c str,
+    host_id: Uuid,
     app_name: &'c str,
     process_id: u32,
     parent_process_id: u32,
@@ -62,6 +64,22 @@ struct Metrics<'c, 'l> {
     total_cpu_time: Duration,
     cpu_time: Duration,
     trace_log: Option<trace::CoordinatorMetrics<'l>>,
+}
+
+#[derive(Copy, Clone)]
+struct Uuid(u128);
+
+impl fmt::Display for Uuid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Always force a length of 32.
+        write!(f, "{:032x}", self.0)
+    }
+}
+
+impl fmt::Debug for Uuid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
 }
 
 impl Coordinator {
@@ -87,10 +105,12 @@ impl Coordinator {
             setup.complete(waker_id, worker_wakers, trace_log)
         });
 
-        let (os, hostname) = host_info()?;
+        let (os, host_name) = host_info()?;
+        let host_id = host_id()?;
         Ok(Coordinator {
             os,
-            hostname,
+            host_name,
+            host_id,
             app_name,
             poll,
             signals,
@@ -233,7 +253,8 @@ impl Coordinator {
             heph_version: concat!("v", env!("CARGO_PKG_VERSION")),
             os: &*self.os,
             architecture: ARCH,
-            hostname: &*self.hostname,
+            host_name: &*self.host_name,
+            host_id: self.host_id,
             app_name: &*self.app_name,
             process_id: process::id(),
             parent_process_id: parent_id(),
@@ -277,6 +298,119 @@ fn host_info() -> io::Result<(Box<str>, Box<str>)> {
     let os = format!("{} ({} {} {})", OS, sysname, release, version).into_boxed_str();
     let hostname = nodename.into_owned().into_boxed_str();
     Ok((os, hostname))
+}
+
+/// Get the host id by reading `/etc/machine-id` on Linux or `/etc/hostid` on
+/// FreeBSD.
+#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+fn host_id() -> io::Result<Uuid> {
+    use std::fs::File;
+    use std::io::Read;
+
+    // See <https://www.freedesktop.org/software/systemd/man/machine-id.html>.
+    #[cfg(target_os = "linux")]
+    const PATH: &str = "/etc/machine-id";
+    // Hexadecimal, 32 characters.
+    #[cfg(target_os = "linux")]
+    const EXPECTED_SIZE: usize = 32;
+
+    // No docs, but a bug tracker:
+    // <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255293>.
+    #[cfg(target_os = "freebsd")]
+    const PATH: &str = "/etc/hostid";
+    // Hexadecimal, hypenated, 36 characters.
+    #[cfg(target_os = "freebsd")]
+    const EXPECTED_SIZE: usize = 36;
+
+    let mut buf = [0; EXPECTED_SIZE];
+    let mut file = File::open(PATH)?;
+    let n = file.read(&mut buf).map_err(|err| {
+        let msg = format!("can't open '{}': {}", PATH, err);
+        io::Error::new(err.kind(), msg)
+    })?;
+
+    if n == EXPECTED_SIZE {
+        #[cfg(target_os = "linux")]
+        let res = from_hex(&buf[..EXPECTED_SIZE]);
+        #[cfg(target_os = "freebsd")]
+        let res = from_hex_hyphenated(&buf[..EXPECTED_SIZE]);
+
+        res.map_err(|()| {
+            let msg = format!("invalid `{}` format: input is not hex", PATH);
+            io::Error::new(io::ErrorKind::InvalidData, msg)
+        })
+    } else {
+        let msg = format!(
+            "can't read '{}', invalid format: only read {} bytes (expected {})",
+            PATH, n, EXPECTED_SIZE,
+        );
+        Err(io::Error::new(io::ErrorKind::InvalidData, msg))
+    }
+}
+
+/// `input` should be 32 bytes long.
+#[cfg(target_os = "linux")]
+fn from_hex(input: &[u8]) -> Result<Uuid, ()> {
+    let mut bytes = [0; 16];
+    for (idx, chunk) in input.chunks_exact(2).enumerate() {
+        let lower = from_hex_byte(chunk[1])?;
+        let higher = from_hex_byte(chunk[0])?;
+        bytes[idx] = lower | (higher << 4);
+    }
+    Ok(Uuid(u128::from_be_bytes(bytes)))
+}
+
+/// `input` should be 36 bytes long.
+#[cfg(target_os = "freebsd")]
+fn from_hex_hyphenated(input: &[u8]) -> Result<Uuid, ()> {
+    let mut bytes = [0; 16];
+    let mut idx = 0;
+
+    // Groups of 8, 4, 4, 4, 12 bytes.
+    let groups: [std::ops::Range<usize>; 5] = [0..8, 9..13, 14..18, 19..23, 24..36];
+
+    for group in groups {
+        let group_end = group.end;
+        for chunk in input[group].chunks_exact(2) {
+            let lower = from_hex_byte(chunk[1])?;
+            let higher = from_hex_byte(chunk[0])?;
+            bytes[idx] = lower | (higher << 4);
+            idx += 1;
+        }
+
+        if let Some(b) = input.get(group_end) {
+            if *b != b'-' {
+                return Err(());
+            }
+        }
+    }
+
+    Ok(Uuid(u128::from_be_bytes(bytes)))
+}
+
+#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+const fn from_hex_byte(b: u8) -> Result<u8, ()> {
+    match b {
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        b'0'..=b'9' => Ok(b - b'0'),
+        _ => Err(()),
+    }
+}
+
+/// Gets the host id by calling `gethostuuid` on macOS.
+#[cfg(target_os = "macos")]
+fn host_id() -> io::Result<Uuid> {
+    let mut bytes = [0; 16];
+    let timeout = libc::timespec {
+        tv_sec: 1, // This shouldn't block, but just in case. SQLite does this also.
+        tv_nsec: 0,
+    };
+    if unsafe { libc::gethostuuid(bytes.as_mut_ptr(), &timeout) } == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(Uuid(u128::from_be_bytes(bytes)))
+    }
 }
 
 /// Set of signals we're listening for.


### PR DESCRIPTION
Add a host or machine id to the coordinator metrics.

On Linux this uses the `/etc/hostid` file, which is a systemd specific
file. More documentation at
https://www.freedesktop.org/software/systemd/man/machine-id.html.

For FreeBSD we use `/etc/machine-id`, which isn't actually documented
anywhere, but has an open issue to do so:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255293.

On macOS we can use the `gethostuuid(2)` system call.