### PR TITLE
Limit the duration of an event loop iteration

### DIFF
--- a/rt/src/process/mod.rs
+++ b/rt/src/process/mod.rs
@@ -154,7 +154,7 @@ impl<P: Process + ?Sized> ProcessData<P> {
     /// Run the process.
     ///
     /// Returns the completion state of the process.
-    pub(crate) fn run(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> Poll<()> {
+    pub(crate) fn run(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> RunStats {
         let pid = self.as_ref().id();
         let name = self.process.name();
         trace!(pid = pid.0, name = name; "running process");
@@ -169,8 +169,18 @@ impl<P: Process + ?Sized> ProcessData<P> {
             pid = pid.0, name = name, elapsed = as_debug!(elapsed), result = as_debug!(result);
             "finished running process",
         );
-        result
+        RunStats { elapsed, result }
     }
+}
+
+/// Statistics about the process run.
+#[derive(Copy, Clone, Debug)]
+#[must_use = "Must check the process's `result`"]
+pub(crate) struct RunStats {
+    /// The duration for which the process ran.
+    pub(crate) elapsed: Duration,
+    /// The result of the process run.
+    pub(crate) result: Poll<()>,
 }
 
 impl<P: Process + ?Sized> Eq for ProcessData<P> {}

--- a/rt/src/scheduler/tests.rs
+++ b/rt/src/scheduler/tests.rs
@@ -11,7 +11,7 @@ use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
 use heph::ActorFutureBuilder;
 
-use crate::process::{FutureProcess, Process, ProcessId};
+use crate::process::{FutureProcess, Process, ProcessId, RunStats};
 use crate::scheduler::{ProcessData, Scheduler};
 use crate::spawn::options::Priority;
 use crate::test::{self, assert_size, AssertUnmoved, TestAssertUnmovedNewActor};
@@ -183,6 +183,14 @@ fn add_process_marked_ready() {
     assert!(scheduler.has_ready_process());
     let process = scheduler.next_process().unwrap();
     assert_eq!(process.as_ref().id(), pid);
+}
+
+// NOTE: This is here because we don't really care about the elapsed duration in
+// these tests, so this makes them easier to write.
+impl PartialEq<Poll<()>> for RunStats {
+    fn eq(&self, other: &Poll<()>) -> bool {
+        self.result.eq(other)
+    }
 }
 
 #[test]


### PR DESCRIPTION
Before this change we always ran a fixed number of processes, defined by RUN_POLL_RATIO, currently 32. This meant that if these processes took a huge amount of time to run, e.g. by using blocking I/O, waiting for a mutex, or just using a larger amount of cpu, we would run even more processes before checking on our timers and other events. This commit changes that.

We still use a fixed number of maximum processes we run each event loop iteration. However we also limit the amount of processes we run by the elapsed duration, i.e. time. This commit sets the limit to five milliseconds.

Note that any process can still take an arbitrary amount of time because we cooperative scheduling, but at least we won't make the problem worse by running more processes.