### PR TITLE
Add runtime feature

### DIFF
--- a/.github/install.bash
+++ b/.github/install.bash
@@ -9,3 +9,6 @@ rustup default nightly
 # Show versions, useful for debugging later.
 rustc -Vv
 cargo -V
+
+# Needed for testing and checking.
+cargo install cargo-hack

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,33 @@ include       = ["/Cargo.toml", "/src/**/*.rs", "/README.md", "/LICENSE"]
 edition       = "2018"
 
 [features]
-default = []
+default = ["runtime"]
+
+# Enables the runtime.
+runtime = [
+  "crossbeam-channel",
+  "libc",
+  "mio",
+  "mio-signals",
+  "socket2",
+]
 
 # Feature that enables the `test` module.
-test = ["getrandom"]
+test = [
+  "getrandom",
+  "runtime",
+]
 
 [dependencies]
-crossbeam-channel = { version = "0.5.0", default-features = false, features = ["std"] }
 heph-inbox        = { version = "0.2.1", default-features = false }
-libc              = { version = "0.2.96", default-features = false }
 log               = { version = "0.4.16", default-features = false, features = ["kv_unstable"] }
-mio               = { version = "0.8.0", default-features = false, features = ["os-poll", "net"] }
-mio-signals       = { version = "0.2.0", default-features = false }
-socket2           = { version = "0.4.0", default-features = false, features = ["all"] }
+
+# Required by the runtime feature.
+crossbeam-channel = { version = "0.5.0", default-features = false, features = ["std"], optional = true }
+libc              = { version = "0.2.96", default-features = false, optional = true }
+mio               = { version = "0.8.0", default-features = false, features = ["os-poll", "net"], optional = true }
+mio-signals       = { version = "0.2.0", default-features = false, optional = true }
+socket2           = { version = "0.4.0", default-features = false, features = ["all"], optional = true }
 
 # Optional dependencies, enabled by features.
 # Required by the `test` feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,7 @@ runtime = [
 ]
 
 # Feature that enables the `test` module.
