### PR TITLE
Implement from_std for various types

### DIFF
--- a/rt/src/fs/mod.rs
+++ b/rt/src/fs/mod.rs
@@ -59,6 +59,18 @@ impl File {
         OpenOptions::new()
     }
 
+    /// Converts a [`std::fs::File`] to a [`heph_rt::fs::File`].
+    ///
+    /// [`heph_rt::fs::File`]: File
+    pub fn from_std<RT>(rt: &RT, file: std::fs::File) -> File
+    where
+        RT: Access,
+    {
+        File {
+            fd: AsyncFd::new(file.into(), rt.submission_queue()),
+        }
+    }
+
     /// Read bytes from the file at `offset`, writing them into `buf`.
     ///
     /// The current file cursor is not affected by this function. This means

--- a/rt/src/net/tcp/listener.rs
+++ b/rt/src/net/tcp/listener.rs
@@ -147,6 +147,18 @@ impl TcpListener {
         Ok(socket)
     }
 
+    /// Converts a [`std::net::TcpListener`] to a [`heph_rt::net::TcpListener`].
+    ///
+    /// [`heph_rt::net::TcpListener`]: TcpListener
+    pub fn from_std<RT>(rt: &RT, listener: std::net::TcpListener) -> TcpListener
+    where
+        RT: Access,
+    {
+        TcpListener {
+            fd: AsyncFd::new(listener.into(), rt.submission_queue()),
+        }
+    }
+
     /// Returns the local socket address of this listener.
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.with_ref(|socket| socket.local_addr().and_then(convert_address))

--- a/rt/src/net/tcp/stream.rs
+++ b/rt/src/net/tcp/stream.rs
@@ -66,6 +66,18 @@ impl TcpStream {
         Ok(socket)
     }
 
+    /// Converts a [`std::net::TcpStream`] to a [`heph_rt::net::TcpStream`].
+    ///
+    /// [`heph_rt::net::TcpStream`]: TcpStream
+    pub fn from_std<RT>(rt: &RT, stream: std::net::TcpStream) -> TcpStream
+    where
+        RT: Access,
+    {
+        TcpStream {
+            fd: AsyncFd::new(stream.into(), rt.submission_queue()),
+        }
+    }
+
     /// Automatically set the CPU affinity based on the runtime access `rt`.
     ///
     /// For non-Linux OSs this is a no-op. If `rt` is not local this is also a

--- a/rt/src/net/udp.rs
+++ b/rt/src/net/udp.rs
@@ -141,6 +141,24 @@ impl<M> UdpSocket<M> {
         })
     }
 
+    /// Converts a [`std::net::UdpSocket`] to a [`heph_rt::net::UdpSocket`].
+    ///
+    /// [`heph_rt::net::UdpSocket`]: UdpSocket
+    ///
+    /// # Notes
+    ///
+    /// It's up to the caller to ensure that the socket's mode is correctly set
+    /// to [`Connected`] or [`Unconnected`].
+    pub fn from_std<RT>(rt: &RT, socket: std::net::UdpSocket) -> UdpSocket
+    where
+        RT: Access,
+    {
+        UdpSocket {
+            fd: AsyncFd::new(socket.into(), rt.submission_queue()),
+            mode: PhantomData,
+        }
+    }
+
     /// Returns the sockets peer address.
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.with_ref(|socket| socket.peer_addr().and_then(convert_address))

--- a/rt/src/net/uds/datagram.rs
+++ b/rt/src/net/uds/datagram.rs
@@ -126,6 +126,25 @@ impl<M> UnixDatagram<M> {
         })
     }
 
+    /// Converts a [`std::os::unix::net::UnixDatagram`] to a
+    /// [`heph_rt::net::UnixDatagram`].
+    ///
+    /// [`heph_rt::net::UnixDatagram`]: UnixDatagram
+    ///
+    /// # Notes
+    ///
+    /// It's up to the caller to ensure that the socket's mode is correctly set
+    /// to [`Connected`] or [`Unconnected`].
+    pub fn from_std<RT>(rt: &RT, socket: std::os::unix::net::UnixDatagram) -> UnixDatagram
+    where
+        RT: Access,
+    {
+        UnixDatagram {
+            fd: AsyncFd::new(socket.into(), rt.submission_queue()),
+            mode: PhantomData,
+        }
+    }
+
     /// Returns the socket address of the remote peer of this socket.
     pub fn peer_addr(&self) -> io::Result<UnixAddr> {
         self.with_ref(|socket| socket.peer_addr().map(|a| UnixAddr { inner: a }))

--- a/rt/src/net/uds/listener.rs
+++ b/rt/src/net/uds/listener.rs
@@ -132,6 +132,19 @@ impl UnixListener {
         Ok(socket)
     }
 
+    /// Converts a [`std::os::unix::net::UnixListener`] to a
+    /// [`heph_rt::net::UnixListener`].
+    ///
+    /// [`heph_rt::net::UnixListener`]: UnixListener
+    pub fn from_std<RT>(rt: &RT, listener: std::os::unix::net::UnixListener) -> UnixListener
+    where
+        RT: Access,
+    {
+        UnixListener {
+            fd: AsyncFd::new(listener.into(), rt.submission_queue()),
+        }
+    }
+
     /// Returns the socket address of the local half of this socket.
     pub fn local_addr(&self) -> io::Result<UnixAddr> {
         self.with_ref(|socket| socket.local_addr().map(|a| UnixAddr { inner: a }))

--- a/rt/src/net/uds/stream.rs
+++ b/rt/src/net/uds/stream.rs
@@ -90,6 +90,19 @@ impl UnixStream {
         socket
     }
 
+    /// Converts a [`std::os::unix::net::UnixStream`] to a
+    /// [`heph_rt::net::UnixStream`].
+    ///
+    /// [`heph_rt::net::UnixStream`]: UnixStream
+    pub fn from_std<RT>(rt: &RT, stream: std::os::unix::net::UnixStream) -> UnixStream
+    where
+        RT: Access,
+    {
+        UnixStream {
+            fd: AsyncFd::new(stream.into(), rt.submission_queue()),
+        }
+    }
+
     /// Automatically set the CPU affinity based on the runtime access `rt`.
     ///
     /// For non-Linux OSs this is a no-op. If `rt` is not local this is also a

--- a/rt/tests/functional/fs.rs
+++ b/rt/tests/functional/fs.rs
@@ -36,6 +36,27 @@ fn file_read_write() {
 }
 
 #[test]
+fn file_from_std() {
+    async fn actor(ctx: actor::Context<!, ThreadLocal>) {
+        let path = temp_file("file_from_std");
+        let file = std::fs::File::options()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .truncate(true)
+            .open(path)
+            .unwrap();
+        let mut file = File::from_std(ctx.runtime_ref(), file);
+
+        file.write_all(DATA1).await.unwrap();
+        let buf = file.read_at(Vec::with_capacity(128), 0).await.unwrap();
+        assert_eq!(buf, DATA1);
+    }
+
+    block_on_local_actor(actor_fn(actor), ()).unwrap();
+}
+
+#[test]
 fn file_sync_all() {
     async fn actor(ctx: actor::Context<!, ThreadLocal>) {
         let path = temp_file("file_sync_all");


### PR DESCRIPTION
This implements a `from_std` method for various types that can be created based on a similar type found in the standard library.