### PR TITLE
Move actor::Bound trait to heph-rt crate

### DIFF
--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -825,3 +825,31 @@ fn cpu_usage(clock_id: libc::clockid_t) -> Duration {
         )
     }
 }
+
+/// Types that are bound to an [`Actor`].
+///
+/// A marker trait to indicate the type is bound to an [`Actor`]. How the type
+/// is bound to the actor is different for each type. For most futures it means
+/// that if progress can be made (when the [future is awoken]) the actor will be
+/// run. This has the unfortunate consequence that those types can't be moved
+/// away from the actor without [(re)binding] it first, otherwise the new actor
+/// will never be run and the actor that created the type will run instead.
+///
+/// Most types that are bound can only be created with a (mutable) reference to
+/// an [`actor::Context`]. Examples of this are `TcpStream`, `UdpSocket` and
+/// all futures in the `heph_rt::timer` module.
+///
+/// [`Actor`]: actor::Actor
+/// [future is awoken]: std::task::Waker::wake
+/// [(re)binding]: Bound::bind_to
+pub trait Bound<RT> {
+    /// Error type used in [`bind_to`].
+    ///
+    /// [`bind_to`]: Bound::bind_to
+    type Error;
+
+    /// Bind a type to the [`Actor`] that owns the `ctx`.
+    ///
+    /// [`Actor`]: actor::Actor
+    fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> Result<(), Self::Error>;
+}

--- a/rt/src/net/mod.rs
+++ b/rt/src/net/mod.rs
@@ -38,11 +38,11 @@
 //!
 //! # Notes
 //!
-//! All types in the `net` module are [bound] to an actor. See the
-//! [`actor::Bound`] trait for more information.
+//! All types in the `net` module are [bound] to an actor. See the [`Bound`]
+//! trait for more information.
 //!
-//! [bound]: heph::actor::Bound
-//! [`actor::Bound`]: heph::actor::Bound
+//! [bound]: crate::Bound
+//! [`Bound`]: crate::Bound
 
 use std::io;
 use std::net::SocketAddr;

--- a/rt/src/net/tcp/listener.rs
+++ b/rt/src/net/tcp/listener.rs
@@ -10,8 +10,8 @@ use std::task::{self, Poll};
 use heph::actor;
 use mio::{net, Interest};
 
-use crate as rt;
 use crate::net::TcpStream;
+use crate::{self as rt, Bound};
 
 /// A TCP socket listener.
 ///
