### PR TITLE
Add {RequestHead, ResponseHead}::header

### DIFF
--- a/http/src/head/mod.rs
+++ b/http/src/head/mod.rs
@@ -16,6 +16,7 @@ pub use status_code::StatusCode;
 pub use version::Version;
 
 use crate::{Request, Response};
+use header::FromHeaderValue;
 
 /// Head of a [`Request`].
 pub struct RequestHead {
@@ -75,6 +76,16 @@ impl RequestHead {
         &mut self.headers
     }
 
+    /// Get the header’s value with `name`, if any.
+    ///
+    /// See [`Headers::get_value`] for more information.
+    pub fn header<'a, T>(&'a self, name: &HeaderName<'_>) -> Result<Option<T>, T::Err>
+    where
+        T: FromHeaderValue<'a>,
+    {
+        self.headers.get_value(name)
+    }
+
     /// Add a body to the request head creating a complete request.
     pub const fn add_body<B>(self, body: B) -> Request<B> {
         Request::from_head(self, body)
@@ -127,6 +138,16 @@ impl ResponseHead {
     /// Returns mutable access to the headers.
     pub const fn headers_mut(&mut self) -> &mut Headers {
         &mut self.headers
+    }
+
+    /// Get the header’s value with `name`, if any.
+    ///
+    /// See [`Headers::get_value`] for more information.
+    pub fn header<'a, T>(&'a self, name: &HeaderName<'_>) -> Result<Option<T>, T::Err>
+    where
+        T: FromHeaderValue<'a>,
+    {
+        self.headers.get_value(name)
     }
 
     /// Add a body to the response head creating a complete response.

--- a/http/tests/functional/head.rs
+++ b/http/tests/functional/head.rs
@@ -1,4 +1,6 @@
-use heph_http::head::{RequestHead, ResponseHead};
+use heph_http::head::{
+    Header, HeaderName, Headers, Method, RequestHead, ResponseHead, StatusCode, Version,
+};
 
 use crate::assert_size;
 
@@ -6,4 +8,26 @@ use crate::assert_size;
 fn size() {
     assert_size::<RequestHead>(80);
     assert_size::<ResponseHead>(56);
+}
+
+#[test]
+fn request_header() {
+    let headers = Headers::EMPTY;
+    let mut head = RequestHead::new(Method::Get, "/".to_string(), Version::Http10, headers);
+    assert_eq!(head.header::<&str>(&HeaderName::USER_AGENT), Ok(None));
+
+    let header = Header::new(HeaderName::USER_AGENT, b"Heph-HTTP");
+    head.headers_mut().add(header);
+    assert_eq!(head.header(&HeaderName::USER_AGENT), Ok(Some("Heph-HTTP")));
+}
+
+#[test]
+fn response_header() {
+    let headers = Headers::EMPTY;
+    let mut head = ResponseHead::new(Version::Http10, StatusCode::OK, headers);
+    assert_eq!(head.header::<&str>(&HeaderName::USER_AGENT), Ok(None));
+
+    let header = Header::new(HeaderName::USER_AGENT, b"Heph-HTTP");
+    head.headers_mut().add(header);
+    assert_eq!(head.header(&HeaderName::USER_AGENT), Ok(Some("Heph-HTTP")));
 }


### PR DESCRIPTION
Convenience method to get the header from the request or response.