### PR TITLE
Use httparse::Request::parse_with_uninit_headers

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 heph     = { version = "0.3.0", path = "../", default-features = false }
-httparse = { version = "1.4.0", default-features = false }
+httparse = { version = "1.5.1", default-features = false }
 httpdate = { version = "1.0.0", default-features = false }
 log      = { version = "0.4.8", default-features = false }
 itoa     = { version = "0.4.7", default-features = false }

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -7,6 +7,7 @@
     const_panic,
     generic_associated_types,
     io_slice_advance,
+    maybe_uninit_uninit_array,
     maybe_uninit_write_slice,
     stmt_expr_attributes
 )]

--- a/http/src/server.rs
+++ b/http/src/server.rs
@@ -422,11 +422,11 @@ impl Connection {
                 }
             }
 
-            let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
-            let mut request = httparse::Request::new(&mut headers);
+            let mut headers = MaybeUninit::uninit_array::<MAX_HEADERS>();
+            let mut request = httparse::Request::new(&mut []);
             // SAFETY: because we received until at least `self.parsed_bytes >=
             // self.buf.len()` above, we can safely slice the buffer..
-            match request.parse(&self.buf[self.parsed_bytes..]) {
+            match request.parse_with_uninit_headers(&self.buf[self.parsed_bytes..], &mut headers) {
                 Ok(httparse::Status::Complete(head_length)) => {
                     self.parsed_bytes += head_length;
 


### PR DESCRIPTION
Avoids us having to zero the empty headers array.

Closed #497.