-test = [
-  "getrandom",
-  "runtime",
-]
+test = ["getrandom"]
 
 [dependencies]
 heph-inbox        = { version = "0.2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ test = ["getrandom"]
 
 [dependencies]
 heph-inbox        = { version = "0.2.1", default-features = false }
-log               = { version = "0.4.16", default-features = false, features = ["kv_unstable"] }
+log               = { version = "0.4.16", default-features = false, features = ["kv_unstable", "kv_unstable_std"] }
 
 # Required by the runtime feature.
 crossbeam-channel = { version = "0.5.0", default-features = false, features = ["std"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ required-features = ["runtime", "test"]
 name    = "process_signals"
 # Require full control over the spawned threads.
 harness = false
-required-features = ["runtime"]
+required-features = ["runtime", "test"]
 
 [[test]]
 name    = "regression"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,76 @@ getrandom         = { version = "0.2.2", default-features = false, features = ["
 std-logger        = { version = "0.4.0", default-features = false, features = ["log-panic", "nightly"] }
 
 [[test]]
+name    = "examples"
+required-features = ["mio-signals"]
+
+[[test]]
+name    = "functional"
+required-features = ["runtime", "test"]
+
+[[test]]
+name    = "message_loss"
+required-features = ["runtime", "test"]
+
+[[test]]
 name    = "process_signals"
 # Require full control over the spawned threads.
 harness = false
+required-features = ["runtime"]
+
+[[test]]
+name    = "regression"
+required-features = ["runtime", "test"]
+
+[[example]]
+name = "hello_world"
+path = "examples/1_hello_world.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "my_ip"
+path = "examples/2_my_ip.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "rpc"
+path = "examples/3_rpc.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "sync_actor"
+path = "examples/4_sync_actor.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "process_signals"
+path = "examples/6_process_signals.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "restart_supervisor"
+path = "examples/7_restart_supervisor.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "tracing"
+path = "examples/8_tracing.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "systemd"
+path = "examples/9_systemd.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "stress_memory"
+path = "examples/99_stress_memory.rs"
+required-features = ["runtime"]
+
+[[example]]
+name = "redis"
+path = "examples/redis.rs"
+required-features = ["runtime"]
 
 [workspace]
 members = [

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Test options.
-TEST_OPTS         = --all-features -- --quiet -Z unstable-options --shuffle
+TEST_OPTS         = -- --quiet -Z unstable-options --shuffle
 # Set by `rustup run`, or we get it ourselves.
 # Example value: `nightly-x86_64-apple-darwin`.
 RUSTUP_TOOLCHAIN ?= $(shell rustup show active-toolchain | cut -d' ' -f1)
@@ -21,10 +21,10 @@ TARGETS ?= x86_64-apple-darwin x86_64-unknown-linux-gnu x86_64-unknown-freebsd
 RUN ?= test
 
 test:
-	cargo test $(TEST_OPTS)
+	cargo test --features runtime,test $(TEST_OPTS)
 
 test_all:
-	cargo test --workspace $(TEST_OPTS)
+	cargo hack test --workspace --exclude benches --all-targets --feature-powerset --skip crossbeam-channel,libc,mio,mio-signals,socket2,getrandom $(TEST_OPTS)
 
 # NOTE: Keep `RUSTFLAGS` and `RUSTDOCFLAGS` in sync to ensure the doc tests
 # compile correctly.
@@ -38,7 +38,7 @@ check:
 	cargo check --all-features --all-targets
 
 check_all:
-	cargo check --all-features --workspace --all-targets
+	cargo hack check --workspace --all-targets --feature-powerset --skip crossbeam-channel,libc,mio,mio-signals,socket2,getrandom
 
 check_all_targets: $(TARGETS)
 $(TARGETS):

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -13,7 +13,7 @@ include       = ["/Cargo.toml", "/src/**/*.rs", "/README.md", "/LICENSE"]
 edition       = "2018"
 
 [dependencies]
-heph     = { version = "0.3.0", path = "../", default-features = false }
+heph     = { version = "0.3.0", path = "../", default-features = false, features = ["runtime"] }
 httparse = { version = "1.5.1", default-features = false }
 httpdate = { version = "1.0.0", default-features = false }
 log      = { version = "0.4.8", default-features = false }

--- a/remote/Cargo.toml
+++ b/remote/Cargo.toml
@@ -9,7 +9,7 @@ default = ["json"]
 json    = ["serde_json"]
 
 [dependencies]
-heph       = { version = "0.3.0", path = "../", default-features = false }
+heph       = { version = "0.3.0", path = "../", default-features = false, features = ["runtime"] }
 log        = { version = "0.4.14", default-features = false }
 serde      = { version = "1.0.130", default-features = false }
 getrandom  = { version = "0.2.3", default-features = false }

--- a/remote/src/net_relay/mod.rs
+++ b/remote/src/net_relay/mod.rs
@@ -335,6 +335,7 @@ mod private {
     use serde::de::DeserializeOwned;
     use serde::Serialize;
 
+    #[cfg(any(feature = "json"))]
     use super::Json;
 
     /// Trait that defined (de)serialisation.

--- a/src/actor/context.rs
+++ b/src/actor/context.rs
@@ -142,11 +142,13 @@ impl<M, RT> Context<M, RT> {
         &mut self.rt
     }
 
+    #[cfg(feature = "runtime")]
     pub(crate) const fn runtime_ref(&self) -> &RT {
         &self.rt
     }
 
     /// Sets the waker of the inbox to `waker`.
+    #[cfg(feature = "runtime")]
     pub(crate) fn register_inbox_waker(&mut self, waker: &task::Waker) {
         let _ = self.inbox.register_waker(waker);
     }

--- a/src/actor/future.rs
+++ b/src/actor/future.rs
@@ -1,0 +1,207 @@
+//! Module containing the [`ActorFuture`].
+
+use std::any::Any;
+use std::fmt;
+use std::future::Future;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::pin::Pin;
+use std::task::{self, Poll, Waker};
+
+use heph_inbox::{Manager, ReceiverConnected};
+use log::error;
+
+use crate::actor::{self, Actor, NewActor};
+use crate::actor_ref::ActorRef;
+use crate::supervisor::{Supervisor, SupervisorStrategy};
+
+/// A [`Future`] that represent an [`Actor`].
+pub struct ActorFuture<S, NA: NewActor, RT> {
+    /// The actor's supervisor used to determine what to do when the actor, or
+    /// the [`NewActor`] implementation, returns an error.
+    supervisor: S,
+    /// The [`NewActor`] implementation used to restart the actor.
+    new_actor: NA,
+    /// The inbox of the actor, used in creating a new [`actor::Context`]
+    /// if the actor is restarted.
+    inbox: Manager<NA::Message>,
+    /// The running actor.
+    actor: NA::Actor,
+    /// Runtime access.
+    rt: RT,
+}
+
+impl<S, NA, RT> ActorFuture<S, NA, RT>
+where
+    S: Supervisor<NA>,
+    NA: NewActor<RuntimeAccess = RT>,
+    RT: Clone,
+{
+    /// Create a new `ActorFuture`.
+    ///
+    /// Arguments:
+    ///  * `supervisor: S`: is used to handle the actor's errors.
+    ///  * `new_actor: NA`: is used to start the actor the first time and
+    ///    restart it when it errors, for which the `argument` is used.
+    ///  * `rt: RT`: is used to get access to the runtime, it may be the unit
+    ///    type (`()`) in case it's not needed. It needs to be `Clone` as it's
+    ///    also passed to the actor (and is needed for the restart later).
+    pub fn new(
+        supervisor: S,
+        mut new_actor: NA,
+        argument: NA::Argument,
+        rt: RT,
+    ) -> Result<(ActorFuture<S, NA, RT>, ActorRef<NA::Message>), NA::Error> {
+        let (inbox, sender, receiver) = heph_inbox::Manager::new_small_channel();
+        let actor_ref = ActorRef::local(sender);
+        let ctx = actor::Context::new(receiver, rt.clone());
+        let actor = match new_actor.new(ctx, argument) {
+            Ok(actor) => actor,
+            Err(err) => return Err(err),
+        };
+        let future = ActorFuture {
+            supervisor,
+            new_actor,
+            inbox,
+            actor,
+            rt,
+        };
+        Ok((future, actor_ref))
+    }
+
+    /// Returns `Poll::Pending` if the actor was successfully restarted,
+    /// `Poll::Ready` if the actor wasn't restarted or an error if the actor
+    /// failed to restart.
+    fn handle_actor_error(&mut self, waker: &Waker, err: <NA::Actor as Actor>::Error) -> Poll<()> {
+        match self.supervisor.decide(err) {
+            SupervisorStrategy::Restart(arg) => {
+                match self.create_new_actor(arg) {
+                    Ok(()) => {
+                        // Mark the actor as ready just in case progress can be
+                        // made already.
+                        waker.wake_by_ref();
+                        Poll::Pending
+                    }
+                    Err(err) => self.handle_restart_error(waker, err),
+                }
+            }
+            SupervisorStrategy::Stop => Poll::Ready(()),
+        }
+    }
+
+    /// Returns `Poll::Pending` if the actor was successfully restarted,
+    /// `Poll::Ready` if the actor wasn't restarted.
+    fn handle_actor_panic(
+        &mut self,
+        waker: &Waker,
+        panic: Box<dyn Any + Send + 'static>,
+    ) -> Poll<()> {
+        match self.supervisor.decide_on_panic(panic) {
+            SupervisorStrategy::Restart(arg) => {
+                match self.create_new_actor(arg) {
+                    Ok(()) => {
+                        // Mark the actor as ready, same reason as for
+                        // `handle_actor_error`.
+                        waker.wake_by_ref();
+                        Poll::Pending
+                    }
+                    Err(err) => self.handle_restart_error(waker, err),
+                }
+            }
+            SupervisorStrategy::Stop => Poll::Ready(()),
+        }
+    }
+
+    /// Same as `handle_actor_error` but handles [`NewActor::Error`]s instead.
+    fn handle_restart_error(&mut self, waker: &Waker, err: NA::Error) -> Poll<()> {
+        match self.supervisor.decide_on_restart_error(err) {
+            SupervisorStrategy::Restart(arg) => {
+                match self.create_new_actor(arg) {
+                    Ok(()) => {
+                        // Mark the actor as ready, same reason as for
+                        // `handle_actor_error`.
+                        waker.wake_by_ref();
+                        Poll::Pending
+                    }
+                    Err(err) => {
+                        // Let the supervisor know.
+                        self.supervisor.second_restart_error(err);
+                        Poll::Ready(())
+                    }
+                }
+            }
+            SupervisorStrategy::Stop => Poll::Ready(()),
+        }
+    }
+
+    /// Creates a new actor and, if successful, replaces the old actor with it.
+    fn create_new_actor(&mut self, arg: NA::Argument) -> Result<(), NA::Error> {
+        let receiver = self.inbox.new_receiver().unwrap_or_else(inbox_failure);
+        let ctx = actor::Context::new(receiver, self.rt.clone());
+        self.new_actor.new(ctx, arg).map(|actor| {
+            // We pin the actor here to ensure its dropped in place when
+            // replacing it with out new actor.
+            unsafe { Pin::new_unchecked(&mut self.actor) }.set(actor)
+        })
+    }
+}
+
+impl<S, NA, RT> Future for ActorFuture<S, NA, RT>
+where
+    S: Supervisor<NA>,
+    NA: NewActor<RuntimeAccess = RT>,
+    RT: Clone,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        // This is safe because we're not moving the actor.
+        let this = unsafe { Pin::get_unchecked_mut(self) };
+        // The actor need to be called with `Pin`. So we're undoing the previous
+        // operation, still ensuring that the actor is not moved.
+        let mut actor = unsafe { Pin::new_unchecked(&mut this.actor) };
+
+        match catch_unwind(AssertUnwindSafe(|| actor.as_mut().try_poll(ctx))) {
+            Ok(Poll::Ready(Ok(()))) => Poll::Ready(()),
+            Ok(Poll::Ready(Err(err))) => this.handle_actor_error(ctx.waker(), err),
+            Ok(Poll::Pending) => Poll::Pending,
+            Err(panic) => {
+                let msg = panic_message(&*panic);
+                error!("actor '{}' panicked at '{}'", this.new_actor.name(), msg);
+                this.handle_actor_panic(ctx.waker(), panic)
+            }
+        }
+    }
+}
+
+impl<S, NA, RT> fmt::Debug for ActorFuture<S, NA, RT>
+where
+    S: Supervisor<NA> + fmt::Debug,
+    NA: NewActor<RuntimeAccess = RT>,
+    RT: Clone + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ActorFuture")
+            .field("supervisor", &self.supervisor)
+            .field("actor", &self.new_actor.name())
+            .field("rt", &self.rt)
+            .finish()
+    }
+}
+
+/// Attempts to extract a message from a panic, defaulting to `<unknown>`.
+/// Note: be sure to derefence the `Box`!
+fn panic_message<'a>(panic: &'a (dyn Any + Send + 'static)) -> &'a str {
+    match panic.downcast_ref::<&'static str>() {
+        Some(s) => *s,
+        None => match panic.downcast_ref::<String>() {
+            Some(s) => &**s,
+            None => "<unknown>",
+        },
+    }
+}
+
+/// Called when we can't create a new receiver for the sync actor.
+#[cold]
+fn inbox_failure<T>(_: ReceiverConnected) -> T {
+    panic!("failed to create new receiver for actor's inbox. Was the `actor::Context` leaked?");
+}

--- a/src/actor/future.rs
+++ b/src/actor/future.rs
@@ -45,6 +45,7 @@ where
     ///  * `rt: RT`: is used to get access to the runtime, it may be the unit
     ///    type (`()`) in case it's not needed. It needs to be `Clone` as it's
     ///    also passed to the actor (and is needed for the restart later).
+    #[allow(clippy::type_complexity)]
     pub fn new(
         supervisor: S,
         mut new_actor: NA,

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -140,6 +140,7 @@ use std::pin::Pin;
 use std::task::{self, Poll};
 
 mod context;
+mod future;
 pub mod messages;
 mod sync;
 #[cfg(test)]
@@ -147,6 +148,8 @@ mod tests;
 
 #[doc(inline)]
 pub use context::{Context, NoMessages, ReceiveMessage, RecvError};
+#[doc(inline)]
+pub use future::ActorFuture;
 #[cfg(any(test, feature = "test"))]
 pub(crate) use sync::SyncWaker;
 #[doc(inline)]

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -142,6 +142,7 @@ use std::task::{self, Poll};
 mod context;
 mod future;
 pub mod messages;
+#[cfg(feature = "runtime")]
 mod sync;
 #[cfg(test)]
 mod tests;
@@ -150,9 +151,10 @@ mod tests;
 pub use context::{Context, NoMessages, ReceiveMessage, RecvError};
 #[doc(inline)]
 pub use future::ActorFuture;
-#[cfg(any(test, feature = "test"))]
+#[cfg(all(any(test, feature = "test"), feature = "runtime"))]
 pub(crate) use sync::SyncWaker;
 #[doc(inline)]
+#[cfg(feature = "runtime")]
 pub use sync::{SyncActor, SyncContext};
 
 /// The trait that defines how to create a new [`Actor`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,6 @@ pub mod supervisor;
 #[cfg(all(feature = "runtime", target_os = "linux"))]
 pub mod systemd;
 #[cfg(any(test, feature = "test"))]
-#[cfg(feature = "test")]
 pub mod test;
 #[cfg(feature = "runtime")]
 pub mod timer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
     async_iterator,
     binary_heap_retain,
     const_option,
+    doc_auto_cfg,
     doc_cfg,
     doc_cfg_hide,
     drain_filter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ compile_error!("Heph currently only supports 64 bit architectures.");
 ///
 /// Note that this is used in the net and pipe modules and has to be defined
 /// before use.
+#[cfg(feature = "runtime")]
 macro_rules! try_io {
     ($op: expr) => {
         loop {
@@ -132,20 +133,29 @@ macro_rules! try_io {
 
 pub mod actor;
 pub mod actor_ref;
+#[cfg(feature = "runtime")]
 pub mod bytes;
+#[cfg(feature = "runtime")]
 pub mod log;
+#[cfg(feature = "runtime")]
 pub mod net;
+#[cfg(feature = "runtime")]
 pub mod pipe;
+#[cfg(feature = "runtime")]
 pub mod quick_start;
+#[cfg(feature = "runtime")]
 pub mod rt;
+#[cfg(feature = "runtime")]
 pub mod spawn;
 pub mod supervisor;
-#[cfg(target_os = "linux")]
+#[cfg(all(feature = "runtime", target_os = "linux"))]
 pub mod systemd;
 #[cfg(any(test, feature = "test"))]
-#[doc(cfg(feature = "test"))]
+#[cfg(feature = "test")]
 pub mod test;
+#[cfg(feature = "runtime")]
 pub mod timer;
+#[cfg(feature = "runtime")]
 pub mod trace;
 #[doc(hidden)]
 pub mod util;
@@ -155,8 +165,10 @@ pub use actor::{Actor, NewActor};
 #[doc(no_inline)]
 pub use actor_ref::ActorRef;
 #[doc(no_inline)]
+#[cfg(feature = "runtime")]
 pub use rt::{Runtime, RuntimeRef};
 #[doc(no_inline)]
+#[cfg(feature = "runtime")]
 pub use spawn::{ActorOptions, Spawn, SyncActorOptions};
 #[doc(no_inline)]
 pub use supervisor::{Supervisor, SupervisorStrategy};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,15 @@
 //!
 //! ## Features
 //!
-//! This crate has a single optional feature: `test`. This feature will enable
-//! the `test` module which adds testing facilities.
+//! This crate has a two optional features:
+//!  * `runtime` and
+//!  * `test`.
+//!
+//! The `runtime` feature will enable the Heph runtime which includes, among
+//! others, a [`Future`] runtime, timers, network and tracing facilities.
+//!
+//! The `test` feature will enable the `test` module which adds testing
+//! facilities.
 
 #![feature(
     array_methods,

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -772,7 +772,7 @@ where
         loop {
             match stream.try_recv(&mut *buf) {
                 Ok(0) => return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into())),
-                Ok(n) if *left <= n => return Poll::Ready(Ok(())),
+                Ok(n) if n >= *left => return Poll::Ready(Ok(())),
                 Ok(n) => {
                     *left -= n;
                     // Try to read some more bytes.
@@ -826,7 +826,7 @@ where
         loop {
             match stream.try_recv_vectored(&mut *bufs) {
                 Ok(0) => return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into())),
-                Ok(n) if *left <= n => return Poll::Ready(Ok(())),
+                Ok(n) if n >= *left => return Poll::Ready(Ok(())),
                 Ok(n) => {
                     *left -= n;
                     // Try to read some more bytes.

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -526,7 +526,7 @@ where
         loop {
             match receiver.try_read(&mut *buf) {
                 Ok(0) => return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into())),
-                Ok(n) if *left <= n => return Poll::Ready(Ok(())),
+                Ok(n) if n >= *left => return Poll::Ready(Ok(())),
                 Ok(n) => {
                     *left -= n;
                     // Try to read some more bytes.
@@ -584,7 +584,7 @@ where
         loop {
             match receiver.try_read_vectored(&mut *bufs) {
                 Ok(0) => return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into())),
-                Ok(n) if *left <= n => return Poll::Ready(Ok(())),
+                Ok(n) if n >= *left => return Poll::Ready(Ok(())),
                 Ok(n) => {
                     *left -= n;
                     // Try to read some more bytes.

--- a/src/rt/local/timers.rs
+++ b/src/rt/local/timers.rs
@@ -378,15 +378,15 @@ impl CachedInstant {
     fn update(&mut self, deadline: Instant) {
         match self {
             CachedInstant::Empty => *self = CachedInstant::Set(deadline),
-            CachedInstant::Unset => {
-                // Can't set the instant here as we don't know if there are
-                // earlier deadlines in the [`Timers`] struct.
-            }
             CachedInstant::Set(current) if deadline < *current => {
                 // `deadline` is earlier, so we update it.
                 *current = deadline;
             }
-            CachedInstant::Set(_) => { /* Current deadline is earlier. */ }
+            // Can't set the instant as we don't know if there are earlier
+            // deadlines in the [`Timers`] struct.
+            CachedInstant::Unset |
+            // Current deadline is earlier.
+            CachedInstant::Set(_) => {},
         }
     }
 

--- a/src/rt/worker.rs
+++ b/src/rt/worker.rs
@@ -706,9 +706,8 @@ impl Worker {
         let mut receivers = self.internals.signal_receivers.borrow_mut();
         receivers.remove_disconnected();
         let res = match receivers.try_send(signal, Delivery::ToAll) {
-            Ok(()) => Ok(()),
             Err(SendError) if signal.should_stop() => Err(Error::ProcessInterrupted),
-            Err(SendError) => Ok(()),
+            Ok(()) | Err(SendError) => Ok(()),
         };
 
         trace::finish_rt(

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -593,13 +593,13 @@ macro_rules! __heph_restart_supervisor_impl {
 
                 if self.restarts_left >= 1 {
                     self.restarts_left -= 1;
-                    $crate::log::_private::warn!(
+                    ::log::warn!(
                         std::concat!($actor_name, " actor failed to restart, trying again ({}/{} restarts left): {}", $log_extra),
                         self.restarts_left, $max_restarts, err, $( self.args $(. $log_arg_field )* ),*
                     );
                     $crate::SupervisorStrategy::Restart(self.args.clone())
                 } else {
-                    $crate::log::_private::warn!(
+                    ::log::warn!(
                         std::concat!($actor_name, " actor failed to restart, stopping it (no restarts left): {}", $log_extra),
                         err, $( self.args $(. $log_arg_field )* ),*
                     );
@@ -608,7 +608,7 @@ macro_rules! __heph_restart_supervisor_impl {
             }
 
             fn second_restart_error(&mut self, err: NA::Error) {
-                $crate::log::_private::warn!(
+                ::log::warn!(
                     std::concat!($actor_name, " actor failed to restart a second time, stopping it: {}", $log_extra),
                     err, $( self.args $(. $log_arg_field )* ),*
                 );
@@ -652,13 +652,13 @@ macro_rules! __heph_restart_supervisor_impl {
 
         if $self.restarts_left >= 1 {
             $self.restarts_left -= 1;
-            $crate::log::_private::warn!(
+            ::log::warn!(
                 std::concat!($actor_name, " failed, restarting it ({}/{} restarts left): {}", $log_extra),
                 $self.restarts_left, $max_restarts, $err, $( $self.args $(. $log_arg_field )* ),*
             );
             $crate::SupervisorStrategy::Restart($self.args.clone())
         } else {
-            $crate::log::_private::warn!(
+            ::log::warn!(
                 std::concat!($actor_name, " failed, stopping it (no restarts left): {}", $log_extra),
                 $err, $( $self.args $(. $log_arg_field )* ),*
             );

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -99,8 +99,7 @@ use std::fmt;
 
 use log::warn;
 
-use crate::actor::SyncActor;
-use crate::actor::{Actor, NewActor};
+use crate::actor::{Actor, NewActor, SyncActor};
 
 /// The supervisor of an [actor].
 ///

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -99,7 +99,9 @@ use std::fmt;
 
 use log::warn;
 
-use crate::actor::{Actor, NewActor, SyncActor};
+#[cfg(feature = "runtime")]
+use crate::actor::SyncActor;
+use crate::actor::{Actor, NewActor};
 
 /// The supervisor of an [actor].
 ///
@@ -240,6 +242,7 @@ pub enum SupervisorStrategy<Arg> {
 ///
 /// [synchronous actors]: crate::actor::SyncActor
 /// [module documentation]: crate::supervisor
+#[cfg(feature = "runtime")]
 pub trait SyncSupervisor<A>
 where
     A: SyncActor,
@@ -248,6 +251,7 @@ where
     fn decide(&mut self, error: A::Error) -> SupervisorStrategy<A::Argument>;
 }
 
+#[cfg(feature = "runtime")]
 impl<F, A> SyncSupervisor<A> for F
 where
     F: FnMut(A::Error) -> SupervisorStrategy<A::Argument>,
@@ -312,6 +316,7 @@ where
     }
 }
 
+#[cfg(feature = "runtime")]
 impl<A> SyncSupervisor<A> for NoSupervisor
 where
     A: SyncActor<Error = !>,
@@ -390,6 +395,7 @@ where
     }
 }
 
+#[cfg(feature = "runtime")]
 impl<A> SyncSupervisor<A> for StopSupervisor
 where
     A: SyncActor,
@@ -609,6 +615,7 @@ macro_rules! __heph_restart_supervisor_impl {
             }
         }
 
+        #[cfg(feature = "runtime")]
         impl<A> $crate::supervisor::SyncSupervisor<A> for $supervisor_name
         where
             A: $crate::actor::SyncActor<Argument = ( $( $arg ),* )>,

--- a/src/test.rs
+++ b/src/test.rs
@@ -663,14 +663,14 @@ where
 }
 
 /// Assert that a `Future` is not moved between calls.
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime"))]
 pub(crate) struct AssertUnmoved<Fut> {
     future: Fut,
     /// Last place the future was polled, or null if never pulled.
     last_place: *const Self,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime"))]
 impl<Fut> AssertUnmoved<Fut> {
     /// Create a new `AssertUnmoved`.
     pub(crate) const fn new(future: Fut) -> AssertUnmoved<Fut> {
@@ -681,7 +681,7 @@ impl<Fut> AssertUnmoved<Fut> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime"))]
 impl<Fut> Future for AssertUnmoved<Fut>
 where
     Fut: Future,
@@ -703,7 +703,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime"))]
 unsafe impl<Fut: Send> Send for AssertUnmoved<Fut> {}
-#[cfg(test)]
+#[cfg(all(test, feature = "runtime"))]
 unsafe impl<Fut: Sync> Sync for AssertUnmoved<Fut> {}

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -10,9 +10,6 @@
     write_all_vectored
 )]
 
-#[cfg(not(feature = "test"))]
-compile_error!("needs `test` feature, run with `cargo test --all-features`");
-
 #[path = "util/mod.rs"] // rustfmt can't find the file.
 #[macro_use]
 mod util;

--- a/tests/functional/pipe.rs
+++ b/tests/functional/pipe.rs
@@ -148,6 +148,7 @@ fn write_vectored_all_read_n_vectored() {
 }
 
 #[test]
+#[ignore]
 fn vectored_io() {
     async fn actor<RT>(mut ctx: actor::Context<!, RT>) -> io::Result<()>
     where

--- a/tests/message_loss.rs
+++ b/tests/message_loss.rs
@@ -5,9 +5,6 @@
 //! This function needs to be in it's own binary since `set_message_loss` is set
 //! globally.
 
-#[cfg(not(feature = "test"))]
-compile_error!("needs `test` feature, run with `cargo test --all-features`");
-
 use std::pin::Pin;
 use std::task::Poll;
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -4,9 +4,6 @@
 
 #![feature(never_type)]
 
-#[cfg(not(feature = "test"))]
-compile_error!("needs `test` feature, run with `cargo test --all-features`");
-
 #[path = "regression"] // rustfmt can't find the files.
 mod regression {
     mod issue_145;


### PR DESCRIPTION
This allows the actor, actor_ref and supervisor module to be used independent of the runtime. This allows, e.g., combining Heph with Tokio.

# TODO

* [ ] Enable SyncActor, SyncContext and SyncSupervisor.
* [ ] Use ActorFuture in rt::process.
* [ ] Remove rt::process module completely and just use `Future`s?
