### PR TITLE
Rework synchronous actors in heph

### DIFF
--- a/examples/3_sync_actor.rs
+++ b/examples/3_sync_actor.rs
@@ -1,5 +1,6 @@
-use heph::actor::{actor_fn, SyncContext};
+use heph::actor::actor_fn;
 use heph::supervisor::NoSupervisor;
+use heph::sync::SyncContext;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::{self as rt, Runtime};
 

--- a/examples/4_restart_supervisor.rs
+++ b/examples/4_restart_supervisor.rs
@@ -3,8 +3,9 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, actor_fn, SyncContext};
+use heph::actor::{self, actor_fn};
 use heph::restart_supervisor;
+use heph::sync::SyncContext;
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
 

--- a/rt/examples/4_sync_actor.rs
+++ b/rt/examples/4_sync_actor.rs
@@ -1,5 +1,6 @@
-use heph::actor::{actor_fn, SyncContext};
+use heph::actor::actor_fn;
 use heph::supervisor::NoSupervisor;
+use heph::sync::SyncContext;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::{self as rt, Runtime};
 

--- a/rt/examples/6_process_signals.rs
+++ b/rt/examples/6_process_signals.rs
@@ -2,8 +2,9 @@
 
 use std::convert::TryFrom;
 
-use heph::actor::{self, actor_fn, SyncContext};
+use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
+use heph::sync::SyncContext;
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, Signal, ThreadLocal, ThreadSafe};
 

--- a/rt/examples/7_restart_supervisor.rs
+++ b/rt/examples/7_restart_supervisor.rs
@@ -3,8 +3,9 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, actor_fn, SyncContext};
+use heph::actor::{self, actor_fn};
 use heph::restart_supervisor;
+use heph::sync::SyncContext;
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
 

--- a/rt/examples/8_tracing.rs
+++ b/rt/examples/8_tracing.rs
@@ -3,9 +3,10 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{self, actor_fn, SyncContext};
+use heph::actor::{self, actor_fn};
 use heph::actor_ref::{ActorRef, SendError};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
+use heph::sync::SyncContext;
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::trace::Trace;
 use heph_rt::{self as rt, Runtime, RuntimeRef};

--- a/rt/src/access.rs
+++ b/rt/src/access.rs
@@ -35,9 +35,10 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::{fmt, task};
 
-use heph::actor::{self, NewActor, SyncContext};
+use heph::actor::{self, NewActor};
 use heph::actor_ref::ActorRef;
 use heph::supervisor::Supervisor;
+use heph::sync::SyncContext;
 
 use crate::spawn::{ActorOptions, FutureOptions, Spawn};
 use crate::timers::TimerToken;

--- a/rt/src/access.rs
+++ b/rt/src/access.rs
@@ -26,7 +26,7 @@
 //! block.
 //!
 //! [`rt::Access`]: crate::Access
-//! [`SyncActor::RuntimeAccess`]: heph::actor::SyncActor::RuntimeAccess
+//! [`SyncActor::RuntimeAccess`]: heph::sync::SyncActor::RuntimeAccess
 //! [`TcpStream::connect`]: crate::net::TcpStream::connect
 
 use std::future::Future;
@@ -53,7 +53,7 @@ use crate::{shared, RuntimeRef};
 ///
 /// Also see [`NewActor::RuntimeAccess`] and [`SyncActor::RuntimeAccess`].
 ///
-/// [`SyncActor::RuntimeAccess`]: heph::actor::SyncActor::RuntimeAccess
+/// [`SyncActor::RuntimeAccess`]: heph::sync::SyncActor::RuntimeAccess
 ///
 /// # Notes
 ///
@@ -348,7 +348,7 @@ where
 /// information.
 ///
 /// [`spawn_future`]: Sync::spawn_future
