### PR TITLE
Change Headers::get_value

### DIFF
--- a/http/src/header.rs
+++ b/http/src/header.rs
@@ -98,7 +98,8 @@ impl Headers {
     ///
     /// # Notes
     ///
-    /// If all you need is the header value you can use [`Headers::get_value`].
+    /// If all you need is the header value you can use [`Headers::get_value`]
+    /// or [`Headers::get_bytes`] for the raw value.
     pub fn get(&self, name: &HeaderName<'_>) -> Option<Header<'_, '_>> {
         for part in &self.parts {
             if part.name == *name {
@@ -109,6 +110,20 @@ impl Headers {
             }
         }
         None
+    }
+
+    /// Get the header's value with `name`, if any.
+    ///
+    /// This returns `Ok(None)` if there is no header with `name` and `Err(..)`
+    /// in case [`FromHeaderValue`] for `T` returns an error.
+    pub fn get_value<'a, T>(&'a self, name: &HeaderName<'_>) -> Result<Option<T>, T::Err>
+    where
+        T: FromHeaderValue<'a>,
+    {
+        match self.get_bytes(name) {
+            Some(value) => FromHeaderValue::from_bytes(value).map(Some),
+            None => Ok(None),
+        }
     }
 
     /// Get the header's value with `name` as byte slice, if any.

--- a/http/src/header.rs
+++ b/http/src/header.rs
@@ -111,8 +111,8 @@ impl Headers {
         None
     }
 
-    /// Get the header's value with `name`, if any.
-    pub fn get_value<'a>(&'a self, name: &HeaderName<'_>) -> Option<&'a [u8]> {
+    /// Get the header's value with `name` as byte slice, if any.
+    pub fn get_bytes<'a>(&'a self, name: &HeaderName<'_>) -> Option<&'a [u8]> {
         for part in &self.parts {
             if part.name == *name {
                 return Some(&self.values[part.start..part.end]);

--- a/http/tests/functional/client.rs
+++ b/http/tests/functional/client.rs
@@ -1357,7 +1357,7 @@ fn expect_request(
     );
     for got_header in request.headers {
         let got_header_name = HeaderName::from_str(got_header.name);
-        let got = headers.get_value(&got_header_name).unwrap();
+        let got = headers.get_bytes(&got_header_name).unwrap();
         assert_eq!(
             got_header.value,
             got,
@@ -1390,7 +1390,7 @@ async fn expect_response(
         headers
     );
     for got_header in response.headers().iter() {
-        let expected = headers.get_value(&got_header.name()).unwrap();
+        let expected = headers.get_bytes(&got_header.name()).unwrap();
         assert_eq!(
             got_header.value(),
             expected,

--- a/http/tests/functional/header.rs
+++ b/http/tests/functional/header.rs
@@ -158,10 +158,12 @@ fn headers_get_not_found() {
     let mut headers = Headers::EMPTY;
     assert!(headers.get(&HeaderName::DATE).is_none());
     assert!(headers.get_bytes(&HeaderName::DATE).is_none());
+    assert_eq!(headers.get_value::<&str>(&HeaderName::DATE), Ok(None));
 
     headers.add(Header::new(HeaderName::ALLOW, b"GET"));
     assert!(headers.get(&HeaderName::DATE).is_none());
     assert!(headers.get_bytes(&HeaderName::DATE).is_none());
+    assert_eq!(headers.get_value::<&str>(&HeaderName::DATE), Ok(None));
 }
 
 #[test]
@@ -197,6 +199,7 @@ fn check_header<'a, T>(
     assert_eq!(got.parse::<T>().unwrap(), parsed_value);
 
     assert_eq!(headers.get_bytes(name).unwrap(), value);
+    assert_eq!(headers.get_value(name).unwrap(), Some(parsed_value));
 }
 
 fn check_iter(headers: &'_ Headers, expected: &[(HeaderName<'_>, &'_ [u8])]) {

--- a/http/tests/functional/header.rs
+++ b/http/tests/functional/header.rs
@@ -157,11 +157,11 @@ fn headers_from_iter_and_extend() {
 fn headers_get_not_found() {
     let mut headers = Headers::EMPTY;
     assert!(headers.get(&HeaderName::DATE).is_none());
-    assert!(headers.get_value(&HeaderName::DATE).is_none());
+    assert!(headers.get_bytes(&HeaderName::DATE).is_none());
 
     headers.add(Header::new(HeaderName::ALLOW, b"GET"));
     assert!(headers.get(&HeaderName::DATE).is_none());
-    assert!(headers.get_value(&HeaderName::DATE).is_none());
+    assert!(headers.get_bytes(&HeaderName::DATE).is_none());
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn check_header<'a, T>(
     assert_eq!(got.value(), value);
     assert_eq!(got.parse::<T>().unwrap(), parsed_value);
 
-    assert_eq!(headers.get_value(name).unwrap(), value);
+    assert_eq!(headers.get_bytes(name).unwrap(), value);
 }
 
 fn check_iter(headers: &'_ Headers, expected: &[(HeaderName<'_>, &'_ [u8])]) {

--- a/http/tests/functional/server.rs
+++ b/http/tests/functional/server.rs
@@ -529,7 +529,7 @@ fn expect_response(
     );
     for got_header in response.headers {
         let got_header_name = HeaderName::from_str(got_header.name);
-        let got = headers.get_value(&got_header_name).unwrap();
+        let got = headers.get_bytes(&got_header_name).unwrap();
         assert_eq!(
             got_header.value,
             got,


### PR DESCRIPTION
First renames `Headers::get_value` to `get_bytes` to free up the name. Next it adds back `Headers::get_value`, but this version returns a parsed header value, using the `FromHeaderValue` trait.

