### PR TITLE
Reduce allocations mapped actor ref sending and joining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ dev:
 # Reasons to allow lints:
 # `cargo-common-metadata`: for `benches` and `tools`.
 # `equatable-if-let`: bad lint.
+# `match-bool`: often less lines of code.
 # `missing-const-for-fn`: See https://github.com/rust-lang/rust-clippy/issues/4979.
 # `module-name-repetitions`: we re-export various names.
 # `needless-lifetimes`: lifetime serves as documentation.
@@ -79,6 +80,7 @@ lint:
 		--allow clippy::cargo-common-metadata \
 		--allow clippy::enum-glob-use \
 		--allow clippy::equatable-if-let \
+		--allow clippy::match-bool \
 		--allow clippy::missing-const-for-fn \
 		--allow clippy::missing-errors-doc \
 		--allow clippy::missing-panics-doc \


### PR DESCRIPTION
commit c085bbcba275c54f3dd1cccf1b706023203b6b8a
Author: Thomas de Zeeuw <thomasdezeeuw@gmail.com>
Date:   Fri Jan 21 18:56:25 2022 +0100

    Reduce the allocations joining a mapped ActorRef
    
    Similar to what we did for sending we simply check if the other side is
    disconnected before making an allocation for the future.

commit 85296239a17fdd905b06b3bf6dc95fc6b72abeea
Author: Thomas de Zeeuw <thomasdezeeuw@gmail.com>
Date:   Fri Jan 21 18:42:03 2022 +0100

    Reduce the allocations sending with a mapped ActorRef
    
    Before creating a Future attempt to send the message, if this succeeds
    or fails unrecoverably (disconnected), we don't have to make the
    allocation and can return a result directly.

Updates #338.