### PR TITLE
Use a10::io::Std{io,out,err}

### DIFF
--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -18,7 +18,7 @@ edition       = "2021"
 test = ["heph/test"]
 
 [dependencies]
-a10               = { version = "0.1.0", default-features = false, features = ["nightly"] }
+a10               = { version = "0.1.1", default-features = false, features = ["nightly"] }
 heph              = { version = "0.5.0", path = "../", default-features = false }
 heph-inbox        = { version = "0.2.3", path = "../inbox", default-features = false }
 log               = { version = "0.4.17", default-features = false, features = ["kv_unstable", "kv_unstable_std"] }

--- a/rt/src/io/mod.rs
+++ b/rt/src/io/mod.rs
@@ -67,9 +67,7 @@ macro_rules! stdio {
     ) => {
         #[doc = concat!("Create a new `", stringify!($name), "`.\n\n")]
         pub fn $fn<RT: Access>(rt: &RT) -> $name {
-            let fd = std::mem::ManuallyDrop::new(unsafe {
-                a10::AsyncFd::from_raw_fd($fd, rt.submission_queue())
-            });
+            let fd = a10::io::$fn(rt.submission_queue());
             $name { fd }
         }
 
@@ -81,7 +79,7 @@ macro_rules! stdio {
         )]
         #[derive(Debug)]
         pub struct $name {
-            fd: std::mem::ManuallyDrop<a10::AsyncFd>,
+            fd: a10::io::$name,
         }
     };
 }


### PR DESCRIPTION
Fixes the leaking of a10::SubmissionQueue. Also avoids the use of some unsafe.