### PR TITLE
Catch unwind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,8 @@ lint:
 		--allow clippy::ptr-as-ptr \
 		--allow clippy::redundant-pub-crate \
 		--allow clippy::semicolon-if-nothing-returned \
-		--allow clippy::single-match-else \
 		--allow clippy::shadow-unrelated \
+		--allow clippy::single-match-else \
 		--allow clippy::use-self
 
 install_clippy:

--- a/src/rt/local/mod.rs
+++ b/src/rt/local/mod.rs
@@ -181,7 +181,7 @@ impl Runtime {
                 match process.as_mut().run(runtime_ref) {
                     ProcessResult::Complete => {
                         // Don't want to panic when dropping the process.
-                        let _ = catch_unwind(AssertUnwindSafe(move || drop(process)));
+                        drop(catch_unwind(AssertUnwindSafe(move || drop(process))));
                     }
                     ProcessResult::Pending => {
                         self.internals.scheduler.borrow_mut().add_process(process);

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -580,6 +580,16 @@ impl RuntimeRef {
         self.internals.shared.new_task_waker(pid)
     }
 
+    /// Mark the process, with `pid`, as ready to run.
+    fn mark_ready_local(&mut self, pid: ProcessId) {
+        self.internals.scheduler.borrow_mut().mark_ready(pid);
+    }
+
+    /// Mark the shared process, with `pid`, as ready to run.
+    fn mark_ready_shared(&mut self, pid: ProcessId) {
+        self.internals.shared.mark_ready(pid);
+    }
+
     /// Add a deadline.
     fn add_deadline(&mut self, pid: ProcessId, deadline: Instant) {
         trace!("adding deadline: pid={}, deadline={:?}", pid, deadline);

--- a/src/rt/process/mod.rs
+++ b/src/rt/process/mod.rs
@@ -1,5 +1,6 @@
 //! Module containing the `Process` trait, related types and implementations.
 
+use std::any::Any;
 use std::cmp::Ordering;
 use std::fmt;
 use std::pin::Pin;
@@ -94,6 +95,18 @@ pub(crate) enum ProcessResult {
     ///
     /// [`Poll::Pending`]: std::task::Poll::Pending
     Pending,
+}
+
+/// Attempts to extract a message from a panic, defaulting to `<unknown>`.
+/// Note: be sure to derefence the `Box`!
+fn panic_message<'a>(panic: &'a (dyn Any + Send + 'static)) -> &'a str {
+    match panic.downcast_ref::<&'static str>() {
+        Some(s) => *s,
+        None => match panic.downcast_ref::<String>() {
+            Some(s) => &**s,
+            None => "<unknown>",
+        },
+    }
 }
 
 /// Data related to a process.

--- a/src/rt/shared/mod.rs
+++ b/src/rt/shared/mod.rs
@@ -302,7 +302,7 @@ impl RuntimeInternals {
     pub(crate) fn wake_all_workers(&self) {
         trace!("waking all worker thread(s)");
         for worker in self.worker_wakers.iter() {
-            let _ = worker.wake();
+            drop(worker.wake());
         }
     }
 

--- a/src/rt/shared/scheduler/inactive.rs
+++ b/src/rt/shared/scheduler/inactive.rs
@@ -159,7 +159,7 @@ impl Inactive {
         }
 
         // Don't want to panic when dropping the process.
-        let _ = catch_unwind(AssertUnwindSafe(move || drop(process)));
+        drop(catch_unwind(AssertUnwindSafe(move || drop(process))));
     }
 
     /// Update `length` with `n` added/removed processes.


### PR DESCRIPTION
commit 1e3484ee48571b53efb31f3f52e9d2d90f7ffd83
Author: Thomas de Zeeuw <thomasdezeeuw@gmail.com>
Date:   Sun Feb 13 15:16:57 2022 +0100

    Catch panics in spawned Futures

commit 7a19f06d09a0f112a8b1e50151aec09eef6fa9ba
Author: Thomas de Zeeuw <thomasdezeeuw@gmail.com>
Date:   Sun Feb 13 15:39:30 2022 +0100

    Don't run a restarted actor
    
    Instead mark it as ready to run.
    
    This prevents a loop in which the actor always returns an error, but is
    also always restart (which is a bad supervisor implementation, but
    still). This change prevents starvation of the other processes.

commit 97a808b21806df52c4547de485dcbb0a019acba6
Author: Thomas de Zeeuw <thomasdezeeuw@gmail.com>
Date:   Sun Feb 13 15:49:01 2022 +0100

    Refactor ActorProcess logic
    
    Moving most of it out of the Process::run implementation into the error
    handling methods.

commit 65a067092c759f576add4a7607be66bf941f3794
Author: Thomas de Zeeuw <thomasdezeeuw@gmail.com>
Date:   Sun Feb 13 16:23:23 2022 +0100

    Handle panics in actors
    
    This add a new method Supervisor::decide_on_panic which is used when an
    actor panics.
