### PR TITLE
Rename SyncContext to sync::Context

### DIFF
--- a/examples/3_sync_actor.rs
+++ b/examples/3_sync_actor.rs
@@ -1,6 +1,6 @@
 use heph::actor::actor_fn;
 use heph::supervisor::NoSupervisor;
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::{self as rt, Runtime};
 
@@ -34,7 +34,7 @@ fn main() -> Result<(), rt::Error> {
     runtime.start()
 }
 
-fn actor<RT>(mut ctx: SyncContext<String, RT>, exit_msg: &'static str) {
+fn actor<RT>(mut ctx: sync::Context<String, RT>, exit_msg: &'static str) {
     while let Ok(msg) = ctx.receive_next() {
         println!("Got a message: {msg}");
     }

--- a/examples/4_restart_supervisor.rs
+++ b/examples/4_restart_supervisor.rs
@@ -4,8 +4,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use heph::actor::{self, actor_fn};
-use heph::restart_supervisor;
-use heph::sync::SyncContext;
+use heph::{restart_supervisor, sync};
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
 
@@ -51,6 +50,6 @@ async fn print_actor(_: actor::Context<(), ThreadLocal>, msg: String) -> Result<
 }
 
 /// A very bad synchronous printing actor.
-fn sync_print_actor<RT>(_: SyncContext<String, RT>, msg: String) -> Result<(), String> {
+fn sync_print_actor<RT>(_: sync::Context<String, RT>, msg: String) -> Result<(), String> {
     Err(format!("can't print message synchronously '{msg}'"))
 }

--- a/rt/examples/4_sync_actor.rs
+++ b/rt/examples/4_sync_actor.rs
@@ -1,6 +1,6 @@
 use heph::actor::actor_fn;
 use heph::supervisor::NoSupervisor;
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::{self as rt, Runtime};
 
@@ -36,7 +36,7 @@ fn main() -> Result<(), rt::Error> {
     runtime.start()
 }
 
-fn actor<RT>(mut ctx: SyncContext<String, RT>, exit_msg: &'static str) {
+fn actor<RT>(mut ctx: sync::Context<String, RT>, exit_msg: &'static str) {
     while let Ok(msg) = ctx.receive_next() {
         println!("Got a message: {msg}");
     }

--- a/rt/examples/6_process_signals.rs
+++ b/rt/examples/6_process_signals.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, Signal, ThreadLocal, ThreadSafe};
 
@@ -71,7 +71,7 @@ impl TryFrom<Signal> for Message {
     }
 }
 
-fn sync_actor<RT>(mut ctx: SyncContext<Message, RT>) {
+fn sync_actor<RT>(mut ctx: sync::Context<Message, RT>) {
     while let Ok(msg) = ctx.receive_next() {
         match msg {
             Message::Print(msg) => println!("Got a message: {msg}"),

--- a/rt/examples/7_restart_supervisor.rs
+++ b/rt/examples/7_restart_supervisor.rs
@@ -4,8 +4,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use heph::actor::{self, actor_fn};
-use heph::restart_supervisor;
-use heph::sync::SyncContext;
+use heph::{restart_supervisor, sync};
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
 
@@ -53,6 +52,6 @@ async fn print_actor(_: actor::Context<(), ThreadLocal>, msg: String) -> Result<
 }
 
 /// A very bad synchronous printing actor.
-fn sync_print_actor<RT>(_: SyncContext<String, RT>, msg: String) -> Result<(), String> {
+fn sync_print_actor<RT>(_: sync::Context<String, RT>, msg: String) -> Result<(), String> {
     Err(format!("can't print message synchronously '{msg}'"))
 }

--- a/rt/examples/8_tracing.rs
+++ b/rt/examples/8_tracing.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use heph::actor::{self, actor_fn};
 use heph::actor_ref::{ActorRef, SendError};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 use heph_rt::trace::Trace;
 use heph_rt::{self as rt, Runtime, RuntimeRef};
@@ -101,7 +101,7 @@ where
 }
 
 /// Sync actor that prints all messages it receives.
-fn print_actor(mut ctx: SyncContext<&'static str, rt::Sync>) {
+fn print_actor(mut ctx: sync::Context<&'static str, rt::Sync>) {
     loop {
         // Start timing of receiving a message.
         let timing = ctx.start_trace();

--- a/rt/src/access.rs
+++ b/rt/src/access.rs
@@ -8,7 +8,7 @@
 //! This is reflected in a number of places:
 //!  * In actors in the [`NewActor::RuntimeAccess`] and
 //!    [`SyncActor::RuntimeAccess`] types.
-//!  * In the `RT` type [`actor::Context`] and [`SyncContext`].
+//!  * In the `RT` type [`actor::Context`] and [`sync::Context`].
 //!  * In various types and function that require runtime access as an argument,
 //!    for example [`TcpStream::connect`].
 //!
@@ -35,10 +35,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::{fmt, task};
 
-use heph::actor::{self, NewActor};
-use heph::actor_ref::ActorRef;
-use heph::supervisor::Supervisor;
-use heph::sync::SyncContext;
+use heph::{actor, sync, ActorRef, NewActor, Supervisor};
 
 use crate::spawn::{ActorOptions, FutureOptions, Spawn};
 use crate::timers::TimerToken;
@@ -344,11 +341,10 @@ where
 /// It implements [`Spawn`] to spawn new thread-safe actors and [`spawn_future`]
 /// to spawn thread-safe [`Future`]s.
 ///
-/// This is usually a part of the actor's [`SyncContext`], see it for more
+/// This is usually a part of the actor's [`sync::Context`], see it for more
 /// information.
 ///
 /// [`spawn_future`]: Sync::spawn_future
-/// [`SyncContext`]: heph::sync::SyncContext
 #[derive(Clone)]
 pub struct Sync {
     rt: Arc<shared::RuntimeInternals>,
@@ -402,7 +398,7 @@ impl fmt::Debug for Sync {
     }
 }
 
-impl<M> Trace for SyncContext<M, Sync> {
+impl<M> Trace for sync::Context<M, Sync> {
     fn start_trace(&self) -> Option<trace::EventTiming> {
         trace::start(&self.runtime_ref().trace_log)
     }

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -71,7 +71,7 @@
 //! # #![feature(never_type)]
 //! use heph::actor::{self, actor_fn};
 //! use heph::supervisor::NoSupervisor;
-//! use heph::sync::SyncContext;
+//! use heph::sync;
 //! use heph_rt::spawn::{ActorOptions, SyncActorOptions};
 //! use heph_rt::{self as rt, Runtime, RuntimeRef};
 //! use heph_rt::access::Sync;
@@ -120,7 +120,7 @@
 //! }
 //!
 //! /// Our synchronous actor.
-//! fn sync_actor(mut ctx: SyncContext<&'static str, Sync>) {
+//! fn sync_actor(mut ctx: sync::Context<&'static str, Sync>) {
 //!     if let Ok(name) = ctx.receive_next() {
 //!         println!("Hello {name} from sync actor");
 //!     }

--- a/rt/src/trace.rs
+++ b/rt/src/trace.rs
@@ -18,7 +18,7 @@
 //! The runtime already add its own trace events, e.g. when running actors, but
 //! users can also log events. Actors can log trace event using the [`Trace`]
 //! implementation for their context, i.e. [`actor::Context`] or
-//! [`SyncContext`].
+//! [`sync::Context`].
 //!
 //! Calling [`start_trace`] will start timing an event by returning
 //! [`EventTiming`]. Next the actor should execute the action(s) it wants to
@@ -38,7 +38,7 @@
 //! events are created by the same actor.
 //!
 //! [`actor::Context`]: heph::actor::Context
-//! [`SyncContext`]: heph::sync::SyncContext
+//! [`sync::Context`]: heph::sync::Context
 //! [`start_trace`]: Trace::start_trace
 //! [`finish_trace`]: Trace::finish_trace
 //!

--- a/rt/tests/functional/runtime.rs
+++ b/rt/tests/functional/runtime.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph::supervisor::{NoSupervisor, Supervisor, SupervisorStrategy};
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::options::{ActorOptions, FutureOptions, Priority, SyncActorOptions};
 use heph_rt::{Runtime, ThreadLocal, ThreadSafe};
 
@@ -494,7 +494,7 @@ fn external_thread_wakes_thread_safe_actor() {
 
 #[test]
 fn external_thread_wakes_sync_actor() {
-    fn actor<RT>(mut ctx: SyncContext<!, RT>, future: WaitFuture) -> Result<(), !> {
+    fn actor<RT>(mut ctx: sync::Context<!, RT>, future: WaitFuture) -> Result<(), !> {
         ctx.block_on(future)
     }
 

--- a/rt/tests/functional/sync_actor.rs
+++ b/rt/tests/functional/sync_actor.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use heph::actor::{actor_fn, RecvError};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::test::spawn_sync_actor;
 
@@ -52,7 +52,7 @@ impl Future for BlockFuture {
     }
 }
 
-fn block_on_actor<RT, Fut>(mut ctx: SyncContext<String, RT>, fut: Fut)
+fn block_on_actor<RT, Fut>(mut ctx: sync::Context<String, RT>, fut: Fut)
 where
     Fut: Future,
 {
@@ -107,7 +107,7 @@ fn block_on_spurious_wake_up() {
     handle.join().unwrap();
 }
 
-fn try_receive_next_actor<RT>(mut ctx: SyncContext<String, RT>) {
+fn try_receive_next_actor<RT>(mut ctx: sync::Context<String, RT>) {
     loop {
         match ctx.try_receive_next() {
             Ok(msg) => {
@@ -155,6 +155,6 @@ fn bad_actor_supervisor(err_count: usize) -> SupervisorStrategy<usize> {
     }
 }
 
-fn bad_actor<RT>(_: SyncContext<!, RT>, count: usize) -> Result<(), usize> {
+fn bad_actor<RT>(_: sync::Context<!, RT>, count: usize) -> Result<(), usize> {
     Err(count + 1)
 }

--- a/rt/tests/process_signals.rs
+++ b/rt/tests/process_signals.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::options::{ActorOptions, SyncActorOptions};
 use heph_rt::{Runtime, Signal};
 
@@ -93,7 +93,7 @@ async fn actor<RT>(mut ctx: actor::Context<Signal, RT>, got_signal: Arc<AtomicUs
     got_signal.fetch_add(1, Ordering::SeqCst);
 }
 
-fn sync_actor<RT>(mut ctx: SyncContext<Signal, RT>, got_signal: Arc<AtomicUsize>) {
+fn sync_actor<RT>(mut ctx: sync::Context<Signal, RT>, got_signal: Arc<AtomicUsize>) {
     let _msg = ctx.receive_next().unwrap();
     got_signal.fetch_add(1, Ordering::SeqCst);
 }

--- a/rt/tests/regression/issue_294.rs
+++ b/rt/tests/regression/issue_294.rs
@@ -5,7 +5,7 @@
 
 use heph::actor::actor_fn;
 use heph::supervisor::NoSupervisor;
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::Runtime;
 
@@ -28,6 +28,6 @@ fn issue_294() {
     runtime.start().unwrap();
 }
 
-fn actor<RT>(mut ctx: SyncContext<(), RT>) {
+fn actor<RT>(mut ctx: sync::Context<(), RT>) {
     while let Ok(()) = ctx.receive_next() {}
 }

--- a/rt/tests/regression/issue_323.rs
+++ b/rt/tests/regression/issue_323.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use heph::actor::actor_fn;
 use heph::supervisor::NoSupervisor;
-use heph::sync::SyncContext;
+use heph::sync;
 use heph_rt::spawn::SyncActorOptions;
 use heph_rt::Runtime;
 
@@ -28,4 +28,4 @@ fn issue_323() {
 }
 
 /// Short running synchronous actor.
-fn actor<RT>(_: SyncContext<(), RT>) {}
+fn actor<RT>(_: sync::Context<(), RT>) {}

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -59,7 +59,7 @@
 //!
 //! Synchronous actors run in their own thread and can use blocking operations,
 //! such as blocking I/O or heavy computation. Instead of an [`actor::Context`]
-//! they use a [`SyncContext`], which provides a similar API to
+//! they use a [`sync::Context`], which provides a similar API to
 //! `actor::Context`, but uses blocking operations. As each synchronous actor
 //! requires their own thread to run on, they are more expansive to run than
 //! asynchronous actors (by an order of a magnitude).
@@ -71,9 +71,9 @@
 //! The example below shows how to run a synchronous actor.
 //!
 //! ```
-//! use heph::actor::{actor_fn};
+//! use heph::actor::actor_fn;
 //! use heph::supervisor::NoSupervisor;
-//! use heph::sync::{SyncContext, SyncActorRunnerBuilder};
+//! use heph::sync::{self, SyncActorRunnerBuilder};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Same as we saw for the asynchronous actors, we have to use the `actor_fn`
@@ -90,7 +90,7 @@
 //! # Ok(())
 //! # }
 //!
-//! fn actor(mut ctx: SyncContext<String>) {
+//! fn actor(mut ctx: sync::Context<String>) {
 //!     if let Ok(msg) = ctx.receive_next() {
 //!         println!("Got a message: {msg}");
 //!     } else {
@@ -101,7 +101,7 @@
 //!
 //! [`actor::Context`]: Context
 //! [`SyncActor`]: crate::sync::SyncActor
-//! [`SyncContext`]: crate::sync::SyncContext
+//! [`sync::Context`]: crate::sync::Context
 //! [`SyncActorRunner`]: crate::sync::SyncActorRunner
 
 use std::any::type_name;

--- a/src/actor_ref/rpc.rs
+++ b/src/actor_ref/rpc.rs
@@ -85,8 +85,7 @@
 //! # #![feature(never_type)]
 //! #
 //! use heph::actor_ref::{ActorRef, RpcMessage};
-//! use heph::sync::SyncContext;
-//! use heph::{actor, from_message};
+//! use heph::{actor, from_message, sync};
 //! use heph_rt::{self as rt, ThreadLocal};
 //!
 //! /// Message type for [`counter`].
@@ -102,7 +101,7 @@
 //! from_message!(Message::Get(()) -> usize);
 //!
 //! /// Receiving synchronous actor of the RPC.
-//! fn counter<RT>(mut ctx: SyncContext<Message, RT>) {
+//! fn counter<RT>(mut ctx: sync::Context<Message, RT>) {
 //!     // State of the counter.
 //!     let mut count: usize = 0;
 //!

--- a/tests/functional/sync_actor.rs
+++ b/tests/functional/sync_actor.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use heph::actor::{actor_fn, RecvError};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy, SyncSupervisor};
-use heph::sync::{SyncActor, SyncActorRunnerBuilder, SyncContext};
+use heph::sync::{self, SyncActor, SyncActorRunnerBuilder};
 
 #[derive(Clone, Debug)]
 struct BlockFuture {
@@ -51,7 +51,7 @@ impl Future for BlockFuture {
     }
 }
 
-fn block_on_actor<RT, Fut>(mut ctx: SyncContext<String, RT>, fut: Fut)
+fn block_on_actor<RT, Fut>(mut ctx: sync::Context<String, RT>, fut: Fut)
 where
     Fut: Future,
 {
@@ -98,7 +98,7 @@ fn block_on_spurious_wake_up() {
     handle.join().unwrap();
 }
 
-fn try_receive_next_actor<RT>(mut ctx: SyncContext<String, RT>) {
+fn try_receive_next_actor<RT>(mut ctx: sync::Context<String, RT>) {
     loop {
         match ctx.try_receive_next() {
             Ok(msg) => {
@@ -138,7 +138,7 @@ fn bad_actor_supervisor(err_count: usize) -> SupervisorStrategy<usize> {
     }
 }
 
-fn bad_actor<RT>(_: SyncContext<!, RT>, count: usize) -> Result<(), usize> {
+fn bad_actor<RT>(_: sync::Context<!, RT>, count: usize) -> Result<(), usize> {
     Err(count + 1)
 }
 
@@ -175,7 +175,7 @@ impl<A: SyncActor> SyncSupervisor<A> for PanicSupervisor {
     }
 }
 
-fn panic_actor<RT>(_: SyncContext<!, RT>) {
+fn panic_actor<RT>(_: sync::Context<!, RT>) {
     panic!("oops!");
 }
 


### PR DESCRIPTION
Similar to actor::Context.

Closes #591 