### PR TITLE
Implement Process::name for FutureProcess

### DIFF
--- a/src/rt/process/future.rs
+++ b/src/rt/process/future.rs
@@ -32,7 +32,7 @@ where
     RT: rt::Access,
 {
     fn name(&self) -> &'static str {
-        "Future"
+        crate::actor::name::<Fut>()
     }
 
     fn run(self: Pin<&mut Self>, runtime_ref: &mut RuntimeRef, pid: ProcessId) -> ProcessResult {

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -311,7 +311,7 @@ where
 /// * Additional logging message, defaults to nothing extra. This uses normal
 ///   [rust formatting rules] and is added at the end of the default message,
 ///   after the error. The `args` keyword gives access to the arguments. See
-///   example 7 restart_supervisor (in the example directory of the source
+///   example 7 Restart Supervisor (in the example directory of the source
 ///   code).
 ///
 /// The new type can be created using the `new` function, e.g.
@@ -342,7 +342,7 @@ where
 /// # Examples
 ///
 /// The example below shows the simplest usage of the `restart_supervisor`
-/// macro. Example 7 restart_supervisor (in the example directory of the source
+/// macro. Example 7 Restart Supervisor (in the example directory of the source
 /// code) has a more complete example.
 ///
 /// ```

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -12,7 +12,6 @@ use std::stream::Stream;
 use std::sync::Once;
 use std::task::{self, Poll};
 
-#[track_caller]
 macro_rules! limited_loop {
     ($($arg: tt)*) => {{
         let mut range = (0..1_000);


### PR DESCRIPTION
Most futures are properly named, so we can use the same logic as we do
for ActorProcess.