### PR TITLE
Add server::Connection::respond_with

### DIFF
--- a/http/examples/route.rs
+++ b/http/examples/route.rs
@@ -103,9 +103,7 @@ async fn http_actor(
             }
         };
 
-        // TODO: improve this, add a `Connection::respond_with(Response)` method.
-        let (head, body) = response.split();
-        let write_response = connection.respond(head.status(), &head.headers(), body);
+        let write_response = connection.respond_with(response);
         Deadline::after(&mut ctx, WRITE_TIMEOUT, write_response).await?;
 
         // Now that we've read a single request we can wait a little for the

--- a/http/src/server.rs
+++ b/http/src/server.rs
@@ -668,6 +668,18 @@ impl Connection {
             .await
     }
 
+    /// Respond to the last parsed request with `response`.
+    ///
+    /// See [`Connection::respond`] for more documentation.
+    #[allow(clippy::future_not_send)] // TODO.
+    pub async fn respond_with<'b, B>(&mut self, response: Response<B>) -> io::Result<()>
+    where
+        B: crate::Body<'b>,
+    {
+        let (head, body) = response.split();
+        self.respond(head.status(), head.headers(), body).await
+    }
+
     /// Send a [`Response`].
     ///
     /// Arguments:


### PR DESCRIPTION
Convenience method to respond with a complete Response. This method is
not a performant as respond, which should still be seen as the default,
as it takes ownership of the headers (which can allocate) even though it
doesn't need to.