-/// [`SyncContext`]: heph::actor::SyncContext
+/// [`SyncContext`]: heph::sync::SyncContext
 #[derive(Clone)]
 pub struct Sync {
     rt: Arc<shared::RuntimeInternals>,

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -69,8 +69,9 @@
 //!
 //! ```
 //! # #![feature(never_type)]
-//! use heph::actor::{self, SyncContext, actor_fn};
+//! use heph::actor::{self, actor_fn};
 //! use heph::supervisor::NoSupervisor;
+//! use heph::sync::SyncContext;
 //! use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 //! use heph_rt::{self as rt, Runtime, RuntimeRef};
 //! use heph_rt::access::Sync;
@@ -212,9 +213,10 @@ use std::task;
 use std::time::{Duration, Instant};
 
 use ::log::{as_debug, debug, warn};
-use heph::actor::{ActorFuture, NewActor, SyncActor};
+use heph::actor::{ActorFuture, NewActor};
 use heph::actor_ref::{ActorGroup, ActorRef};
 use heph::supervisor::{Supervisor, SyncSupervisor};
+use heph::sync::SyncActor;
 
 pub mod access;
 mod channel;

--- a/rt/src/spawn/mod.rs
+++ b/rt/src/spawn/mod.rs
@@ -17,7 +17,7 @@
 //! hides the issue, it doesn't solve it.
 //!
 //! [`Actor`]: heph::actor::Actor
-//! [`SyncActor`]: heph::actor::SyncActor
+//! [`SyncActor`]: heph::sync::SyncActor
 //! [`Future`]: std::future::Future
 //! [crate documentation]: crate#examples
 //!

--- a/rt/src/spawn/options.rs
+++ b/rt/src/spawn/options.rs
@@ -2,7 +2,7 @@
 //!
 //! [spawning]: crate::spawn::Spawn
 //! [`Actor`]: heph::actor::Actor
-//! [`SyncActor`]: heph::actor::SyncActor
+//! [`SyncActor`]: heph::sync::SyncActor
 //! [`Future`]: std::future::Future
 
 use std::cmp::Ordering;
@@ -151,7 +151,7 @@ fn priority_duration_multiplication() {
 
 /// Options for spawning a [`SyncActor`].
 ///
-/// [`SyncActor`]: heph::actor::SyncActor
+/// [`SyncActor`]: heph::sync::SyncActor
 ///
 /// # Examples
 ///

--- a/rt/src/sync_worker.rs
+++ b/rt/src/sync_worker.rs
@@ -14,9 +14,9 @@
 use std::sync::Arc;
 use std::{io, thread};
 
-use heph::actor::{SyncActor, SyncContext};
 use heph::actor_ref::ActorRef;
 use heph::supervisor::{SupervisorStrategy, SyncSupervisor};
+use heph::sync::{SyncActor, SyncContext};
 use heph_inbox::{self as inbox, ReceiverConnected};
 use log::trace;
 

--- a/rt/src/test.rs
+++ b/rt/src/test.rs
@@ -62,9 +62,10 @@ use std::task::{self, Poll};
 use std::time::{Duration, Instant};
 use std::{fmt, io, slice, thread};
 
-use heph::actor::{self, Actor, NewActor, SyncActor, SyncWaker};
+use heph::actor::{self, Actor, NewActor};
 use heph::actor_ref::{ActorGroup, ActorRef};
 use heph::supervisor::{Supervisor, SyncSupervisor};
+use heph::sync::{SyncActor, SyncWaker};
 use heph_inbox as inbox;
 use heph_inbox::oneshot::{self, new_oneshot};
 

--- a/rt/src/trace.rs
+++ b/rt/src/trace.rs
@@ -38,7 +38,7 @@
 //! events are created by the same actor.
 //!
 //! [`actor::Context`]: heph::actor::Context
-//! [`SyncContext`]: heph::actor::SyncContext
+//! [`SyncContext`]: heph::sync::SyncContext
 //! [`start_trace`]: Trace::start_trace
 //! [`finish_trace`]: Trace::finish_trace
 //!

--- a/rt/tests/functional/runtime.rs
+++ b/rt/tests/functional/runtime.rs
@@ -9,8 +9,9 @@ use std::task::{self, Poll};
 use std::thread::{self, sleep};
 use std::time::Duration;
 
-use heph::actor::{self, actor_fn, Actor, NewActor, SyncContext};
+use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph::supervisor::{NoSupervisor, Supervisor, SupervisorStrategy};
+use heph::sync::SyncContext;
 use heph_rt::spawn::options::{ActorOptions, FutureOptions, Priority, SyncActorOptions};
 use heph_rt::{Runtime, ThreadLocal, ThreadSafe};
 

--- a/rt/tests/functional/sync_actor.rs
+++ b/rt/tests/functional/sync_actor.rs
@@ -5,8 +5,9 @@ use std::task::{self, Poll};
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{actor_fn, RecvError, SyncContext};
+use heph::actor::{actor_fn, RecvError};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
+use heph::sync::SyncContext;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::test::spawn_sync_actor;
 

--- a/rt/tests/process_signals.rs
+++ b/rt/tests/process_signals.rs
@@ -4,8 +4,9 @@ use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use heph::actor::{self, actor_fn, SyncContext};
+use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
+use heph::sync::SyncContext;
 use heph_rt::spawn::options::{ActorOptions, SyncActorOptions};
 use heph_rt::{Runtime, Signal};
 

--- a/rt/tests/regression/issue_294.rs
+++ b/rt/tests/regression/issue_294.rs
@@ -3,8 +3,9 @@
 //! In this test the actor reference, to the sync actor, should be dropped allow
 //! the sync actor to stop and not prevent the test from returning.
 
-use heph::actor::{actor_fn, SyncContext};
+use heph::actor::actor_fn;
 use heph::supervisor::NoSupervisor;
+use heph::sync::SyncContext;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::Runtime;
 

--- a/rt/tests/regression/issue_323.rs
+++ b/rt/tests/regression/issue_323.rs
@@ -4,8 +4,9 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{actor_fn, SyncContext};
+use heph::actor::actor_fn;
 use heph::supervisor::NoSupervisor;
+use heph::sync::SyncContext;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::Runtime;
 

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -70,8 +70,9 @@
 //! The example below shows how to run a synchronous actor.
 //!
 //! ```
-//! use heph::actor::{actor_fn, spawn_sync_actor, SyncContext};
+//! use heph::actor::{actor_fn};
 //! use heph::supervisor::NoSupervisor;
+//! use heph::sync::{SyncContext, spawn_sync_actor};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Same as we saw for the asynchronous actors, we have to use the `actor_fn`
@@ -107,7 +108,6 @@ use std::task::{self, Poll};
 
 mod context;
 mod future;
-mod sync;
 #[cfg(test)]
 mod tests;
 
@@ -115,11 +115,6 @@ mod tests;
 pub use context::{Context, NoMessages, ReceiveMessage, RecvError};
 #[doc(inline)]
 pub use future::ActorFuture;
-#[doc(inline)]
-pub use sync::{spawn_sync_actor, SyncActor, SyncContext};
-
-#[doc(hidden)] // Not part of the stable API.
-pub use sync::SyncWaker;
 
 /// Creating asynchronous actors.
 ///
@@ -439,7 +434,7 @@ pub const fn actor_fn<T, M, RT, Arg, A>(implementation: T) -> ActorFn<T, M, RT, 
 #[allow(clippy::type_complexity)]
 pub struct ActorFn<F, M, RT, Args, A> {
     /// The actual implementation.
-    inner: F,
+    pub(crate) inner: F,
     /// Required parameters to implement `NewActor` for this type.
     _phantom: PhantomData<fn(Context<M, RT>, Args) -> A>,
 }
@@ -637,7 +632,7 @@ where
     }
 }
 