@@ -178,7 +178,7 @@ impl TcpListener {
     /// `actor::Context`, which means the actor will be run every time the
     /// listener has a connection ready to be accepted.
     ///
-    /// [bound]: heph::actor::Bound
+    /// [bound]: crate::Bound
     pub fn bind<M, RT>(
         ctx: &mut actor::Context<M, RT>,
         address: SocketAddr,
@@ -323,7 +323,7 @@ impl<'a> AsyncIterator for Incoming<'a> {
     }
 }
 
-impl<RT: rt::Access> actor::Bound<RT> for TcpListener {
+impl<RT: rt::Access> Bound<RT> for TcpListener {
     type Error = io::Error;
 
     fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {

--- a/rt/src/net/tcp/stream.rs
+++ b/rt/src/net/tcp/stream.rs
@@ -19,8 +19,8 @@ use mio::{net, Interest};
 use heph::actor;
 use socket2::SockRef;
 
-use crate as rt;
 use crate::bytes::{Bytes, BytesVectored, MaybeUninitSlice};
+use crate::{self as rt, Bound};
 
 /// A non-blocking TCP stream between a local socket and a remote socket.
 ///
@@ -61,7 +61,7 @@ impl TcpStream {
     /// which means the actor will be run every time the stream is ready to read
     /// or write.
     ///
-    /// [bound]: heph::actor::Bound
+    /// [bound]: crate::Bound
     pub fn connect<M, RT>(
         ctx: &mut actor::Context<M, RT>,
         address: SocketAddr,
@@ -952,7 +952,7 @@ mod private {
     impl PrivateFileSend for File {}
 }
 
-impl<RT: rt::Access> actor::Bound<RT> for TcpStream {
+impl<RT: rt::Access> Bound<RT> for TcpStream {
     type Error = io::Error;
 
     fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {

--- a/rt/src/net/udp.rs
+++ b/rt/src/net/udp.rs
@@ -21,9 +21,9 @@ use log::warn;
 use mio::{net, Interest};
 use socket2::{SockAddr, SockRef};
 
-use crate as rt;
 use crate::bytes::{Bytes, BytesVectored, MaybeUninitSlice};
 use crate::net::convert_address;
+use crate::{self as rt, Bound};
 
 /// The unconnected mode of an [`UdpSocket`].
 #[allow(missing_debug_implementations)]
@@ -151,7 +151,7 @@ impl UdpSocket {
     /// `actor::Context`, which means the actor will be run every time the
     /// socket is ready to be read from or write to.
     ///
-    /// [bound]: heph::actor::Bound
+    /// [bound]: crate::Bound
     pub fn bind<M, RT>(
         ctx: &mut actor::Context<M, RT>,
         local: SocketAddr,
@@ -838,7 +838,7 @@ impl<M> fmt::Debug for UdpSocket<M> {
     }
 }
 
-impl<M, RT: rt::Access> actor::Bound<RT> for UdpSocket<M> {
+impl<M, RT: rt::Access> Bound<RT> for UdpSocket<M> {
     type Error = io::Error;
 
     fn bind_to<Msg>(&mut self, ctx: &mut actor::Context<Msg, RT>) -> io::Result<()> {

--- a/rt/src/pipe.rs
+++ b/rt/src/pipe.rs
@@ -13,10 +13,10 @@
 //! # Notes
 //!
 //! Both the [`Sender`] and [`Receiver`] types are [bound] to an actor. See the
-//! [`actor::Bound`] trait for more information.
+//! [`Bound`] trait for more information.
 //!
-//! [bound]: heph::actor::Bound
-//! [`actor::Bound`]: heph::actor::Bound
+//! [bound]: crate::Bound
+//! [`Bound`]: crate::Bound
 //!
 //! # Examples
 //!
@@ -116,8 +116,8 @@ use heph::actor;
 use mio::unix::pipe;
 use mio::Interest;
 
-use crate as rt;
 use crate::bytes::{Bytes, BytesVectored, MaybeUninitSlice};
+use crate::{self as rt, Bound};
 
 /// Create a new Unix pipe.
 ///
@@ -319,7 +319,7 @@ impl<'a, 'b> Future for WriteVectoredAll<'a, 'b> {
     }
 }
 
-impl<RT: rt::Access> actor::Bound<RT> for Sender {
+impl<RT: rt::Access> Bound<RT> for Sender {
     type Error = io::Error;
 
     fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {
@@ -601,7 +601,7 @@ where
     }
 }
 
-impl<RT: rt::Access> actor::Bound<RT> for Receiver {
+impl<RT: rt::Access> Bound<RT> for Receiver {
     type Error = io::Error;
 
     fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {

--- a/rt/src/systemd.rs
+++ b/rt/src/systemd.rs
@@ -27,7 +27,7 @@ use socket2::SockRef;
 
 use crate::timer::Interval;
 use crate::util::{either, next};
-use crate::{self as rt, Signal};
+use crate::{self as rt, Bound, Signal};
 
 /// Systemd notifier.
 ///
@@ -303,7 +303,7 @@ impl<'a> Future for TriggerWatchdog<'a> {
     }
 }
 
-impl<RT: rt::Access> actor::Bound<RT> for Notify {
+impl<RT: rt::Access> Bound<RT> for Notify {
     type Error = io::Error;
 
     fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {

--- a/rt/src/timer.rs
+++ b/rt/src/timer.rs
@@ -19,7 +19,7 @@ use std::{io, ptr};
 
 use heph::actor;
 
-use crate as rt;
+use crate::{self as rt, Bound};
 
 /// Type returned when the deadline has passed.
 ///
@@ -152,7 +152,7 @@ impl<RT: rt::Access> Future for Timer<RT> {
 
 impl<RT: rt::Access> Unpin for Timer<RT> {}
 
-impl<RT: rt::Access> actor::Bound<RT> for Timer<RT> {
+impl<RT: rt::Access> Bound<RT> for Timer<RT> {
     type Error = io::Error;
 
     fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {
@@ -348,7 +348,7 @@ where
 
 impl<Fut: Unpin, RT: rt::Access> Unpin for Deadline<Fut, RT> {}
 
-impl<Fut, RT: rt::Access> actor::Bound<RT> for Deadline<Fut, RT> {
+impl<Fut, RT: rt::Access> Bound<RT> for Deadline<Fut, RT> {
     type Error = io::Error;
 
     fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> io::Result<()> {
@@ -470,7 +470,7 @@ impl<RT: rt::Access> AsyncIterator for Interval<RT> {
 
 impl<RT: rt::Access> Unpin for Interval<RT> {}
 
-impl<RT: rt::Access> actor::Bound<RT> for Interval<RT> {
+impl<RT: rt::Access> Bound<RT> for Interval<RT> {
     type Error = !;
 
     fn bind_to<M>(&mut self, ctx: &mut actor::Context<M, RT>) -> Result<(), !> {

--- a/rt/tests/functional/pipe.rs
+++ b/rt/tests/functional/pipe.rs
@@ -3,12 +3,11 @@
 use std::io::{self, IoSlice};
 use std::time::Duration;
 
-use heph::actor::{self, Bound};
 use heph::spawn::ActorOptions;
-use heph::ActorRef;
-use heph_rt as rt;
+use heph::{actor, ActorRef};
 use heph_rt::pipe::{self, Receiver, Sender};
 use heph_rt::test::{join, join_many, try_spawn_local, PanicSupervisor};
+use heph_rt::{self as rt, Bound};
 
 const DATA: &[u8] = b"Hello world";
 const DATAV: &[&[u8]] = &[b"Hello world!", b" ", b"From mars."];

--- a/rt/tests/functional/tcp/listener.rs
+++ b/rt/tests/functional/tcp/listener.rs
@@ -4,13 +4,12 @@ use std::pin::Pin;
 use std::task::Poll;
 use std::time::Duration;
 
-use heph::actor::{self, Bound};
 use heph::supervisor::NoSupervisor;
-use heph::{ActorOptions, ActorRef};
+use heph::{actor, ActorOptions, ActorRef};
 use heph_rt::net::{TcpListener, TcpStream};
 use heph_rt::test::{init_local_actor, join_many, poll_actor, try_spawn_local};
 use heph_rt::util::next;
-use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
+use heph_rt::{self as rt, Bound, Runtime, RuntimeRef, ThreadLocal};
 
 use crate::util::{any_local_address, any_local_ipv6_address, pending_once};
 

--- a/rt/tests/functional/tcp/stream.rs
+++ b/rt/tests/functional/tcp/stream.rs
@@ -9,13 +9,13 @@ use std::num::NonZeroUsize;
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, Bound};
+use heph::actor;
 use heph::actor_ref::{ActorRef, RpcMessage};
 use heph::spawn::ActorOptions;
 use heph::supervisor::NoSupervisor;
 use heph_rt::net::{TcpListener, TcpStream};
 use heph_rt::test::{join, join_many, try_spawn_local, PanicSupervisor};
-use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
+use heph_rt::{self as rt, Bound, Runtime, RuntimeRef, ThreadLocal};
 
 use crate::util::{any_local_address, refused_address};
 

--- a/rt/tests/functional/timer.rs
+++ b/rt/tests/functional/timer.rs
@@ -5,14 +5,13 @@ use std::task::{self, Poll};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use heph::actor::{self, Bound};
 use heph::spawn::ActorOptions;
 use heph::supervisor::NoSupervisor;
-use heph::ActorRef;
+use heph::{actor, ActorRef};
 use heph_rt::test::{init_local_actor, poll_actor, poll_future, poll_next};
 use heph_rt::timer::{Deadline, DeadlinePassed, Interval, Timer};
 use heph_rt::util::next;
-use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
+use heph_rt::{self as rt, Bound, Runtime, RuntimeRef, ThreadLocal};
 
 use crate::util::{count_polls, expect_pending};
 

--- a/rt/tests/functional/udp.rs
+++ b/rt/tests/functional/udp.rs
@@ -4,13 +4,13 @@ use std::io::{self, IoSlice};
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use heph::actor::{self, Actor, Bound, NewActor};
+use heph::actor::{self, Actor, NewActor};
 use heph::actor_ref::{ActorRef, RpcMessage};
 use heph::spawn::ActorOptions;
 use heph::supervisor::NoSupervisor;
 use heph_rt::net::udp::{UdpSocket, Unconnected};
 use heph_rt::test::{join, try_spawn_local, PanicSupervisor};
-use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
+use heph_rt::{self as rt, Bound, Runtime, RuntimeRef, ThreadLocal};
 
 use crate::util::{any_local_address, any_local_ipv6_address};
 

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -689,29 +689,3 @@ fn format_name(full_name: &'static str) -> &'static str {
 
     name
 }
-
-/// Types that are bound to an [`Actor`].
-///
-/// A marker trait to indicate the type is bound to an [`Actor`]. How the type
-/// is bound to the actor is different for each type. For most futures it means
-/// that if progress can be made (when the [future is awoken]) the actor will be
-/// run. This has the unfortunate consequence that those types can't be moved
-/// away from the actor without [(re)binding] it first, otherwise the new actor
-/// will never be run and the actor that created the type will run instead.
-///
-/// Most types that are bound can only be created with a (mutable) reference to
-/// an [`actor::Context`]. Examples of this are `TcpStream`, `UdpSocket` and
-/// all futures in the `heph_rt::timer` module.
-///
-/// [future is awoken]: std::task::Waker::wake
-/// [(re)binding]: Bound::bind_to
-/// [`actor::Context`]: Context
-pub trait Bound<RT> {
-    /// Error type used in [`bind_to`].
-    ///
-    /// [`bind_to`]: Bound::bind_to
-    type Error;
-
-    /// Bind a type to the [`Actor`] that owns the `ctx`.
-    fn bind_to<M>(&mut self, ctx: &mut Context<M, RT>) -> Result<(), Self::Error>;
-}

--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -247,11 +247,10 @@ impl<M, RT> SyncContext<M, RT> {
     ///
     /// # Limitations
     ///
-    /// Any [`Future`] returned by a type that is [bound] to an actor **cannot**
-    /// be used by this function. Those types use specialised wake-up mechanisms
-    /// bypassing the `Future`'s [`task`] system.
-    ///
-    /// [bound]: crate::actor::Bound
+    /// Any [`Future`] returned by a type that is bound to an actor (see `Bound`
+    /// trait of the heph-rt crate) **cannot** be used by this function. Those
+    /// types use specialised wake-up mechanisms bypassing the `Future`'s
+    /// [`task`] system.
     pub fn block_on<Fut>(&mut self, fut: Fut) -> Fut::Output
     where
         Fut: Future,


### PR DESCRIPTION
Currently lives at the root, might need to find a better place for it
later.

Closes #548.