### PR TITLE
Implement From<Runtime(Ref)> for Thread{Local,Safe}

### DIFF
--- a/rt/src/access.rs
+++ b/rt/src/access.rs
@@ -40,7 +40,7 @@ use heph::{actor, sync, ActorRef, NewActor, Supervisor};
 use crate::spawn::{ActorOptions, FutureOptions, Spawn};
 use crate::timers::TimerToken;
 use crate::trace::{self, Trace};
-use crate::{shared, RuntimeRef};
+use crate::{shared, Runtime, RuntimeRef};
 
 /// Runtime Access Trait.
 ///
@@ -152,6 +152,12 @@ pub struct ThreadLocal {
 impl ThreadLocal {
     pub(crate) const fn new(rt: RuntimeRef) -> ThreadLocal {
         ThreadLocal { rt }
+    }
+}
+
+impl From<RuntimeRef> for ThreadLocal {
+    fn from(rt: RuntimeRef) -> ThreadLocal {
+        ThreadLocal::new(rt)
     }
 }
 
@@ -283,6 +289,18 @@ impl ThreadSafe {
         Fut: Future<Output = ()> + Send + std::marker::Sync + 'static,
     {
         self.rt.spawn_future(future, options);
+    }
+}
+
+impl From<&Runtime> for ThreadSafe {
+    fn from(rt: &Runtime) -> ThreadSafe {
+        ThreadSafe::new(rt.internals.clone())
+    }
+}
+
+impl From<&RuntimeRef> for ThreadSafe {
+    fn from(rt: &RuntimeRef) -> ThreadSafe {
+        ThreadSafe::new(rt.clone_shared())
     }
 }
 

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -618,7 +618,6 @@ impl RuntimeRef {
     }
 
     /// Returns a copy of the shared internals.
-    #[cfg(any(test, feature = "test"))]
     fn clone_shared(&self) -> Arc<shared::RuntimeInternals> {
         self.internals.shared.clone()
     }

--- a/rt/tests/functional.rs
+++ b/rt/tests/functional.rs
@@ -8,6 +8,7 @@ mod util;
 
 #[path = "functional"] // rustfmt can't find the files.
 mod functional {
+    mod access;
     mod actor;
     mod actor_context;
     mod actor_group;

--- a/rt/tests/functional/access.rs
+++ b/rt/tests/functional/access.rs
@@ -1,0 +1,53 @@
+//! Tests for the access module.
+
+use heph_rt::{Runtime, RuntimeRef, ThreadLocal, ThreadSafe};
+
+use crate::util::{assert_send, assert_sync};
+
+#[test]
+fn thread_safe_is_send_sync() {
+    assert_send::<ThreadSafe>();
+    assert_sync::<ThreadSafe>();
+}
+
+#[test]
+fn thread_local_from_runtime_ref() {
+    let mut rt = Runtime::new().unwrap();
+    rt.run_on_workers(|runtime_ref| {
+        let thread_local = ThreadLocal::from(runtime_ref);
+        drop(thread_local);
+        Ok::<_, !>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn thread_local_deref_as_runtime_ref() {
+    let mut rt = Runtime::new().unwrap();
+    rt.run_on_workers(|runtime_ref| {
+        let mut thread_local = ThreadLocal::from(runtime_ref);
+        let _runtime_ref: &mut RuntimeRef = &mut *thread_local;
+        drop(thread_local);
+        Ok::<_, !>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn thread_safe_from_runtime() {
+    let rt = Runtime::new().unwrap();
+    let thread_safe = ThreadSafe::from(&rt);
+    drop(thread_safe);
+    drop(rt);
+}
+
+#[test]
+fn thread_safe_from_runtime_ref() {
+    let mut rt = Runtime::new().unwrap();
+    rt.run_on_workers(|runtime_ref| {
+        let thread_safe = ThreadSafe::from(&runtime_ref);
+        drop(thread_safe);
+        Ok::<_, !>(())
+    })
+    .unwrap();
+}


### PR DESCRIPTION
This allows the creation of ThreadLocal and ThreadSafe from the Runtime and RuntimeRef types.

This is required for manual creation of actors using ActorFutureBuilder type and customer runtime.