### PR TITLE
Add actor_fn

### DIFF
--- a/examples/1_hello_world.rs
+++ b/examples/1_hello_world.rs
@@ -1,6 +1,6 @@
 #![feature(never_type)]
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::ActorOptions;
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
@@ -25,7 +25,7 @@ fn add_greeter_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
     // arguments.
     // We'll use the default actor options here, other examples expand on the
     // options available.
-    let actor = greeter_actor as fn(_) -> _;
+    let actor = actor_fn(greeter_actor);
     let actor_ref = runtime_ref.spawn_local(NoSupervisor, actor, (), ActorOptions::default());
 
     // Now we can send our actor a message using its `actor_ref`.

--- a/examples/2_rpc.rs
+++ b/examples/2_rpc.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph::actor_ref::{ActorRef, RpcMessage};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::ActorOptions;
@@ -17,10 +17,10 @@ fn main() -> Result<(), rt::Error> {
 
 fn add_rpc_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
     // See example 1 for information on how to spawn actors.
-    let pong_actor = pong_actor as fn(_) -> _;
+    let pong_actor = actor_fn(pong_actor);
     let actor_ref = runtime_ref.spawn_local(NoSupervisor, pong_actor, (), ActorOptions::default());
 
-    let ping_actor = ping_actor as fn(_, _) -> _;
+    let ping_actor = actor_fn(ping_actor);
     runtime_ref.spawn_local(NoSupervisor, ping_actor, actor_ref, ActorOptions::default());
 
     Ok(())

--- a/examples/3_sync_actor.rs
+++ b/examples/3_sync_actor.rs
@@ -1,4 +1,4 @@
-use heph::actor::SyncContext;
+use heph::actor::{actor_fn, SyncContext};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::{self as rt, Runtime};
@@ -10,11 +10,10 @@ fn main() -> Result<(), rt::Error> {
     let mut runtime = Runtime::new()?;
 
     // Spawn a new synchronous actor, returning an actor reference to it.
-    let actor = actor as fn(_, _);
     // Options used to spawn the synchronous actor. Here we'll set the name of
     // the thread that runs the actor.
     let options = SyncActorOptions::default().with_name("My actor".to_owned());
-    let actor_ref = runtime.spawn_sync_actor(NoSupervisor, actor, "Bye", options)?;
+    let actor_ref = runtime.spawn_sync_actor(NoSupervisor, actor_fn(actor), "Bye", options)?;
 
     // Just like with any actor reference we can send the actor a message.
     actor_ref.try_send("Hello world".to_string()).unwrap();

--- a/examples/4_restart_supervisor.rs
+++ b/examples/4_restart_supervisor.rs
@@ -3,7 +3,7 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, SyncContext};
+use heph::actor::{self, actor_fn, SyncContext};
 use heph::restart_supervisor;
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
@@ -12,21 +12,19 @@ fn main() -> Result<(), rt::Error> {
     std_logger::Config::logfmt().init();
     let mut runtime = Runtime::setup().build()?;
 
-    let sync_actor = sync_print_actor as fn(_, _) -> _;
     let arg = "Hello world!".to_owned();
     let supervisor = PrintSupervisor::new(arg.clone());
     let options = SyncActorOptions::default();
-    runtime.spawn_sync_actor(supervisor, sync_actor, arg, options)?;
+    runtime.spawn_sync_actor(supervisor, actor_fn(sync_print_actor), arg, options)?;
 
     // NOTE: this is only here to make the test pass.
     sleep(Duration::from_millis(100));
 
     runtime.run_on_workers(|mut runtime_ref: RuntimeRef| -> Result<(), !> {
-        let print_actor = print_actor as fn(_, _) -> _;
         let options = ActorOptions::default();
         let arg = "Hello world!".to_owned();
         let supervisor = PrintSupervisor::new(arg.clone());
-        runtime_ref.spawn_local(supervisor, print_actor, arg, options);
+        runtime_ref.spawn_local(supervisor, actor_fn(print_actor), arg, options);
         Ok(())
     })?;
 

--- a/http/examples/my_ip.rs
+++ b/http/examples/my_ip.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::io;
 use std::time::Duration;
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph::supervisor::SupervisorStrategy;
 use heph_http::body::OneshotBody;
 use heph_http::{self as http, server, Header, HeaderName, Headers, Method, StatusCode};
@@ -17,7 +17,7 @@ use log::{debug, error, info, warn};
 fn main() -> Result<(), heph_rt::Error> {
     std_logger::Config::logfmt().init();
 
-    let actor = http_actor as fn(_, _) -> _;
+    let actor = actor_fn(http_actor);
     let address = "127.0.0.1:7890".parse().unwrap();
     let server = server::setup(address, conn_supervisor, actor, ActorOptions::default())
         .map_err(heph_rt::Error::setup)?;

--- a/http/examples/route.rs
+++ b/http/examples/route.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::time::Duration;
 
-use heph::actor::{self};
+use heph::actor::{self, actor_fn};
 use heph::supervisor::SupervisorStrategy;
 use heph_http::body::OneshotBody;
 use heph_http::{self as http, route, server, Request, Response};
@@ -16,7 +16,7 @@ use log::{error, info, warn};
 fn main() -> Result<(), heph_rt::Error> {
     std_logger::Config::logfmt().init();
 
-    let actor = http_actor as fn(_, _) -> _;
+    let actor = actor_fn(http_actor);
     let address = "127.0.0.1:7890".parse().unwrap();
     let server = server::setup(address, conn_supervisor, actor, ActorOptions::default())
         .map_err(heph_rt::Error::setup)?;

--- a/http/src/server.rs
+++ b/http/src/server.rs
@@ -32,7 +32,7 @@
 //! use std::net::SocketAddr;
 //! use std::time::Duration;
 //!
-//! use heph::actor::{self, Actor, NewActor};
+//! use heph::actor::{self, Actor, NewActor, actor_fn};
 //! use heph::supervisor::{Supervisor, SupervisorStrategy};
 //! use heph_http::body::OneshotBody;
 //! use heph_http::{self as http, server, Header, HeaderName, Headers, Method, StatusCode};
@@ -44,7 +44,7 @@
 //!
 //! fn main() -> Result<(), heph_rt::Error> {
 //!     // Setup the HTTP server.
-//!     let actor = http_actor as fn(_, _) -> _;
+//!     let actor = actor_fn(http_actor);
 //!     let address = "127.0.0.1:7890".parse().unwrap();
 //!     let server = server::setup(address, conn_supervisor, actor, ActorOptions::default())
 //!         .map_err(heph_rt::Error::setup)?;

--- a/http/tests/functional/client.rs
+++ b/http/tests/functional/client.rs
@@ -9,8 +9,9 @@ use std::thread::{self, sleep};
 use std::time::{Duration, SystemTime};
 use std::{fmt, str};
 
+use heph::actor::{self, actor_fn};
 use heph::messages::Terminate;
-use heph::{actor, Actor, ActorRef, NewActor, Supervisor, SupervisorStrategy};
+use heph::{Actor, ActorRef, NewActor, Supervisor, SupervisorStrategy};
 use heph_http::body::{EmptyBody, OneshotBody};
 use heph_http::client::{Client, ResponseError};
 use heph_http::server::RequestError;
@@ -45,11 +46,8 @@ fn get() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -82,11 +80,8 @@ fn get_no_response() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -117,11 +112,8 @@ fn get_invalid_response() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -159,11 +151,8 @@ fn request_with_headers() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -204,11 +193,8 @@ fn request_with_user_agent_header() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -252,9 +238,8 @@ fn request_with_content_length_header() {
         }
 
         let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
+            init_actor(actor_fn(http_actor), address).unwrap().0
+
         });
 
         expect_request(
@@ -298,9 +283,8 @@ fn request_with_transfer_encoding_header() {
         }
 
         let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
+            init_actor(actor_fn(http_actor), address).unwrap().0
+
         });
 
         expect_request(
@@ -343,9 +327,8 @@ fn request_sets_content_length_header() {
         }
 
         let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
+            init_actor(actor_fn(http_actor), address).unwrap().0
+
         });
 
         expect_request(
@@ -388,11 +371,8 @@ fn partial_response() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -430,11 +410,8 @@ fn same_content_length() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -469,11 +446,8 @@ fn different_content_length() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -508,11 +482,8 @@ fn transfer_encoding_and_content_length_and() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -547,11 +518,8 @@ fn invalid_content_length() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -584,11 +552,8 @@ fn chunked_transfer_encoding() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -621,11 +586,8 @@ fn slow_chunked_transfer_encoding() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -660,11 +622,8 @@ fn empty_chunked_transfer_encoding() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -700,11 +659,8 @@ fn content_length_and_identity_transfer_encoding() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -741,11 +697,8 @@ fn unsupported_transfer_encoding() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -781,11 +734,8 @@ fn chunked_not_last_transfer_encoding() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -821,11 +771,8 @@ fn content_length_and_transfer_encoding() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -860,11 +807,8 @@ fn invalid_chunk_size() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -900,11 +844,8 @@ fn connect() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -939,11 +880,8 @@ fn head() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -979,11 +917,8 @@ fn response_status_204() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -1018,11 +953,8 @@ fn no_content_length_no_transfer_encoding_response() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -1057,11 +989,8 @@ fn response_head_too_large() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -1098,11 +1027,8 @@ fn invalid_header_name() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -1136,11 +1062,8 @@ fn invalid_header_value() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -1176,11 +1099,8 @@ fn invalid_new_line() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -1214,11 +1134,8 @@ fn invalid_version() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -1252,11 +1169,8 @@ fn invalid_status() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,
@@ -1290,11 +1204,8 @@ fn too_many_headers() {
             Ok(())
         }
 
-        let (mut stream, handle) = test_server.accept(|address| {
-            let http_actor = http_actor as fn(_, _) -> _;
-            let (actor, _) = init_actor(http_actor, address).unwrap();
-            actor
-        });
+        let (mut stream, handle) =
+            test_server.accept(|address| init_actor(actor_fn(http_actor), address).unwrap().0);
 
         expect_request(
             &mut stream,

--- a/http/tests/functional/server.rs
+++ b/http/tests/functional/server.rs
@@ -6,8 +6,9 @@ use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::thread::{self, sleep};
 use std::time::{Duration, SystemTime};
 
+use heph::actor::{self, actor_fn};
 use heph::messages::Terminate;
-use heph::{actor, ActorRef, SupervisorStrategy};
+use heph::{ActorRef, SupervisorStrategy};
 use heph_http::body::OneshotBody;
 use heph_http::server::{self, RequestError};
 use heph_http::{self as http, Header, HeaderName, Headers, Method, StatusCode, Version};
@@ -580,7 +581,7 @@ impl TestServer {
         let server_ref = Arc::new((Mutex::new(None), Condvar::new()));
         let set_ref = server_ref.clone();
 
-        let actor = http_actor as fn(_, _) -> _;
+        let actor = actor_fn(http_actor);
         let address = "127.0.0.1:0".parse().unwrap();
         let server = server::setup(address, conn_supervisor, actor, ActorOptions::default())
             .map_err(heph_rt::Error::setup)

--- a/remote/src/net_relay/mod.rs
+++ b/remote/src/net_relay/mod.rs
@@ -29,7 +29,8 @@
 //! use std::net::SocketAddr;
 //!
 //! use heph::supervisor::NoSupervisor;
-//! use heph::{actor, restart_supervisor, ActorRef};
+//! use heph::actor::{self, actor_fn};
+//! use heph::{restart_supervisor, ActorRef};
 //! use heph_remote::net_relay::{self, Relay, UdpRelayMessage};
 //! use heph_rt::spawn::ActorOptions;
 //! use heph_rt::{self as rt, Runtime};
@@ -51,7 +52,7 @@
 //!         println!("received message: {msg}");
 //!     }
 //! }
-//! let local_actor = local_actor as fn(_) -> _;
+//! let local_actor = actor_fn(local_actor);
 //! let local_actor_ref = runtime.spawn(NoSupervisor, local_actor, (), ActorOptions::default());
 //!
 //! // Next we're going to spawn our net relay actor.

--- a/rt/examples/1_hello_world.rs
+++ b/rt/examples/1_hello_world.rs
@@ -1,6 +1,6 @@
 #![feature(never_type)]
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::ActorOptions;
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
@@ -25,7 +25,7 @@ fn add_greeter_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
     // arguments.
     // We'll use the default actor options here, other examples expand on the
     // options available.
-    let actor = greeter_actor as fn(_) -> _;
+    let actor = actor_fn(greeter_actor);
     let actor_ref = runtime_ref.spawn_local(NoSupervisor, actor, (), ActorOptions::default());
 
     // Now we can send our actor a message using its `actor_ref`.

--- a/rt/examples/2_my_ip.rs
+++ b/rt/examples/2_my_ip.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use heph::actor::{self, Actor, NewActor};
+use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph::supervisor::{Supervisor, SupervisorStrategy};
 use heph_rt::net::{tcp, TcpStream};
 use heph_rt::spawn::options::{ActorOptions, Priority};
@@ -22,7 +22,7 @@ fn main() -> Result<(), rt::Error> {
     // done by `conn_supervisor` in this example. And as each actor will need to
     // be added to the runtime it needs the `ActorOptions` to do that, we'll use
     // the defaults options here.
-    let actor = conn_actor as fn(_, _) -> _;
+    let actor = actor_fn(conn_actor);
     let address = "127.0.0.1:7890".parse().unwrap();
     let server = tcp::server::setup(address, conn_supervisor, actor, ActorOptions::default())
         .map_err(rt::Error::setup)?;

--- a/rt/examples/3_rpc.rs
+++ b/rt/examples/3_rpc.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph::actor_ref::{ActorRef, RpcMessage};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::ActorOptions;
@@ -17,10 +17,10 @@ fn main() -> Result<(), rt::Error> {
 
 fn add_rpc_actor(mut runtime_ref: RuntimeRef) -> Result<(), !> {
     // See example 1 for information on how to spawn actors.
-    let pong_actor = pong_actor as fn(_) -> _;
+    let pong_actor = actor_fn(pong_actor);
     let actor_ref = runtime_ref.spawn_local(NoSupervisor, pong_actor, (), ActorOptions::default());
 
-    let ping_actor = ping_actor as fn(_, _) -> _;
+    let ping_actor = actor_fn(ping_actor);
     runtime_ref.spawn_local(NoSupervisor, ping_actor, actor_ref, ActorOptions::default());
 
     Ok(())

--- a/rt/examples/4_sync_actor.rs
+++ b/rt/examples/4_sync_actor.rs
@@ -1,4 +1,4 @@
-use heph::actor::SyncContext;
+use heph::actor::{actor_fn, SyncContext};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::{self as rt, Runtime};
@@ -10,7 +10,7 @@ fn main() -> Result<(), rt::Error> {
     let mut runtime = Runtime::new()?;
 
     // Spawn a new synchronous actor, returning an actor reference to it.
-    let actor = actor as fn(_, _);
+    let actor = actor_fn(actor);
     // Options used to spawn the synchronous actor. Here we'll set the name of
     // the thread that runs the actor.
     let options = SyncActorOptions::default().with_name("My actor".to_owned());

--- a/rt/examples/7_restart_supervisor.rs
+++ b/rt/examples/7_restart_supervisor.rs
@@ -3,7 +3,7 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, SyncContext};
+use heph::actor::{self, actor_fn, SyncContext};
 use heph::restart_supervisor;
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
@@ -12,7 +12,7 @@ fn main() -> Result<(), rt::Error> {
     std_logger::Config::logfmt().init();
     let mut runtime = Runtime::setup().build()?;
 
-    let sync_actor = sync_print_actor as fn(_, _) -> _;
+    let sync_actor = actor_fn(sync_print_actor);
     let arg = "Hello world!".to_owned();
     let supervisor = PrintSupervisor::new(arg.clone());
     let options = SyncActorOptions::default();
@@ -22,7 +22,7 @@ fn main() -> Result<(), rt::Error> {
     sleep(Duration::from_millis(100));
 
     runtime.run_on_workers(|mut runtime_ref: RuntimeRef| -> Result<(), !> {
-        let print_actor = print_actor as fn(_, _) -> _;
+        let print_actor = actor_fn(print_actor);
         let options = ActorOptions::default();
         let arg = "Hello world!".to_owned();
         let supervisor = PrintSupervisor::new(arg.clone());

--- a/rt/examples/redis.rs
+++ b/rt/examples/redis.rs
@@ -10,7 +10,7 @@ use std::io::{self, Write};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use heph::actor::{self, Actor, NewActor};
+use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph::supervisor::{Supervisor, SupervisorStrategy};
 use heph_rt::net::{tcp, TcpStream};
 use heph_rt::spawn::options::{ActorOptions, Priority};
@@ -41,7 +41,7 @@ fn main() -> Result<(), rt::Error> {
     std_logger::Config::logfmt().init();
 
     let values = Arc::new(RwLock::new(HashMap::new()));
-    let actor = (conn_actor as fn(_, _, _) -> _).map_arg(move |stream| (stream, values.clone()));
+    let actor = actor_fn(conn_actor).map_arg(move |stream| (stream, values.clone()));
     let address = "127.0.0.1:6379".parse().unwrap();
     let server = tcp::server::setup(address, conn_supervisor, actor, ActorOptions::default())
         .map_err(rt::Error::setup)?;

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -69,7 +69,7 @@
 //!
 //! ```
 //! # #![feature(never_type)]
-//! use heph::actor::{self, SyncContext};
+//! use heph::actor::{self, SyncContext, actor_fn};
 //! use heph::supervisor::NoSupervisor;
 //! use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 //! use heph_rt::{self as rt, Runtime, RuntimeRef};
@@ -90,12 +90,12 @@
 //!
 //!     // We'll start with spawning a synchronous actor.
 //!     // For more information on spawning actors see the spawn module.
-//!     let actor_ref = runtime.spawn_sync_actor(NoSupervisor, sync_actor as fn(_) -> _, (), SyncActorOptions::default())?;
+//!     let actor_ref = runtime.spawn_sync_actor(NoSupervisor, actor_fn(sync_actor), (), SyncActorOptions::default())?;
 //!     // And sending it a message.
 //!     actor_ref.try_send("Alice").unwrap();
 //!
 //!     // Next a thread-safe actor.
-//!     let actor_ref = runtime.spawn(NoSupervisor, actor as fn(_, _) -> _, "thread-safe", ActorOptions::default());
+//!     let actor_ref = runtime.spawn(NoSupervisor, actor_fn(actor), "thread-safe", ActorOptions::default());
 //!     actor_ref.try_send("Bob").unwrap();
 //!
 //!     // To spawn thread-safe actors we need to run it on the worker thread,
@@ -113,7 +113,7 @@
 //! // this example we create two threads (see `main`).
 //! fn setup(mut runtime_ref: RuntimeRef) -> Result<(), !> {
 //!     // Spawn a thread-local actor.
-//!     let actor_ref = runtime_ref.spawn_local(NoSupervisor, actor as fn(_, _) -> _, "thread-local", ActorOptions::default());
+//!     let actor_ref = runtime_ref.spawn_local(NoSupervisor, actor_fn(actor), "thread-local", ActorOptions::default());
 //!     actor_ref.try_send("Charlie").unwrap();
 //!     Ok(())
 //! }

--- a/rt/src/net/tcp/server.rs
+++ b/rt/src/net/tcp/server.rs
@@ -28,7 +28,7 @@
 //!
 //! use std::io;
 //!
-//! use heph::actor;
+//! use heph::actor::{self, actor_fn};
 //! # use heph::messages::Terminate;
 //! use heph::supervisor::SupervisorStrategy;
 //! use heph_rt::net::{tcp, TcpStream};
@@ -49,7 +49,7 @@
 //!     // The address to listen on.
 //!     let address = "127.0.0.1:7890".parse().unwrap();
 //!     // Create our TCP server.
-//!     let new_actor = conn_actor as fn(_, _) -> _;
+//!     let new_actor = actor_fn(conn_actor);
 //!     let server = tcp::server::setup(address, conn_supervisor, new_actor, ActorOptions::default())?;
 //!
 //!     // We advice to give the TCP server a low priority to prioritise
@@ -99,7 +99,7 @@
 //! #
 //! use std::io;
 //!
-//! use heph::actor;
+//! use heph::actor::{self, actor_fn};
 //! use heph::messages::Terminate;
 //! # use heph::supervisor::SupervisorStrategy;
 //! use heph_rt::net::{tcp, TcpStream};
@@ -118,7 +118,7 @@
 //!     // This uses the same supervisors as in the previous example, not shown here.
 //!
 //!     // Adding the TCP server is the same as in the example above.
-//!     let new_actor = conn_actor as fn(_, _) -> _;
+//!     let new_actor = actor_fn(conn_actor);
 //!     let address = "127.0.0.1:7890".parse().unwrap();
 //!     let server = tcp::server::setup(address, conn_supervisor, new_actor, ActorOptions::default())?;
 //!     let options = ActorOptions::default().with_priority(Priority::LOW);
@@ -167,7 +167,7 @@
 //!
 //! use std::io;
 //!
-//! use heph::actor;
+//! use heph::actor::{self, actor_fn};
 //! # use heph::messages::Terminate;
 //! use heph::supervisor::{SupervisorStrategy};
 //! use heph_rt::net::{tcp, TcpStream};
@@ -181,7 +181,7 @@
 //!     // The address to listen on.
 //!     let address = "127.0.0.1:7890".parse().unwrap();
 //!     // Create our TCP server. We'll use the default actor options.
-//!     let new_actor = conn_actor as fn(_, _) -> _;
+//!     let new_actor = actor_fn(conn_actor);
 //!     let server = tcp::server::setup(address, conn_supervisor, new_actor, ActorOptions::default())
 //!         .map_err(rt::Error::setup)?;
 //!

--- a/rt/src/pipe.rs
+++ b/rt/src/pipe.rs
@@ -41,7 +41,7 @@
 //! #
 //! # let actor_ref = heph_rt::test::try_spawn(
 //! #     heph_rt::test::PanicSupervisor,
-//! #     actor as fn(_) -> _,
+//! #     heph::actor::actor_fn(actor),
 //! #     (),
 //! #     heph_rt::spawn::ActorOptions::default(),
 //! # ).unwrap();
@@ -90,7 +90,7 @@
 //! #
 //! # let actor_ref = heph_rt::test::try_spawn(
 //! #     heph_rt::test::PanicSupervisor,
-//! #     process_handler as fn(_) -> _,
+//! #     heph::actor::actor_fn(process_handler),
 //! #     (),
 //! #     heph_rt::spawn::ActorOptions::default(),
 //! # ).unwrap();

--- a/rt/src/scheduler/shared/tests.rs
+++ b/rt/src/scheduler/shared/tests.rs
@@ -4,7 +4,7 @@ use std::future::pending;
 use std::sync::{Arc, Mutex};
 use std::task::{self, Poll};
 
-use heph::actor::{self, ActorFuture};
+use heph::actor::{self, actor_fn, ActorFuture};
 use heph::supervisor::NoSupervisor;
 
 use crate::process::{FutureProcess, ProcessId};
@@ -104,7 +104,7 @@ fn scheduler_run_order() {
     let run_order = Arc::new(Mutex::new(Vec::new()));
 
     // Add our processes.
-    let new_actor = order_actor as fn(_, _, _) -> _;
+    let new_actor = actor_fn(order_actor);
     let priorities = [Priority::LOW, Priority::NORMAL, Priority::HIGH];
     let mut pids = vec![];
     for (id, priority) in priorities.iter().enumerate() {
@@ -181,7 +181,7 @@ fn assert_future_process_unmoved() {
 }
 
 fn add_test_actor(scheduler: &Scheduler, priority: Priority) -> ProcessId {
-    let new_actor = simple_actor as fn(_) -> _;
+    let new_actor = actor_fn(simple_actor);
     let rt = ThreadSafe::new(test::shared_internals());
     let (process, _) = ActorFuture::new(NoSupervisor, new_actor, (), rt).unwrap();
     scheduler.add_new_process(priority, process)

--- a/rt/src/timer.rs
+++ b/rt/src/timer.rs
@@ -52,6 +52,7 @@ impl From<DeadlinePassed> for io::ErrorKind {
 /// # use std::time::Instant;
 ///
 /// use heph::actor;
+/// # use heph::actor::actor_fn;
 /// # use heph::supervisor::NoSupervisor;
 /// # use heph_rt::spawn::ActorOptions;
 /// # use heph_rt::{self as rt, Runtime, RuntimeRef};
@@ -66,9 +67,7 @@ impl From<DeadlinePassed> for io::ErrorKind {
 /// #
 /// #
 /// # fn setup(mut runtime_ref: RuntimeRef) -> Result<(), !> {
-/// #   let actor = actor as fn(_) -> _;
-/// #   let options = ActorOptions::default();
-/// #   runtime_ref.spawn_local(NoSupervisor, actor, (), options);
+/// #   runtime_ref.spawn_local(NoSupervisor, actor_fn(actor), (), ActorOptions::default());
 /// #   Ok(())
 /// # }
 /// #
@@ -181,6 +180,7 @@ impl<RT: Access> Drop for Timer<RT> {
 /// # use std::time::Instant;
 ///
 /// use heph::actor;
+/// # use heph::actor::actor_fn;
 /// # use heph::supervisor::NoSupervisor;
 /// use heph_rt::ThreadSafe;
 /// # use heph_rt::spawn::ActorOptions;
@@ -188,7 +188,7 @@ impl<RT: Access> Drop for Timer<RT> {
 /// use heph_rt::timer::Deadline;
 ///
 /// # fn main() -> Result<(), rt::Error> {
-/// #     let actor = actor as fn(_) -> _;
+/// #     let actor = actor_fn(actor);
 /// #     let options = ActorOptions::default();
 /// #     let mut rt = Runtime::new()?;
 /// #     let _ = rt.spawn(NoSupervisor, actor, (), options);
@@ -322,6 +322,7 @@ impl<Fut: Unpin, RT: Access> Unpin for Deadline<Fut, RT> {}
 /// # use std::time::Instant;
 ///
 /// use heph::actor;
+/// # use heph::actor::actor_fn;
 /// # use heph::supervisor::NoSupervisor;
 /// # use heph_rt::spawn::ActorOptions;
 /// # use heph_rt::{self as rt, Runtime, RuntimeRef};
@@ -336,7 +337,7 @@ impl<Fut: Unpin, RT: Access> Unpin for Deadline<Fut, RT> {}
 /// # }
 /// #
 /// # fn setup(mut runtime_ref: RuntimeRef) -> Result<(), !> {
-/// #   let actor = actor as fn(_) -> _;
+/// #   let actor = actor_fn(actor);
 /// #   let options = ActorOptions::default();
 /// #   runtime_ref.spawn_local(NoSupervisor, actor, (), options);
 /// #   Ok(())

--- a/rt/tests/functional/actor.rs
+++ b/rt/tests/functional/actor.rs
@@ -1,6 +1,6 @@
 //! Tests for the [`Actor`] trait.
 
-use heph::actor::{self, NewActor};
+use heph::actor::{self, actor_fn, NewActor};
 
 #[test]
 fn future_output_result() {
@@ -8,14 +8,14 @@ fn future_output_result() {
     async fn actor(_: actor::Context<(), ()>) -> Result<(), ()> {
         Ok(())
     }
-    is_new_actor(actor as fn(_) -> _);
+    is_new_actor(actor_fn(actor));
 }
 
 #[test]
 fn future_output_tuple() {
     // Actor is implemented for `Future<Output = ()>`.
     async fn actor(_: actor::Context<(), ()>) {}
-    is_new_actor(actor as fn(_) -> _);
+    is_new_actor(actor_fn(actor));
 }
 
 fn is_new_actor<NA: NewActor>(_: NA) {}

--- a/rt/tests/functional/actor_context.rs
+++ b/rt/tests/functional/actor_context.rs
@@ -3,7 +3,7 @@
 use std::pin::Pin;
 use std::task::Poll;
 
-use heph::actor::{self, NoMessages, RecvError};
+use heph::actor::{self, actor_fn, NoMessages, RecvError};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::{ActorOptions, Spawn};
 use heph_rt::test::{init_local_actor, poll_actor};
@@ -29,7 +29,7 @@ async fn local_actor_context_actor(mut ctx: actor::Context<usize, ThreadLocal>) 
 
 #[test]
 fn local_actor_context() {
-    let local_actor_context_actor = local_actor_context_actor as fn(_) -> _;
+    let local_actor_context_actor = actor_fn(local_actor_context_actor);
     let (actor, actor_ref) = init_local_actor(local_actor_context_actor, ()).unwrap();
     let mut actor = Box::pin(actor);
 
@@ -57,7 +57,7 @@ async fn actor_ref_actor(mut ctx: actor::Context<usize, ThreadLocal>) {
 
 #[test]
 fn actor_ref() {
-    let actor_ref_actor = actor_ref_actor as fn(_) -> _;
+    let actor_ref_actor = actor_fn(actor_ref_actor);
     let (actor, actor_ref) = init_local_actor(actor_ref_actor, ()).unwrap();
     let mut actor = Box::pin(actor);
 
@@ -69,14 +69,14 @@ async fn thread_safe_try_spawn_actor(mut ctx: actor::Context<usize, ThreadSafe>)
     let actor_ref1 = ctx
         .try_spawn(
             NoSupervisor,
-            spawned_actor1 as fn(_) -> _,
+            actor_fn(spawned_actor1),
             (),
             ActorOptions::default(),
         )
         .unwrap();
     let actor_ref2 = ctx.spawn(
         NoSupervisor,
-        spawned_actor1 as fn(_) -> _,
+        actor_fn(spawned_actor1),
         (),
         ActorOptions::default(),
     );
@@ -92,7 +92,7 @@ async fn spawned_actor1(mut ctx: actor::Context<usize, ThreadSafe>) {
 
 #[test]
 fn thread_safe_try_spawn() {
-    let thread_safe_try_spawn_actor = thread_safe_try_spawn_actor as fn(_) -> _;
+    let thread_safe_try_spawn_actor = actor_fn(thread_safe_try_spawn_actor);
     let mut runtime = Runtime::new().unwrap();
     let _ = runtime.spawn(
         NoSupervisor,

--- a/rt/tests/functional/from_message.rs
+++ b/rt/tests/functional/from_message.rs
@@ -2,9 +2,10 @@
 
 use std::time::Duration;
 
+use heph::actor::{self, actor_fn};
 use heph::actor_ref::{ActorRef, RpcMessage};
+use heph::from_message;
 use heph::supervisor::NoSupervisor;
-use heph::{actor, from_message};
 use heph_rt::spawn::ActorOptions;
 use heph_rt::test::{join, try_spawn_local};
 use heph_rt::ThreadLocal;
@@ -22,10 +23,10 @@ from_message!(Message::Rpc2(String, usize) -> (usize, usize));
 
 #[test]
 fn from_message() {
-    let pong_actor = pong_actor as fn(_) -> _;
+    let pong_actor = actor_fn(pong_actor);
     let pong_ref = try_spawn_local(NoSupervisor, pong_actor, (), ActorOptions::default()).unwrap();
 
-    let ping_actor = ping_actor as fn(_, _) -> _;
+    let ping_actor = actor_fn(ping_actor);
     let ping_ref = try_spawn_local(
         NoSupervisor,
         ping_actor,

--- a/rt/tests/functional/fs.rs
+++ b/rt/tests/functional/fs.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::path::PathBuf;
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph_rt::access::ThreadLocal;
 use heph_rt::fs::{self, Advice, AllocateMode, File};
 use heph_rt::io::{Read, Write};
@@ -32,7 +32,7 @@ fn file_read_write() {
         assert_eq!(buf, DATA2);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn file_sync_all() {
         file.sync_all().await.unwrap();
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn file_sync_data() {
         file.sync_all().await.unwrap();
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn file_metadata() {
         assert!(!permissions.owner_can_execute());
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn file_advise() {
         drop(file);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -135,7 +135,7 @@ fn file_allocate() {
         assert_eq!(buf.len(), SIZE);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn create_dir() {
         (&file).write(DATA1).await.unwrap();
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn rename() {
         assert_eq!(buf, DATA1);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn remove_file() {
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -212,5 +212,5 @@ fn remove_dir() {
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }

--- a/rt/tests/functional/future.rs
+++ b/rt/tests/functional/future.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::{ActorOptions, FutureOptions};
 use heph_rt::test::poll_future;
@@ -72,7 +72,7 @@ fn thread_safe_waking() {
     let mut runtime = Runtime::new().unwrap();
     let _ = runtime.spawn(
         NoSupervisor,
-        spawn_actor as fn(_) -> _,
+        actor_fn(spawn_actor),
         (),
         ActorOptions::default(),
     );

--- a/rt/tests/functional/pipe.rs
+++ b/rt/tests/functional/pipe.rs
@@ -3,7 +3,8 @@
 use std::io;
 use std::time::Duration;
 
-use heph::{actor, ActorRef};
+use heph::actor::{self, actor_fn};
+use heph::ActorRef;
 use heph_rt::io::{Read, Write};
 use heph_rt::pipe::{self, Receiver};
 use heph_rt::spawn::ActorOptions;
@@ -32,8 +33,7 @@ fn smoke() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }
@@ -72,12 +72,10 @@ fn write_all_read_n() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let reader = reader as fn(_) -> _;
+    let reader = actor_fn(reader);
     let reader_ref = try_spawn_local(PanicSupervisor, reader, (), ActorOptions::default()).unwrap();
 
-    #[allow(trivial_casts)]
-    let writer = writer as fn(_, _) -> _;
+    let writer = actor_fn(writer);
     let writer_ref = try_spawn_local(
         PanicSupervisor,
         writer,
@@ -129,12 +127,10 @@ fn write_vectored_all_read_n_vectored() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let reader = reader as fn(_) -> _;
+    let reader = actor_fn(reader);
     let reader_ref = try_spawn_local(PanicSupervisor, reader, (), ActorOptions::default()).unwrap();
 
-    #[allow(trivial_casts)]
-    let writer = writer as fn(_, _) -> _;
+    let writer = actor_fn(writer);
     let writer_ref = try_spawn_local(
         PanicSupervisor,
         writer,
@@ -171,8 +167,7 @@ fn vectored_io() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }

--- a/rt/tests/functional/sync_actor.rs
+++ b/rt/tests/functional/sync_actor.rs
@@ -5,7 +5,7 @@ use std::task::{self, Poll};
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{RecvError, SyncContext};
+use heph::actor::{actor_fn, RecvError, SyncContext};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::test::spawn_sync_actor;
@@ -64,7 +64,7 @@ fn block_on() {
 
     let (handle, _) = spawn_sync_actor(
         NoSupervisor,
-        block_on_actor as fn(_, _) -> _,
+        actor_fn(block_on_actor),
         future.clone(),
         SyncActorOptions::default(),
     )
@@ -84,7 +84,7 @@ fn block_on_spurious_wake_up() {
 
     let (handle, _) = spawn_sync_actor(
         NoSupervisor,
-        block_on_actor as fn(_, _) -> _,
+        actor_fn(block_on_actor),
         future.clone(),
         SyncActorOptions::default(),
     )
@@ -123,7 +123,7 @@ fn try_receive_next_actor<RT>(mut ctx: SyncContext<String, RT>) {
 fn context_try_receive_next() {
     let (handle, actor_ref) = spawn_sync_actor(
         NoSupervisor,
-        try_receive_next_actor as fn(_) -> _,
+        actor_fn(try_receive_next_actor),
         (),
         SyncActorOptions::default(),
     )
@@ -137,7 +137,7 @@ fn context_try_receive_next() {
 fn supervision() {
     let (handle, _) = spawn_sync_actor(
         bad_actor_supervisor,
-        bad_actor as fn(_, _) -> _,
+        actor_fn(bad_actor),
         0usize,
         SyncActorOptions::default(),
     )

--- a/rt/tests/functional/tcp/listener.rs
+++ b/rt/tests/functional/tcp/listener.rs
@@ -1,8 +1,9 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
-use heph::{actor, ActorRef};
+use heph::ActorRef;
 use heph_rt::net::{TcpListener, TcpStream};
 use heph_rt::spawn::ActorOptions;
 use heph_rt::test::{join, join_many, try_spawn_local};
@@ -24,7 +25,7 @@ fn local_addr() {
         assert_eq!(listener.local_addr().unwrap(), address);
     }
 
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(NoSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }
@@ -46,7 +47,7 @@ fn local_addr_port_zero() {
         assert!(got.port() != 0);
     }
 
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(NoSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }
@@ -64,7 +65,7 @@ fn ttl() {
         assert_eq!(listener.ttl().unwrap(), expected);
     }
 
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(NoSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }
@@ -105,11 +106,11 @@ fn accept() {
         assert_eq!(buf, DATA);
     }
 
-    let stream_actor = stream_actor as fn(_) -> _;
+    let stream_actor = actor_fn(stream_actor);
     let stream_ref =
         try_spawn_local(NoSupervisor, stream_actor, (), ActorOptions::default()).unwrap();
 
-    let listener_actor = listener_actor as fn(_, _) -> _;
+    let listener_actor = actor_fn(listener_actor);
     let s_ref = stream_ref.clone();
     let listener_ref =
         try_spawn_local(NoSupervisor, listener_actor, s_ref, ActorOptions::default()).unwrap();
@@ -138,11 +139,11 @@ fn incoming() {
         assert_eq!(buf, DATA);
     }
 
-    let stream_actor = stream_actor as fn(_) -> _;
+    let stream_actor = actor_fn(stream_actor);
     let stream_ref =
         try_spawn_local(NoSupervisor, stream_actor, (), ActorOptions::default()).unwrap();
 
-    let listener_actor = listener_actor as fn(_, _) -> _;
+    let listener_actor = actor_fn(listener_actor);
     let s_ref = stream_ref.clone();
     let listener_ref =
         try_spawn_local(NoSupervisor, listener_actor, s_ref, ActorOptions::default()).unwrap();

--- a/rt/tests/functional/tcp/stream.rs
+++ b/rt/tests/functional/tcp/stream.rs
@@ -5,7 +5,7 @@ use std::io::{self, IoSlice, Read, Write};
 use std::net::{self, Shutdown, SocketAddr};
 use std::time::Duration;
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph::actor_ref::ActorRef;
 use heph::supervisor::NoSupervisor;
 use heph_rt::net::{TcpListener, TcpStream};
@@ -68,7 +68,7 @@ fn smoke() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -94,7 +94,7 @@ fn connect() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -127,7 +127,7 @@ fn connect_connection_refused() {
         }
     }
 
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }
@@ -152,7 +152,7 @@ fn recv() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -186,7 +186,7 @@ fn recv_n_read_exact_amount() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -223,7 +223,7 @@ fn recv_n_read_more_bytes() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -251,7 +251,7 @@ fn recv_n_less_bytes() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -278,7 +278,7 @@ fn recv_n_from_multiple_writes() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -305,7 +305,7 @@ fn send() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -333,7 +333,7 @@ fn send_all() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -369,7 +369,7 @@ fn send_vectored() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -401,7 +401,7 @@ fn send_vectored_all() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -456,7 +456,7 @@ fn recv_vectored() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -503,7 +503,7 @@ fn recv_n_vectored_exact_amount() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -543,7 +543,7 @@ fn recv_n_vectored_more_bytes() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -574,7 +574,7 @@ fn recv_n_vectored_less_bytes() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -606,7 +606,7 @@ fn recv_n_vectored_from_multiple_writes() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -644,7 +644,7 @@ fn peek() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -680,7 +680,7 @@ fn send_file() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _, _) -> _;
+    let actor = actor_fn(actor);
     let args = (address, TEST_FILE0);
     let actor_ref1 =
         try_spawn_local(PanicSupervisor, actor, args, ActorOptions::default()).unwrap();
@@ -743,7 +743,7 @@ fn send_file_all() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _, _) -> _;
+    let actor = actor_fn(actor);
     let args = (address, TEST_FILE0);
     let actor_ref1 =
         try_spawn_local(PanicSupervisor, actor, args, ActorOptions::default()).unwrap();
@@ -794,7 +794,7 @@ fn send_entire_file() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _, _) -> _;
+    let actor = actor_fn(actor);
     let args = (address, TEST_FILE0);
     let actor_ref1 =
         try_spawn_local(PanicSupervisor, actor, args, ActorOptions::default()).unwrap();
@@ -892,7 +892,7 @@ fn peek_vectored() {
     let listener = net::TcpListener::bind(any_local_address()).unwrap();
     let address = listener.local_addr().unwrap();
 
-    let actor = actor as fn(_, _) -> _;
+    let actor = actor_fn(actor);
     let actor_ref =
         try_spawn_local(PanicSupervisor, actor, address, ActorOptions::default()).unwrap();
 
@@ -950,11 +950,11 @@ fn shutdown_read() {
         stream.send_all(DATA).await.unwrap();
     }
 
-    let stream_actor = stream_actor as fn(_) -> _;
+    let stream_actor = actor_fn(stream_actor);
     let stream_ref =
         try_spawn_local(NoSupervisor, stream_actor, (), ActorOptions::default()).unwrap();
 
-    let listener_actor = listener_actor as fn(_, _) -> _;
+    let listener_actor = actor_fn(listener_actor);
     let s_ref = stream_ref.clone();
     let listener_ref =
         try_spawn_local(NoSupervisor, listener_actor, s_ref, ActorOptions::default()).unwrap();
@@ -1001,11 +1001,11 @@ fn shutdown_write() {
         assert_eq!(buf, DATA);
     }
 
-    let stream_actor = stream_actor as fn(_) -> _;
+    let stream_actor = actor_fn(stream_actor);
     let stream_ref =
         try_spawn_local(NoSupervisor, stream_actor, (), ActorOptions::default()).unwrap();
 
-    let listener_actor = listener_actor as fn(_, _) -> _;
+    let listener_actor = actor_fn(listener_actor);
     let s_ref = stream_ref.clone();
     let listener_ref =
         try_spawn_local(NoSupervisor, listener_actor, s_ref, ActorOptions::default()).unwrap();
@@ -1048,11 +1048,11 @@ fn shutdown_both() {
         assert!(buf.is_empty());
     }
 
-    let stream_actor = stream_actor as fn(_) -> _;
+    let stream_actor = actor_fn(stream_actor);
     let stream_ref =
         try_spawn_local(NoSupervisor, stream_actor, (), ActorOptions::default()).unwrap();
 
-    let listener_actor = listener_actor as fn(_, _) -> _;
+    let listener_actor = actor_fn(listener_actor);
     let s_ref = stream_ref.clone();
     let listener_ref =
         try_spawn_local(NoSupervisor, listener_actor, s_ref, ActorOptions::default()).unwrap();

--- a/rt/tests/functional/timer.rs
+++ b/rt/tests/functional/timer.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::{self, Poll};
 use std::time::{Duration, Instant};
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::ActorOptions;
 use heph_rt::test::{block_on_local_actor, poll_future, poll_next};
@@ -48,7 +48,7 @@ fn timer() {
         assert!(start.elapsed() >= TIMEOUT);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -78,7 +78,7 @@ fn timer_wrap() {
         assert!(start.elapsed() >= TIMEOUT);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn deadline() {
         assert!(start.elapsed() >= TIMEOUT);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn interval() {
         assert!(start.elapsed() >= TIMEOUT);
     }
 
-    block_on_local_actor(actor as fn(_) -> _, ()).unwrap();
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
 }
 
 #[test]
@@ -150,19 +150,19 @@ fn triggered_timers_run_actors() {
         // Spawn thread-local actors.
         let _ = runtime_ref.spawn_local(
             NoSupervisor,
-            timer_actor as fn(_) -> _,
+            actor_fn(timer_actor),
             (),
             ActorOptions::default(),
         );
         let _ = runtime_ref.spawn_local(
             NoSupervisor,
-            deadline_actor as fn(_) -> _,
+            actor_fn(deadline_actor),
             (),
             ActorOptions::default(),
         );
         let _ = runtime_ref.spawn_local(
             NoSupervisor,
-            interval_actor as fn(_) -> _,
+            actor_fn(interval_actor),
             (),
             ActorOptions::default(),
         );
@@ -175,19 +175,19 @@ fn triggered_timers_run_actors() {
     // Spawn thread-safe actors.
     let _ = runtime.spawn(
         NoSupervisor,
-        timer_actor as fn(_) -> _,
+        actor_fn(timer_actor),
         (),
         ActorOptions::default(),
     );
     let _ = runtime.spawn(
         NoSupervisor,
-        deadline_actor as fn(_) -> _,
+        actor_fn(deadline_actor),
         (),
         ActorOptions::default(),
     );
     let _ = runtime.spawn(
         NoSupervisor,
-        interval_actor as fn(_) -> _,
+        actor_fn(interval_actor),
         (),
         ActorOptions::default(),
     );
@@ -243,19 +243,19 @@ fn timers_dont_trigger_after_drop() {
         // Spawn thread-local actors.
         let _ = runtime_ref.spawn_local(
             NoSupervisor,
-            timer_actor as fn(_) -> _,
+            actor_fn(timer_actor),
             (),
             ActorOptions::default(),
         );
         let _ = runtime_ref.spawn_local(
             NoSupervisor,
-            deadline_actor as fn(_) -> _,
+            actor_fn(deadline_actor),
             (),
             ActorOptions::default(),
         );
         let _ = runtime_ref.spawn_local(
             NoSupervisor,
-            interval_actor as fn(_) -> _,
+            actor_fn(interval_actor),
             (),
             ActorOptions::default(),
         );
@@ -268,19 +268,19 @@ fn timers_dont_trigger_after_drop() {
     // Spawn thread-safe actors.
     let _ = runtime.spawn(
         NoSupervisor,
-        timer_actor as fn(_) -> _,
+        actor_fn(timer_actor),
         (),
         ActorOptions::default(),
     );
     let _ = runtime.spawn(
         NoSupervisor,
-        deadline_actor as fn(_) -> _,
+        actor_fn(deadline_actor),
         (),
         ActorOptions::default(),
     );
     let _ = runtime.spawn(
         NoSupervisor,
-        interval_actor as fn(_) -> _,
+        actor_fn(interval_actor),
         (),
         ActorOptions::default(),
     );

--- a/rt/tests/functional/udp.rs
+++ b/rt/tests/functional/udp.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use heph::actor::{self, Actor, NewActor};
+use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph_rt::net::udp::UdpSocket;
 use heph_rt::spawn::ActorOptions;
 use heph_rt::test::{join, try_spawn_local, PanicSupervisor};
@@ -18,26 +18,22 @@ const DATAV_LEN: usize = DATAV[0].len() + DATAV[1].len() + DATAV[2].len();
 
 #[test]
 fn unconnected_ipv4() {
-    let new_actor = unconnected_udp_actor as fn(_, _) -> _;
-    test(any_local_address(), new_actor)
+    test(any_local_address(), actor_fn(unconnected_udp_actor))
 }
 
 #[test]
 fn unconnected_ipv6() {
-    let new_actor = unconnected_udp_actor as fn(_, _) -> _;
-    test(any_local_ipv6_address(), new_actor)
+    test(any_local_ipv6_address(), actor_fn(unconnected_udp_actor))
 }
 
 #[test]
 fn connected_ipv4() {
-    let new_actor = connected_udp_actor as fn(_, _) -> _;
-    test(any_local_address(), new_actor)
+    test(any_local_address(), actor_fn(connected_udp_actor))
 }
 
 #[test]
 fn connected_ipv6() {
-    let new_actor = connected_udp_actor as fn(_, _) -> _;
-    test(any_local_ipv6_address(), new_actor)
+    test(any_local_ipv6_address(), actor_fn(connected_udp_actor))
 }
 
 fn test<NA>(local_address: SocketAddr, new_actor: NA)
@@ -132,8 +128,7 @@ fn test_reconnecting(local_address: SocketAddr) {
     let address1 = socket1.local_addr().unwrap();
     let address2 = socket2.local_addr().unwrap();
 
-    #[allow(trivial_casts)]
-    let actor = reconnecting_actor as fn(_, _, _) -> _;
+    let actor = actor_fn(reconnecting_actor);
     let args = (address1, address2);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, args, ActorOptions::default()).unwrap();
 
@@ -182,25 +177,25 @@ async fn reconnecting_actor(
 
 #[test]
 fn connected_vectored_io_ipv4() {
-    let new_actor = connected_vectored_io_actor as fn(_, _) -> _;
+    let new_actor = actor_fn(connected_vectored_io_actor);
     test_vectored_io(any_local_address(), new_actor)
 }
 
 #[test]
 fn connected_vectored_io_ipv6() {
-    let new_actor = connected_vectored_io_actor as fn(_, _) -> _;
+    let new_actor = actor_fn(connected_vectored_io_actor);
     test_vectored_io(any_local_ipv6_address(), new_actor)
 }
 
 #[test]
 fn unconnected_vectored_io_ipv4() {
-    let new_actor = unconnected_vectored_io_actor as fn(_, _) -> _;
+    let new_actor = actor_fn(unconnected_vectored_io_actor);
     test_vectored_io(any_local_address(), new_actor)
 }
 
 #[test]
 fn unconnected_vectored_io_ipv6() {
-    let new_actor = unconnected_vectored_io_actor as fn(_, _) -> _;
+    let new_actor = actor_fn(unconnected_vectored_io_actor);
     test_vectored_io(any_local_ipv6_address(), new_actor)
 }
 

--- a/rt/tests/functional/uds/datagram.rs
+++ b/rt/tests/functional/uds/datagram.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::net::Shutdown;
 use std::time::Duration;
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph_rt::net::uds::{UnixAddr, UnixDatagram};
 use heph_rt::spawn::ActorOptions;
 use heph_rt::test::{join, try_spawn_local, PanicSupervisor};
@@ -58,8 +58,7 @@ fn pair() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }
@@ -98,8 +97,7 @@ fn bound() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }

--- a/rt/tests/functional/uds/listener.rs
+++ b/rt/tests/functional/uds/listener.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::time::Duration;
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph_rt::net::uds::{UnixAddr, UnixListener, UnixStream};
 use heph_rt::spawn::ActorOptions;
 use heph_rt::test::{join, try_spawn_local, PanicSupervisor};
@@ -42,8 +42,7 @@ fn accept() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }
@@ -78,8 +77,7 @@ fn incoming() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }

--- a/rt/tests/functional/uds/stream.rs
+++ b/rt/tests/functional/uds/stream.rs
@@ -5,7 +5,7 @@ use std::net::Shutdown;
 use std::os::unix::net;
 use std::time::Duration;
 
-use heph::actor;
+use heph::actor::{self, actor_fn};
 use heph_rt::net::uds::{UnixAddr, UnixStream};
 use heph_rt::spawn::ActorOptions;
 use heph_rt::test::{join, try_spawn_local, PanicSupervisor};
@@ -59,8 +59,7 @@ fn pair() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }
@@ -94,8 +93,7 @@ fn connect() {
         Ok(())
     }
 
-    #[allow(trivial_casts)]
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let actor_ref = try_spawn_local(PanicSupervisor, actor, (), ActorOptions::default()).unwrap();
     join(&actor_ref, Duration::from_secs(1)).unwrap();
 }

--- a/rt/tests/process_signals.rs
+++ b/rt/tests/process_signals.rs
@@ -4,7 +4,7 @@ use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use heph::actor::{self, SyncContext};
+use heph::actor::{self, actor_fn, SyncContext};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::options::{ActorOptions, SyncActorOptions};
 use heph_rt::{Runtime, Signal};
@@ -40,11 +40,11 @@ fn with_signal_handles() {
     let ts = thread_safe1.clone();
     runtime
         .run_on_workers(|mut runtime_ref| -> Result<(), !> {
-            let tla = actor as fn(_, _) -> _;
+            let tla = actor_fn(actor);
             let actor_ref = runtime_ref.spawn_local(NoSupervisor, tla, tl, ActorOptions::default());
             runtime_ref.receive_signals(actor_ref);
 
-            let tsa = actor as fn(_, _) -> _;
+            let tsa = actor_fn(actor);
             let actor_ref = runtime_ref.spawn(NoSupervisor, tsa, ts, ActorOptions::default());
             runtime_ref.receive_signals(actor_ref);
 
@@ -54,7 +54,7 @@ fn with_signal_handles() {
 
     let actor_ref = runtime.spawn(
         NoSupervisor,
-        actor as fn(_, _) -> _,
+        actor_fn(actor),
         thread_safe2.clone(),
         ActorOptions::default(),
     );
@@ -63,7 +63,7 @@ fn with_signal_handles() {
     let actor_ref = runtime
         .spawn_sync_actor(
             NoSupervisor,
-            sync_actor as fn(_, _) -> _,
+            actor_fn(sync_actor),
             sync.clone(),
             SyncActorOptions::default(),
         )

--- a/rt/tests/regression/issue_294.rs
+++ b/rt/tests/regression/issue_294.rs
@@ -3,7 +3,7 @@
 //! In this test the actor reference, to the sync actor, should be dropped allow
 //! the sync actor to stop and not prevent the test from returning.
 
-use heph::actor::SyncContext;
+use heph::actor::{actor_fn, SyncContext};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::Runtime;
@@ -12,7 +12,7 @@ use heph_rt::Runtime;
 fn issue_294() {
     let mut runtime = Runtime::new().unwrap();
 
-    let actor = actor as fn(_);
+    let actor = actor_fn(actor);
     let options = SyncActorOptions::default();
     let actor_ref = runtime
         .spawn_sync_actor(NoSupervisor, actor, (), options)

--- a/rt/tests/regression/issue_323.rs
+++ b/rt/tests/regression/issue_323.rs
@@ -4,7 +4,7 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::SyncContext;
+use heph::actor::{actor_fn, SyncContext};
 use heph::supervisor::NoSupervisor;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::Runtime;
@@ -13,7 +13,7 @@ use heph_rt::Runtime;
 fn issue_323() {
     let mut runtime = Runtime::new().unwrap();
 
-    let actor = actor as fn(_) -> _;
+    let actor = actor_fn(actor);
     let options = SyncActorOptions::default();
     runtime
         .spawn_sync_actor(NoSupervisor, actor, (), options)

--- a/src/actor/future.rs
+++ b/src/actor/future.rs
@@ -19,7 +19,7 @@ use crate::supervisor::{Supervisor, SupervisorStrategy};
 /// This can be used to wrap actors into a `Future`, it automatically handles
 /// errors and panics using the provided supervisor. This can run on any runtime
 /// that can runs `Future`s.
-pub struct ActorFuture<S, NA: NewActor, RT> {
+pub struct ActorFuture<S, NA: NewActor, RT = ()> {
     /// The actor's supervisor used to determine what to do when the actor, or
     /// the [`NewActor`] implementation, returns an error.
     supervisor: S,

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -395,11 +395,27 @@ pub const fn actor_fn<F, M, RT, Arg, A>(f: F) -> ActorFn<F, M, RT, Arg, A> {
 }
 
 /// Implementation behind [`actor_fn`].
+#[allow(clippy::type_complexity)]
 pub struct ActorFn<F, M, RT, Args, A> {
     /// The actual implementation.
     inner: F,
     /// Required parameters to implement `NewActor` for this type.
     _phantom: PhantomData<fn(Context<M, RT>, Args) -> A>,
+}
+
+impl<T: Copy, M, RT, Args, A> Copy for ActorFn<T, M, RT, Args, A> {}
+
+impl<T: Clone, M, RT, Args, A> Clone for ActorFn<T, M, RT, Args, A> {
+    fn clone(&self) -> Self {
+        ActorFn {
+            inner: self.inner.clone(),
+            _phantom: PhantomData,
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.inner.clone_from(&source.inner);
+    }
 }
 
 impl<T: fmt::Debug, M, RT, Args, A> fmt::Debug for ActorFn<T, M, RT, Args, A> {

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -382,7 +382,7 @@ where
     }
 }
 
-/// A [`NewActor`] implementation backed by a function.
+/// A [`NewActor`] or [`SyncActor`] implementation backed by a function.
 ///
 /// This type is a workaround for not being able to implement the `NewActor`
 /// trait directly for types `T` where `T: Fn(Context<M, RT>, Args) -> A`, as it

--- a/src/actor/sync.rs
+++ b/src/actor/sync.rs
@@ -226,7 +226,7 @@ impl<M, RT> SyncContext<M, RT> {
     /// }
     ///
     /// # fn assert_sync_actor<A: heph::actor::SyncActor<RuntimeAccess = ()>>(_: A) { }
-    /// # assert_sync_actor(greeter_actor as fn(_) -> _);
+    /// # assert_sync_actor(heph::actor::actor_fn(greeter_actor));
     /// ```
     pub fn try_receive_next(&mut self) -> Result<M, RecvError> {
         self.inbox.try_recv().map_err(RecvError::from)
@@ -254,7 +254,7 @@ impl<M, RT> SyncContext<M, RT> {
     /// }
     ///
     /// # fn assert_sync_actor<A: heph::actor::SyncActor<RuntimeAccess = ()>>(_: A) { }
-    /// # assert_sync_actor(print_actor as fn(_) -> _);
+    /// # assert_sync_actor(heph::actor::actor_fn(print_actor));
     /// ```
     pub fn receive_next(&mut self) -> Result<M, NoMessages> {
         let waker = self.future_waker();

--- a/src/actor_ref/mod.rs
+++ b/src/actor_ref/mod.rs
@@ -40,7 +40,7 @@
 //!
 //! ```
 //! # #![feature(never_type)]
-//! use heph::actor;
+//! use heph::actor::{self, actor_fn};
 //! use heph::supervisor::NoSupervisor;
 //! use heph_rt::spawn::ActorOptions;
 //! use heph_rt::{self as rt, Runtime, ThreadLocal};
@@ -49,8 +49,7 @@
 //!     let mut runtime = Runtime::new()?;
 //!     runtime.run_on_workers(|mut runtime_ref| -> Result<(), !> {
 //!         // Spawn the actor.
-//!         let new_actor = actor as fn(_) -> _;
-//!         let actor_ref = runtime_ref.spawn_local(NoSupervisor, new_actor, (), ActorOptions::default());
+//!         let actor_ref = runtime_ref.spawn_local(NoSupervisor, actor_fn(actor), (), ActorOptions::default());
 //!
 //!         // Now we can use the actor reference to send the actor a message.
 //!         actor_ref.try_send("Hello world".to_owned()).unwrap();
@@ -81,7 +80,7 @@
 //!
 //! ```
 //! # #![feature(never_type)]
-//! use heph::actor;
+//! use heph::actor::{self, actor_fn};
 //! use heph::supervisor::NoSupervisor;
 //! use heph_rt::spawn::ActorOptions;
 //! use heph_rt::{self as rt, Runtime, ThreadLocal};
@@ -89,8 +88,7 @@
 //! fn main() -> Result<(), rt::Error> {
 //!     let mut runtime = Runtime::new()?;
 //!     runtime.run_on_workers(|mut runtime_ref| -> Result<(), !> {
-//!         let new_actor = actor as fn(_) -> _;
-//!         let actor_ref = runtime_ref.spawn_local(NoSupervisor, new_actor, (), ActorOptions::default());
+//!         let actor_ref = runtime_ref.spawn_local(NoSupervisor, actor_fn(actor), (), ActorOptions::default());
 //!
 //!         // To create another actor reference we can simply clone the
 //!         // first one.
@@ -129,7 +127,8 @@
 //!
 //! ```
 //! # #![feature(never_type)]
-//! use heph::{actor, ActorRef};
+//! use heph::ActorRef;
+//! use heph::actor::{self, actor_fn};
 //! use heph::supervisor::NoSupervisor;
 //! use heph_rt::spawn::ActorOptions;
 //! use heph_rt::{self as rt, Runtime, ThreadLocal};
@@ -137,15 +136,13 @@
 //! fn main() -> Result<(), rt::Error> {
 //!     let mut runtime = Runtime::new()?;
 //!     runtime.run_on_workers(|mut runtime_ref| -> Result<(), !> {
-//!         let new_actor = actor as fn(_) -> _;
-//!         let actor_ref = runtime_ref.spawn_local(NoSupervisor, new_actor, (), ActorOptions::default());
+//!         let actor_ref = runtime_ref.spawn_local(NoSupervisor, actor_fn(actor), (), ActorOptions::default());
 //!
 //!         // Send the actor a message to start.
 //!         actor_ref.try_send("Hello world".to_owned()).unwrap();
 //!
 //!         // Spawn our watchdog actor that watches the actor we spawned above.
-//!         let new_watchdog = watchdog as fn(_, _) -> _;
-//!         runtime_ref.spawn_local(NoSupervisor, new_watchdog, actor_ref, ActorOptions::default());
+//!         runtime_ref.spawn_local(NoSupervisor, actor_fn(watchdog), actor_ref, ActorOptions::default());
 //!
 //!         Ok(())
 //!     })?;

--- a/src/actor_ref/rpc.rs
+++ b/src/actor_ref/rpc.rs
@@ -63,16 +63,14 @@
 //! }
 //!
 //! # fn main() -> Result<(), rt::Error> {
+//! #    use heph::actor::actor_fn;
 //! #    use heph::supervisor::NoSupervisor;
 //! #    use heph_rt::Runtime;
 //! #    use heph_rt::spawn::ActorOptions;
 //! #    let mut runtime = Runtime::new()?;
 //! #    runtime.run_on_workers(|mut runtime_ref| -> Result<(), !> {
-//! #        let counter = counter as fn(_) -> _;
-//! #        let actor_ref = runtime_ref.spawn_local(NoSupervisor, counter, (), ActorOptions::default());
-//! #
-//! #        let requester = requester as fn(_, _) -> _;
-//! #        runtime_ref.spawn_local(NoSupervisor, requester, actor_ref, ActorOptions::default());
+//! #        let actor_ref = runtime_ref.spawn_local(NoSupervisor, actor_fn(counter), (), ActorOptions::default());
+//! #        runtime_ref.spawn_local(NoSupervisor, actor_fn(requester), actor_ref, ActorOptions::default());
 //! #        Ok(())
 //! #    })?;
 //! #    runtime.start()
@@ -139,17 +137,16 @@
 //! }
 //!
 //! # fn main() -> Result<(), rt::Error> {
+//! #    use heph::actor::actor_fn;
 //! #    use heph::supervisor::NoSupervisor;
 //! #    use heph_rt::Runtime;
 //! #    use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 //! #
 //! #    let mut runtime = Runtime::new()?;
-//! #    let counter = counter as fn(_) -> _;
 //! #    let options = SyncActorOptions::default();
-//! #    let actor_ref = runtime.spawn_sync_actor(NoSupervisor, counter, (), options)?;
+//! #    let actor_ref = runtime.spawn_sync_actor(NoSupervisor, actor_fn(counter), (), options)?;
 //! #    runtime.run_on_workers(move |mut runtime_ref| -> Result<(), !> {
-//! #        let requester = requester as fn(_, _) -> _;
-//! #        runtime_ref.spawn_local(NoSupervisor, requester, actor_ref, ActorOptions::default());
+//! #        runtime_ref.spawn_local(NoSupervisor, actor_fn(requester), actor_ref, ActorOptions::default());
 //! #        Ok(())
 //! #    })?;
 //! #    runtime.start()

--- a/src/quick_start.rs
+++ b/src/quick_start.rs
@@ -114,8 +114,8 @@
 //!
 //! ```
 //! use std::io::{self, stdout, Write};
-//! use heph::{actor, ActorRef};
-//! use heph::actor_ref::SendError;
+//! use heph::actor::{self, actor_fn};
+//! use heph::actor_ref::{ActorRef, SendError};
 //! use heph::supervisor::SupervisorStrategy;
 //! use heph_rt::spawn::options::ActorOptions;
 //! use heph_rt::ThreadLocal;
@@ -126,8 +126,12 @@
 //!         // Our supervisor for the error, see the function below.
 //!         let supervisor = greeter_supervisor;
 //!         // An unfortunate implementation detail requires us to convert our
-//!         // actor into a *function pointer* to implement the required traits.
-//!         let actor = greeter_actor as fn(_, _, _) -> _;
+//!         // asynchronous function to an `NewActor` implementation (trait
+//!         // that defines how actors are (re)started).
+//!         // The easiest way to do this is to use the `actor_fn` helper
+//!         // function. See the documentation of `actor_fn` for more details on
+//!         // why this is required.
+//!         let actor = actor_fn(greeter_actor);
 //!         // The arguments passed to the actor, see the `actor` implementation
 //!         // below. Since we want to pass multiple arguments we must do so in
 //!         // the tuple notation.
@@ -250,14 +254,14 @@
 //!
 //! ```
 //! # #![feature(never_type)]
-//! use heph::actor::{self, ActorFuture};
+//! use heph::actor::{self, actor_fn, ActorFuture};
 //! use heph::supervisor::NoSupervisor;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // The `Supervisor`, `NewActor` and argument are the same as for using
 //!     // heph-rt.
 //!     let supervisor = NoSupervisor;
-//!     let new_actor = actor as fn(_) -> _;
+//!     let new_actor = actor_fn(actor);
 //!     let arguments = (); // No arguments required.
 //!     // The runtime (`rt`) argument gives access to the runtime within the
 //!     // context of the actor. Note that not all runtimes need this, so you

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -72,7 +72,7 @@
 //!
 //! ```
 //! # #![feature(never_type)]
-//! # use heph::actor;
+//! # use heph::actor::{self, actor_fn};
 //! # use heph_rt::spawn::ActorOptions;
 //! # use heph_rt::{self as rt, Runtime};
 //! use heph::supervisor::SupervisorStrategy;
@@ -84,7 +84,7 @@
 //! #
 //! #     let mut runtime = Runtime::new()?;
 //! #     runtime.run_on_workers(|mut runtime_ref| -> Result<(), !> {
-//! #         runtime_ref.spawn_local(supervisor, bad_actor as fn(_) -> _, (), ActorOptions::default());
+//! #         runtime_ref.spawn_local(supervisor, actor_fn(bad_actor), (), ActorOptions::default());
 //! #         Ok(())
 //! #     })?;
 //! #     runtime.start()
@@ -289,7 +289,7 @@ where
 /// ```
 /// #![feature(never_type)]
 ///
-/// use heph::actor;
+/// use heph::actor::{self, actor_fn};
 /// use heph::supervisor::NoSupervisor;
 /// use heph_rt::spawn::ActorOptions;
 /// use heph_rt::{self as rt, ThreadLocal, Runtime};
@@ -297,7 +297,7 @@ where
 /// fn main() -> Result<(), rt::Error> {
 ///     let mut runtime = Runtime::new()?;
 ///     runtime.run_on_workers(|mut runtime_ref| -> Result<(), !> {
-///         runtime_ref.spawn_local(NoSupervisor, actor as fn(_) -> _, (), ActorOptions::default());
+///         runtime_ref.spawn_local(NoSupervisor, actor_fn(actor), (), ActorOptions::default());
 ///         Ok(())
 ///     })?;
 ///     runtime.start()
@@ -353,7 +353,7 @@ where
 /// ```
 /// #![feature(never_type)]
 ///
-/// use heph::actor;
+/// use heph::actor::{self, actor_fn};
 /// use heph::supervisor::StopSupervisor;
 /// use heph_rt::spawn::ActorOptions;
 /// use heph_rt::{self as rt, ThreadLocal, Runtime};
@@ -362,7 +362,7 @@ where
 ///     let mut runtime = Runtime::new()?;
 ///     runtime.run_on_workers(|mut runtime_ref| -> Result<(), !> {
 ///         let supervisor = StopSupervisor::for_actor("print actor");
-///         runtime_ref.spawn_local(supervisor, print_actor as fn(_) -> _, (), ActorOptions::default());
+///         runtime_ref.spawn_local(supervisor, actor_fn(print_actor), (), ActorOptions::default());
 ///         Ok(())
 ///     })?;
 ///     runtime.start()

--- a/src/test.rs
+++ b/src/test.rs
@@ -79,7 +79,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use heph::actor;
+/// use heph::actor::{self, actor_fn};
 /// use heph::test::size_of_actor_val;
 /// use heph_rt::ThreadLocal;
 ///
@@ -91,7 +91,7 @@ where
 ///     }
 /// }
 ///
-/// assert_eq!(size_of_actor_val(&(actor as fn(_) -> _)), 72);
+/// assert_eq!(size_of_actor_val(&actor_fn(actor)), 72);
 /// ```
 pub const fn size_of_actor_val<NA>(_: &NA) -> usize
 where

--- a/tests/functional/actor.rs
+++ b/tests/functional/actor.rs
@@ -1,6 +1,6 @@
 //! Tests for the [`Actor`] trait.
 
-use heph::actor::{self, NewActor};
+use heph::actor::{self, actor_fn, NewActor};
 
 #[test]
 fn future_output_result() {
@@ -8,14 +8,14 @@ fn future_output_result() {
     async fn actor(_: actor::Context<(), ()>) -> Result<(), ()> {
         Ok(())
     }
-    is_new_actor(actor as fn(_) -> _);
+    is_new_actor(actor_fn(actor));
 }
 
 #[test]
 fn future_output_tuple() {
     // Actor is implemented for `Future<Output = ()>`.
     async fn actor(_: actor::Context<(), ()>) {}
-    is_new_actor(actor as fn(_) -> _);
+    is_new_actor(actor_fn(actor));
 }
 
 fn is_new_actor<NA: NewActor>(_: NA) {}

--- a/tests/functional/test.rs
+++ b/tests/functional/test.rs
@@ -4,7 +4,7 @@ use std::mem::size_of;
 use std::pin::Pin;
 use std::task::{self, Poll};
 
-use heph::actor::{self, Actor, NewActor};
+use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph::test::{size_of_actor, size_of_actor_val};
 
 #[test]
@@ -13,10 +13,7 @@ fn test_size_of_actor() {
         /* Nothing. */
     }
 
-    #[allow(trivial_casts)]
-    {
-        assert_eq!(size_of_actor_val(&(actor1 as fn(_) -> _)), 24);
-    }
+    assert_eq!(size_of_actor_val(&actor_fn(actor1)), 24);
 
     struct Na;
 

--- a/tests/message_loss.rs
+++ b/tests/message_loss.rs
@@ -8,7 +8,7 @@
 use std::pin::Pin;
 use std::task::Poll;
 
-use heph::actor::{self, NoMessages};
+use heph::actor::{self, actor_fn, NoMessages};
 use heph::test::set_message_loss;
 use heph_rt::test::{init_local_actor, poll_actor};
 use heph_rt::ThreadLocal;
@@ -25,8 +25,7 @@ async fn expect_1_messages(mut ctx: actor::Context<usize, ThreadLocal>) {
 
 #[test]
 fn actor_ref_message_loss() {
-    let actor = expect_1_messages as fn(_) -> _;
-    let (actor, actor_ref) = init_local_actor(actor, ()).unwrap();
+    let (actor, actor_ref) = init_local_actor(actor_fn(expect_1_messages), ()).unwrap();
     let mut actor = Box::pin(actor);
 
     // Should arrive.


### PR DESCRIPTION
Instead of using `my_actor as fn(_) -> _` we can now use `actor_fn`. This has the benefit of not having to worry about the amount of arguments, etc., but it's also zero-sized for function (where function *pointers* take 64 bits).