### PR TITLE
Process all watch events

### DIFF
--- a/rt/src/fs/watch.rs
+++ b/rt/src/fs/watch.rs
@@ -306,6 +306,12 @@ impl<'w> fmt::Debug for Events<'w> {
     }
 }
 
+impl<'w> Drop for Events<'w> {
+    fn drop(&mut self) {
+        while self.next().is_some() { /* Process `IN_IGNORED` events. */ }
+    }
+}
+
 /// Event that represent a file system change.
 pub struct Event {
     event: libc::inotify_event,


### PR DESCRIPTION
Even if the user didn't retrieve them.

This is mainly important for IN_IGNORED events which makes us deleted paths that are no longer watched.