-mod private {
+pub(crate) mod private {
     /// Trait to support [`Actor`] for `Result<(), E>` and `()`.
     ///
     /// [`Actor`]: crate::actor::Actor

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -63,7 +63,7 @@
 //! requires their own thread to run on, they are more expansive to run than
 //! asynchronous actors (by an order of a magnitude).
 //!
-//! Synchronous actors can be spawned using [`spawn_sync_actor`]. Note that the
+//! Synchronous actors can be ran using [`SyncActorRunner`]. Note that the
 //! Heph-rt crate provides function to spawn synchronous actors that it manages
 //! for you.
 //!
@@ -72,13 +72,14 @@
 //! ```
 //! use heph::actor::{actor_fn};
 //! use heph::supervisor::NoSupervisor;
-//! use heph::sync::{SyncContext, spawn_sync_actor};
+//! use heph::sync::{SyncContext, SyncActorRunnerBuilder};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Same as we saw for the asynchronous actors, we have to use the `actor_fn`
 //! // helper to implement `SyncActor`.
 //! let actor = actor_fn(actor);
-//! let (thread_handle, actor_ref) = spawn_sync_actor(NoSupervisor, actor, (), ())?;
+//! let (thread_handle, actor_ref) = SyncActorRunnerBuilder::new()
+//!     .spawn(NoSupervisor, actor, ())?;
 //!
 //! // We can send it a message like we do with asynchronous actors.
 //! actor_ref.try_send("Hello world!")?;
@@ -100,7 +101,7 @@
 //! [`actor::Context`]: Context
 //! [`SyncActor`]: crate::sync::SyncActor
 //! [`SyncContext`]: crate::sync::SyncContext
-//! [`spawn_sync_actor`]: crate::sync::spawn_sync_actor
+//! [`SyncActorRunner`]: crate::sync::SyncActorRunner
 
 use std::any::type_name;
 use std::fmt;

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -98,6 +98,9 @@
 //! ```
 //!
 //! [`actor::Context`]: Context
+//! [`SyncActor`]: crate::sync::SyncActor
+//! [`SyncContext`]: crate::sync::SyncContext
+//! [`spawn_sync_actor`]: crate::sync::spawn_sync_actor
 
 use std::any::type_name;
 use std::fmt;
@@ -390,6 +393,8 @@ where
 /// This is caused by the fact that `T` could implement the `Fn` trait multiple
 /// times, but the `NewActor` trait can (and should) only be implemented once.
 ///
+/// [`SyncActor`]: crate::sync::SyncActor
+///
 /// # Examples
 ///
 /// ```
@@ -431,6 +436,8 @@ pub const fn actor_fn<T, M, RT, Arg, A>(implementation: T) -> ActorFn<T, M, RT, 
 ///
 /// This implement both the [`NewActor`] and [`SyncActor`] traits, dependening
 /// of what kind of function type `F` is.
+///
+/// [`SyncActor`]: crate::sync::SyncActor
 #[allow(clippy::type_complexity)]
 pub struct ActorFn<F, M, RT, Args, A> {
     /// The actual implementation.

--- a/src/actor_ref/rpc.rs
+++ b/src/actor_ref/rpc.rs
@@ -84,9 +84,9 @@
 //! ```
 //! # #![feature(never_type)]
 //! #
-//! use heph::actor::{self, SyncContext};
 //! use heph::actor_ref::{ActorRef, RpcMessage};
-//! use heph::from_message;
+//! use heph::sync::SyncContext;
+//! use heph::{actor, from_message};
 //! use heph_rt::{self as rt, ThreadLocal};
 //!
 //! /// Message type for [`counter`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub mod actor_ref;
 pub mod messages;
 pub mod quick_start;
 pub mod supervisor;
+pub mod sync;
 #[cfg(any(test, feature = "test"))]
 pub mod test;
 
@@ -106,3 +107,5 @@ pub use actor::{Actor, NewActor};
 pub use actor_ref::ActorRef;
 #[doc(no_inline)]
 pub use supervisor::{Supervisor, SupervisorStrategy};
+#[doc(no_inline)]
+pub use sync::SyncActor;

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -111,8 +111,7 @@ use std::fmt;
 
 use log::warn;
 
-use crate::actor::SyncActor;
-use crate::actor::{Actor, NewActor};
+use crate::{Actor, NewActor, SyncActor};
 
 /// The supervisor of an [actor].
 ///
@@ -634,7 +633,7 @@ macro_rules! __heph_restart_supervisor_impl {
 
         impl<A> $crate::supervisor::SyncSupervisor<A> for $supervisor_name
         where
-            A: $crate::actor::SyncActor<Argument = ( $( $arg ),* )>,
+            A: $crate::sync::SyncActor<Argument = ( $( $arg ),* )>,
             A::Error: std::fmt::Display,
         {
             fn decide(&mut self, err: A::Error) -> $crate::SupervisorStrategy<A::Argument> {

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -41,7 +41,7 @@
 //! is the same.
 //!
 //! [regular/asynchronous actors]: crate::actor::Actor
-//! [synchronous actors]: crate::actor::SyncActor
+//! [synchronous actors]: crate::sync::SyncActor
 //! [`Supervisor`]: crate::supervisor::Supervisor
 //! [`SyncSupervisor`]: crate::supervisor::SyncSupervisor
 //!
@@ -254,7 +254,7 @@ pub enum SupervisorStrategy<Arg> {
 /// `SyncSupervisor` is implemented for any function that takes an error `E` and
 /// returns `SupervisorStrategy<Arg>` automatically.
 ///
-/// [synchronous actors]: crate::actor::SyncActor
+/// [synchronous actors]: crate::sync::SyncActor
 /// [module documentation]: crate::supervisor
 pub trait SyncSupervisor<A>
 where

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -265,6 +265,34 @@ where
     /// Also see the notes on [`Supervisor::decide`] as they also apply for
     /// synchronous supervision.
     fn decide(&mut self, error: A::Error) -> SupervisorStrategy<A::Argument>;
+
+    /// Decide what happens to the actor that panicked.
+    ///
+    /// This is similar to [`SyncSupervisor::decide`], but handles panics
+    /// instead of errors ([`SyncActor::Error`]).
+    ///
+    /// # Default
+    ///
+    /// By default this stops the actor as a panic is always unexpected and is
+    /// generally harder to recover from then an error.
+    ///
+    /// # Notes
+    ///
+    /// The panic is always logged using the [panic hook], in addition an error
+    /// message is printed which states what actor panicked.
+    ///
+    /// When `panic = abort` is set in `Cargo.toml` we will not be able to
+    /// recover the panic and instead the process will abort. The same is true
+    /// for a panic while panicking. Both situations are out of control of Heph.
+    ///
+    /// [panic hook]: std::panic::set_hook
+    fn decide_on_panic(
+        &mut self,
+        panic: Box<dyn Any + Send + 'static>,
+    ) -> SupervisorStrategy<A::Argument> {
+        drop(panic);
+        SupervisorStrategy::Stop
+    }
 }
 
 impl<F, A> SyncSupervisor<A> for F

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -81,6 +81,23 @@ pub trait SyncActor {
         ctx: SyncContext<Self::Message, Self::RuntimeAccess>,
         arg: Self::Argument,
     ) -> Result<(), Self::Error>;
+
+    /// Returns the name of the actor.
+    ///
+    /// The default implementation creates the name based on the name of type of
+    /// the actor.
+    ///
+    /// # Notes
+    ///
+    /// This uses [`type_name`] under the hood which does not have a stable
+    /// output. Like the `type_name` function the default implementation is
+    /// provided on a best effort basis.
+    ///
+    /// When using `my_actor as fn(..) -> _` the will most likely be useless,
+    /// consider using [`ActorFn`] which does produce usable names.
+    fn name() -> &'static str {
+        crate::actor::name::<Self>()
+    }
 }
 
 /// Macro to implement the [`SyncActor`] trait on function pointers.
@@ -120,6 +137,10 @@ macro_rules! impl_sync_actor {
                 fn run(&self, ctx: SyncContext<Self::Message, Self::RuntimeAccess>, arg: Self::Argument) -> Result<(), Self::Error> {
                     let ($( $arg ),*) = arg;
                     (self.inner)(ctx, $( $arg ),*).into()
+                }
+
+                fn name() -> &'static str {
+                    crate::actor::name::<F>()
                 }
             }
         )*
@@ -163,6 +184,10 @@ where
         arg: Self::Argument,
     ) -> Result<(), Self::Error> {
         ((self.inner)(ctx, arg)).into()
+    }
+
+    fn name() -> &'static str {
+        crate::actor::name::<F>()
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -95,6 +95,8 @@ pub trait SyncActor {
     ///
     /// When using `my_actor as fn(..) -> _` the will most likely be useless,
     /// consider using [`ActorFn`] which does produce usable names.
+    ///
+    /// [`type_name`]: std::any::type_name
     fn name() -> &'static str {
         crate::actor::name::<Self>()
     }
@@ -474,7 +476,7 @@ where
 
 /// Synchronous actor runner.
 #[derive(Debug)]
-struct SyncActorRunner<S, A: SyncActor> {
+pub struct SyncActorRunner<S, A: SyncActor> {
     supervisor: S,
     actor: A,
     inbox: inbox::Manager<A::Message>,
@@ -490,7 +492,7 @@ where
     ///
     /// This handles errors and catches panics, and depending on the supervisor
     /// `S`, restarts the actor if required.
-    fn run(mut self, mut arg: A::Argument, rt: A::RuntimeAccess) {
+    pub fn run(mut self, mut arg: A::Argument, rt: A::RuntimeAccess) {
         let name = A::name();
         trace!(name = name; "running synchronous actor");
         loop {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -459,6 +459,19 @@ where
     A: SyncActor,
     A::RuntimeAccess: Clone,
 {
+    /// Create a new `SyncActorRunner`.
+    ///
+    /// Arguments:
+    ///  * `supervisor: S`: is used to handle the actor's errors.
+    ///  * `actor: A`: the actor we're running.
+    pub fn new(self, supervisor: S, actor: A) -> (SyncActorRunner<S, A>, ActorRef<A::Message>)
+    where
+        S: SyncSupervisor<A>,
+        A: SyncActor<RuntimeAccess = ()>,
+    {
+        SyncActorRunnerBuilder::new().build(supervisor, actor)
+    }
+
     /// Run the synchronous actor.
     ///
     /// This handles errors and catches panics, and depending on the supervisor

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,9 @@
 //! Synchronous actors.
+//!
+//! See the [`actor`] module for a description of actors, including synchronous
+//! actors.
+//!
+//! [`actor`]: crate::actor
 
 use std::future::Future;
 use std::io;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -491,8 +491,7 @@ where
     /// This handles errors and catches panics, and depending on the supervisor
     /// `S`, restarts the actor if required.
     fn run(mut self, mut arg: A::Argument, rt: A::RuntimeAccess) {
-        let thread = thread::current();
-        let name = thread.name().unwrap();
+        let name = A::name();
         trace!(name = name; "running synchronous actor");
         loop {
             let receiver = self.inbox.new_receiver().unwrap_or_else(inbox_failure);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-//! Module containing the types for synchronous actors.
+//! Synchronous actors.
 
 use std::future::Future;
 use std::io;
@@ -215,7 +215,7 @@ impl<M, RT> SyncContext<M, RT> {
     /// world.
     ///
     /// ```
-    /// use heph::actor::SyncContext;
+    /// use heph::sync::SyncContext;
     ///
     /// fn greeter_actor(mut ctx: SyncContext<String>) {
     ///     if let Ok(name) = ctx.try_receive_next() {
@@ -225,7 +225,7 @@ impl<M, RT> SyncContext<M, RT> {
     ///     }
     /// }
     ///
-    /// # fn assert_sync_actor<A: heph::actor::SyncActor<RuntimeAccess = ()>>(_: A) { }
+    /// # fn assert_sync_actor<A: heph::SyncActor<RuntimeAccess = ()>>(_: A) { }
     /// # assert_sync_actor(heph::actor::actor_fn(greeter_actor));
     /// ```
     pub fn try_receive_next(&mut self) -> Result<M, RecvError> {
@@ -243,7 +243,7 @@ impl<M, RT> SyncContext<M, RT> {
     /// An actor that waits for a message and prints it.
     ///
     /// ```
-    /// use heph::actor::SyncContext;
+    /// use heph::sync::SyncContext;
     ///
     /// fn print_actor(mut ctx: SyncContext<String>) {
     ///     if let Ok(msg) = ctx.receive_next() {
@@ -253,7 +253,7 @@ impl<M, RT> SyncContext<M, RT> {
     ///     }
     /// }
     ///
-    /// # fn assert_sync_actor<A: heph::actor::SyncActor<RuntimeAccess = ()>>(_: A) { }
+    /// # fn assert_sync_actor<A: heph::SyncActor<RuntimeAccess = ()>>(_: A) { }
     /// # assert_sync_actor(heph::actor::actor_fn(print_actor));
     /// ```
     pub fn receive_next(&mut self) -> Result<M, NoMessages> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,8 +21,8 @@ use std::{fmt, slice};
 use getrandom::getrandom;
 use log::warn;
 
-use crate::actor::{self, Actor, NewActor, SyncActor};
 use crate::supervisor::{Supervisor, SupervisorStrategy, SyncSupervisor};
+use crate::{actor, Actor, NewActor, SyncActor};
 
 /// Percentage of messages lost on purpose.
 static MSG_LOSS: AtomicU8 = AtomicU8::new(0);

--- a/tests/functional/sync_actor.rs
+++ b/tests/functional/sync_actor.rs
@@ -172,3 +172,19 @@ impl<A: SyncActor> SyncSupervisor<A> for PanicSupervisor {
 fn panic_actor<RT>(_: SyncContext<!, RT>) {
     panic!("oops!");
 }
+
+#[test]
+fn sync_actor_name() {
+    #[track_caller]
+    fn assert_name<A: SyncActor>(_: A, expected: &str) {
+        let got = A::name();
+        assert_eq!(got, expected);
+    }
+
+    assert_name(actor_fn(panic_actor::<()>), "panic_actor");
+    assert_name(actor_fn(bad_actor::<()>), "bad_actor");
+    assert_name(
+        actor_fn(block_on_actor::<(), BlockFuture>),
+        "block_on_actor",
+    );
+}

--- a/tests/functional/sync_actor.rs
+++ b/tests/functional/sync_actor.rs
@@ -5,8 +5,10 @@ use std::task::{self, Poll};
 use std::thread::sleep;
 use std::time::Duration;
 
-use heph::actor::{actor_fn, spawn_sync_actor, RecvError, SyncContext};
+use heph::actor::{actor_fn, RecvError};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
+use heph::sync::spawn_sync_actor;
+use heph::sync::SyncContext;
 
 #[derive(Clone, Debug)]
 struct BlockFuture {


### PR DESCRIPTION
Create a new `heph::sync` module, which contains all the types related to sync actors, such as `SyncActor` and `SyncContext`. Within that module I've added `SyncActorRunner` (previously called `SyncWorker` and private) and `SyncActorRunnerBuilder` (yes, it's too long), which can be use to run synchronous actors, catching errors, etc.

This also adds panic handling within the `SyncActorRunner`, which required the `SyncSupervisor::decide_on_panic` method. Which is similar to `Supervisor::decide_on_panic` for async actors.

Finally I've added `SyncActor::name` to determine the name of the sync actor. With `ActorFn` this actually produces are reasonable result, with `sync_actor as fn(..) -> _` not so much.

Closes #572
Closes #576