### PR TITLE
Remove actor name arguments from StopSupervisor and restart_supervisor!

### DIFF
--- a/examples/4_restart_supervisor.rs
+++ b/examples/4_restart_supervisor.rs
@@ -30,7 +30,6 @@ fn main() {
 // Create a restart supervisor for the actors below.
 restart_supervisor!(
     PrintSupervisor,         // Name of the supervisor type.
-    "print actor",           // Name of the actor.
     &'static str,            // Argument for the actor.
     5,                       // Maximum number of restarts.
     Duration::from_secs(30), // Time to reset the max. reset counter.

--- a/remote/src/net_relay/mod.rs
+++ b/remote/src/net_relay/mod.rs
@@ -57,7 +57,7 @@
 //!
 //! // Next we're going to spawn our net relay actor.
 //! // First it needs a supervisor.
-//! restart_supervisor!(RelaySupervisor, "relay actor", SocketAddr);
+//! restart_supervisor!(RelaySupervisor, SocketAddr);
 //! let supervisor = RelaySupervisor::new(local_address);
 //! // It needs a way to route all incoming messages, here we're direct them to
 //! // our local actor using the `local_actor_ref`.

--- a/rt/examples/7_restart_supervisor.rs
+++ b/rt/examples/7_restart_supervisor.rs
@@ -38,7 +38,6 @@ fn main() -> Result<(), rt::Error> {
 // Create a restart supervisor for the [`print_actor`].
 restart_supervisor!(
     PrintSupervisor,
-    "print actor",
     String,
     5,
     Duration::from_secs(5),

--- a/rt/examples/9_systemd.rs
+++ b/rt/examples/9_systemd.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), rt::Error> {
     runtime.start()
 }
 
-restart_supervisor!(ServerSupervisor, "TCP server actor", ());
+restart_supervisor!(ServerSupervisor, ());
 
 async fn conn_actor(_: actor::Context<!, ThreadLocal>, stream: TcpStream) -> io::Result<()> {
     let address = stream.peer_addr()?;

--- a/rt/tests/examples.rs
+++ b/rt/tests/examples.rs
@@ -125,36 +125,37 @@ fn test_6_process_signals() {
 #[test]
 fn test_7_restart_supervisor() {
     // Index of the "?" in the string below.
-    const LEFT_INDEX: usize = 51;
+    const SYNC_LEFT_INDEX: usize = 56;
+    const ASYNC_LEFT_INDEX: usize = 51;
 
     let output = run_example_output("7_restart_supervisor");
     let mut lines = output.lines();
 
-    let mut expected = "lvl=\"WARN\" msg=\"print actor failed, restarting it (?/5 restarts left): can't print message synchronously 'Hello world!': actor message 'Hello world!'\" target=\"7_restart_supervisor\" module=\"7_restart_supervisor\"".to_owned();
+    let mut expected = "lvl=\"WARN\" msg=\"sync_print_actor failed, restarting it (?/5 restarts left): can't print message synchronously 'Hello world!': actor message 'Hello world!'\" target=\"7_restart_supervisor\" module=\"7_restart_supervisor\"".to_owned();
     for left in (0..5).rev() {
         let line = lines.next().unwrap();
 
         unsafe {
-            expected.as_bytes_mut()[LEFT_INDEX] = b'0' + left;
+            expected.as_bytes_mut()[SYNC_LEFT_INDEX] = b'0' + left;
         }
         assert_eq!(line, expected);
     }
 
-    let expected = "lvl=\"WARN\" msg=\"print actor failed, stopping it (no restarts left): can't print message synchronously 'Hello world!': actor message 'Hello world!'\" target=\"7_restart_supervisor\" module=\"7_restart_supervisor\"";
+    let expected = "lvl=\"WARN\" msg=\"sync_print_actor failed, stopping it (no restarts left): can't print message synchronously 'Hello world!': actor message 'Hello world!'\" target=\"7_restart_supervisor\" module=\"7_restart_supervisor\"";
     let last_line = lines.next().unwrap();
     assert_eq!(last_line, expected);
 
-    let mut expected = "lvl=\"WARN\" msg=\"print actor failed, restarting it (?/5 restarts left): can't print message 'Hello world!': actor message 'Hello world!'\" target=\"7_restart_supervisor\" module=\"7_restart_supervisor\"".to_owned();
+    let mut expected = "lvl=\"WARN\" msg=\"print_actor failed, restarting it (?/5 restarts left): can't print message 'Hello world!': actor message 'Hello world!'\" target=\"7_restart_supervisor\" module=\"7_restart_supervisor\"".to_owned();
     for left in (0..5).rev() {
         let line = lines.next().unwrap();
 
         unsafe {
-            expected.as_bytes_mut()[LEFT_INDEX] = b'0' + left;
+            expected.as_bytes_mut()[ASYNC_LEFT_INDEX] = b'0' + left;
         }
         assert_eq!(line, expected);
     }
 
-    let expected = "lvl=\"WARN\" msg=\"print actor failed, stopping it (no restarts left): can't print message 'Hello world!': actor message 'Hello world!'\" target=\"7_restart_supervisor\" module=\"7_restart_supervisor\"";
+    let expected = "lvl=\"WARN\" msg=\"print_actor failed, stopping it (no restarts left): can't print message 'Hello world!': actor message 'Hello world!'\" target=\"7_restart_supervisor\" module=\"7_restart_supervisor\"";
     let last_line = lines.next().unwrap();
     assert_eq!(last_line, expected);
 

--- a/rt/tests/functional/restart_supervisor.rs
+++ b/rt/tests/functional/restart_supervisor.rs
@@ -19,7 +19,7 @@ const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(5);
 
 #[test]
 fn new_actor_unit_argument() {
-    restart_supervisor!(Supervisor, "my actor");
+    restart_supervisor!(Supervisor);
     // Should be able to create it without arguments passed to `new`.
     let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
@@ -28,7 +28,7 @@ fn new_actor_unit_argument() {
 
 #[test]
 fn new_actor_unit_argument_explicit() {
-    restart_supervisor!(Supervisor, "my actor", ());
+    restart_supervisor!(Supervisor, ());
     // Should be able to create it without arguments passed to `new`.
     let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
@@ -37,7 +37,7 @@ fn new_actor_unit_argument_explicit() {
 
 #[test]
 fn new_actor_single_argument() {
-    restart_supervisor!(Supervisor, "my actor", String);
+    restart_supervisor!(Supervisor, String);
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned());
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
@@ -46,7 +46,7 @@ fn new_actor_single_argument() {
 
 #[test]
 fn new_actor_tuple_argument() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize));
+    restart_supervisor!(Supervisor, (String, usize));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123);
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
@@ -55,7 +55,7 @@ fn new_actor_tuple_argument() {
 
 #[test]
 fn no_log_unit_argument() {
-    restart_supervisor!(Supervisor, "my actor", (), 2, Duration::from_secs(10));
+    restart_supervisor!(Supervisor, (), 2, Duration::from_secs(10));
     let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
@@ -63,7 +63,7 @@ fn no_log_unit_argument() {
 
 #[test]
 fn no_log_single_argument() {
-    restart_supervisor!(Supervisor, "my actor", usize, 2, Duration::from_secs(10));
+    restart_supervisor!(Supervisor, usize, 2, Duration::from_secs(10));
     let _supervisor = Supervisor::new(123);
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
@@ -71,13 +71,7 @@ fn no_log_single_argument() {
 
 #[test]
 fn no_log_tuple_argument() {
-    restart_supervisor!(
-        Supervisor,
-        "my actor",
-        (u8, u16),
-        2,
-        Duration::from_secs(10)
-    );
+    restart_supervisor!(Supervisor, (u8, u16), 2, Duration::from_secs(10));
     let _supervisor = Supervisor::new(123, 456);
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
@@ -85,14 +79,7 @@ fn no_log_tuple_argument() {
 
 #[test]
 fn all_unit_argument() {
-    restart_supervisor!(
-        Supervisor,
-        "my actor",
-        (),
-        2,
-        Duration::from_secs(10),
-        ": log extra",
-    );
+    restart_supervisor!(Supervisor, (), 2, Duration::from_secs(10), ": log extra",);
     let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
@@ -102,7 +89,6 @@ fn all_unit_argument() {
 fn all_single_argument() {
     restart_supervisor!(
         Supervisor,
-        "my actor",
         usize,
         2,
         Duration::from_secs(10),
@@ -118,7 +104,6 @@ fn all_single_argument() {
 fn all_tuple_argument() {
     restart_supervisor!(
         Supervisor,
-        "my actor",
         (u8, u16),
         2,
         Duration::from_secs(10),
@@ -133,46 +118,42 @@ fn all_tuple_argument() {
 
 #[test]
 fn tuple_2() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize));
+    restart_supervisor!(Supervisor, (String, usize));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123);
 }
 
 #[test]
 fn tuple_3() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize, u8));
+    restart_supervisor!(Supervisor, (String, usize, u8));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1);
 }
 
 #[test]
 fn tuple_4() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, &'static str));
+    restart_supervisor!(Supervisor, (String, usize, u8, &'static str));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, "arg");
 }
 
 #[test]
 fn tuple_5() {
-    restart_supervisor!(
-        Supervisor,
-        "my actor",
-        (String, usize, u8, &'static str, u8)
-    );
+    restart_supervisor!(Supervisor, (String, usize, u8, &'static str, u8));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, "arg", 1);
 }
 
 #[test]
 fn tuple_6() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, u8, u8, u8));
+    restart_supervisor!(Supervisor, (String, usize, u8, u8, u8, u8));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, 2, 3, 4);
 }
 
 #[test]
 fn tuple_7() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, u8, u8, u8, u8));
+    restart_supervisor!(Supervisor, (String, usize, u8, u8, u8, u8, u8));
     // Need to use tuple format.
     let _supervisor = Supervisor::new(("Hello World".to_owned(), 123, 1, 2, 3, 4, 5));
 }
@@ -257,7 +238,7 @@ fn decide_for_restart_second<NA, S>(
 
 #[test]
 fn decide() {
-    restart_supervisor!(Supervisor, "my actor", bool, 1, Duration::from_secs(60));
+    restart_supervisor!(Supervisor, bool, 1, Duration::from_secs(60));
 
     let arg = true;
     let mut supervisor = Supervisor::new(arg);
@@ -274,7 +255,7 @@ fn decide() {
 
 #[test]
 fn decide_max_duration_elapsed() {
-    restart_supervisor!(Supervisor, "my actor", bool, 1, Duration::from_millis(100));
+    restart_supervisor!(Supervisor, bool, 1, Duration::from_millis(100));
 
     let arg = true;
     let mut supervisor = Supervisor::new(arg);
@@ -302,7 +283,7 @@ fn decide_max_duration_elapsed() {
 
 #[test]
 fn decide_on_restart_error() {
-    restart_supervisor!(Supervisor, "my actor", bool, 1, Duration::from_secs(60));
+    restart_supervisor!(Supervisor, bool, 1, Duration::from_secs(60));
 
     let arg = true;
     let mut supervisor = Supervisor::new(arg);
@@ -319,7 +300,7 @@ fn decide_on_restart_error() {
 
 #[test]
 fn decide_on_second_restart_error() {
-    restart_supervisor!(Supervisor, "my actor", bool, 1, Duration::from_secs(60));
+    restart_supervisor!(Supervisor, bool, 1, Duration::from_secs(60));
 
     let arg = true;
     let mut supervisor = Supervisor::new(arg);

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -422,7 +422,6 @@ where
 /// * `$vis`: visibility indicator (*optional*), defaults to private (i.e. no
 ///   indicator).
 /// * `$supervisor_name`: name of the new supervisor type.
-/// * `$actor_name`: display friendly name of the actor, used in logging.
 /// * `$args`: type of the argument(s) used to restart the actor. Multiple
 ///   arguments must be in the tuple format (same as for the
 ///   [`NewActor::Argument`] type).
@@ -474,7 +473,6 @@ where
 /// restart_supervisor!(
 ///     pub                      // Visibility indicator.
 ///     MySupervisor,            // Name of the supervisor type.
-///     "my actor",              // Name of the actor.
 ///     (bool, u32),             // Type of the arguments for the actor.
 ///     2,                       // Maximum number of restarts.
 ///     Duration::from_secs(30), // Maximum duration before the restart counter
@@ -494,45 +492,45 @@ where
 #[macro_export]
 macro_rules! restart_supervisor {
     // No non-optional arguments, unit `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, (), 5, std::time::Duration::from_secs(5), "",);
+    ($vis: vis $supervisor_name: ident $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, (), 5, std::time::Duration::from_secs(5), "",);
     };
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, () $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, (), 5, std::time::Duration::from_secs(5), "",);
+    ($vis: vis $supervisor_name: ident, () $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, (), 5, std::time::Duration::from_secs(5), "",);
     };
     // No non-optional arguments, tuple `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, ( $( $arg: ty),* ) $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, ( $( $arg ),* ), 5, std::time::Duration::from_secs(5), "",);
+    ($vis: vis $supervisor_name: ident, ( $( $arg: ty),* ) $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, ( $( $arg ),* ), 5, std::time::Duration::from_secs(5), "",);
     };
     // No non-optional arguments, single `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, $arg: ty $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, ( $arg ), 5, std::time::Duration::from_secs(5), "",);
+    ($vis: vis $supervisor_name: ident, $arg: ty $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, ( $arg ), 5, std::time::Duration::from_secs(5), "",);
     };
 
     // No log extra, unit `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, (), $max_restarts: expr, $max_duration: expr $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, (), $max_restarts, $max_duration, "",);
+    ($vis: vis $supervisor_name: ident, (), $max_restarts: expr, $max_duration: expr $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, (), $max_restarts, $max_duration, "",);
     };
     // No log extra, tuple `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, ( $( $arg: ty ),* ), $max_restarts: expr, $max_duration: expr $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, ( $( $arg ),* ), $max_restarts, $max_duration, "",);
+    ($vis: vis $supervisor_name: ident, ( $( $arg: ty ),* ), $max_restarts: expr, $max_duration: expr $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, ( $( $arg ),* ), $max_restarts, $max_duration, "",);
     };
     // No log extra, single `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, $arg: ty, $max_restarts: expr, $max_duration: expr $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, ( $arg ), $max_restarts, $max_duration, "",);
+    ($vis: vis $supervisor_name: ident, $arg: ty, $max_restarts: expr, $max_duration: expr $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, ( $arg ), $max_restarts, $max_duration, "",);
     };
 
     // All arguments, unit `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, (), $max_restarts: expr, $max_duration: expr, $log_extra: expr, $( args $(. $log_arg_field: tt )* ),* $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, (), $max_restarts, $max_duration, $log_extra, $( args $(. $log_arg_field )* ),*);
+    ($vis: vis $supervisor_name: ident, (), $max_restarts: expr, $max_duration: expr, $log_extra: expr, $( args $(. $log_arg_field: tt )* ),* $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, (), $max_restarts, $max_duration, $log_extra, $( args $(. $log_arg_field )* ),*);
     };
     // All arguments, tuple `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, ( $( $arg: ty ),* ), $max_restarts: expr, $max_duration: expr, $log_extra: expr, $( args $(. $log_arg_field: tt )* ),* $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, ( $( $arg ),* ), $max_restarts, $max_duration, $log_extra, $( args $(. $log_arg_field )* ),*);
+    ($vis: vis $supervisor_name: ident, ( $( $arg: ty ),* ), $max_restarts: expr, $max_duration: expr, $log_extra: expr, $( args $(. $log_arg_field: tt )* ),* $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, ( $( $arg ),* ), $max_restarts, $max_duration, $log_extra, $( args $(. $log_arg_field )* ),*);
     };
     // All arguments, single `NewActor::Argument`.
-    ($vis: vis $supervisor_name: ident, $actor_name: expr, $arg: ty, $max_restarts: expr, $max_duration: expr, $log_extra: expr, $( args $(. $log_arg_field: tt )* ),* $(,)?) => {
-        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, $actor_name, ( $arg ), $max_restarts, $max_duration, $log_extra, $( args $(. $log_arg_field )* ),*);
+    ($vis: vis $supervisor_name: ident, $arg: ty, $max_restarts: expr, $max_duration: expr, $log_extra: expr, $( args $(. $log_arg_field: tt )* ),* $(,)?) => {
+        $crate::__heph_restart_supervisor_impl!($vis $supervisor_name, ( $arg ), $max_restarts, $max_duration, $log_extra, $( args $(. $log_arg_field )* ),*);
     };
 }
 
@@ -545,7 +543,6 @@ macro_rules! __heph_restart_supervisor_impl {
     (
         $vis: vis
         $supervisor_name: ident,
-        $actor_name: expr,
         ( $( $arg: ty ),* ),
         $max_restarts: expr,
         $max_duration: expr,
@@ -555,7 +552,7 @@ macro_rules! __heph_restart_supervisor_impl {
     ) => {
         $crate::__heph_doc!(
             std::concat!(
-                "Supervisor for ", $actor_name, ".\n\n",
+                "Restart supervisor.\n\n",
                 "Maximum number of restarts: `", stringify!($max_restarts), "`, ",
                 "within a duration of: `", stringify!($max_duration), "`.",
             ),
@@ -594,7 +591,7 @@ macro_rules! __heph_restart_supervisor_impl {
             <NA::Actor as $crate::Actor>::Error: std::fmt::Display,
         {
             fn decide(&mut self, err: <NA::Actor as $crate::Actor>::Error) -> $crate::SupervisorStrategy<NA::Argument> {
-                $crate::__heph_restart_supervisor_impl!{decide_impl self, err, $actor_name, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
+                $crate::__heph_restart_supervisor_impl!{decide_impl NA, self, err, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
             }
 
             fn decide_on_restart_error(&mut self, err: NA::Error) -> $crate::SupervisorStrategy<NA::Argument> {
@@ -603,14 +600,14 @@ macro_rules! __heph_restart_supervisor_impl {
                 if self.restarts_left >= 1 {
                     self.restarts_left -= 1;
                     ::log::warn!(
-                        std::concat!($actor_name, " actor failed to restart, trying again ({}/{} restarts left): {}", $log_extra),
-                        self.restarts_left, $max_restarts, err, $( self.args $(. $log_arg_field )* ),*
+                        std::concat!("{} actor failed to restart, trying again ({}/{} restarts left): {}", $log_extra),
+                        NA::name(), self.restarts_left, $max_restarts, err, $( self.args $(. $log_arg_field )* ),*
                     );
                     $crate::SupervisorStrategy::Restart(self.args.clone())
                 } else {
                     ::log::warn!(
-                        std::concat!($actor_name, " actor failed to restart, stopping it (no restarts left): {}", $log_extra),
-                        err, $( self.args $(. $log_arg_field )* ),*
+                        std::concat!("{} actor failed to restart, stopping it (no restarts left): {}", $log_extra),
+                        NA::name(), err, $( self.args $(. $log_arg_field )* ),*
                     );
                     $crate::SupervisorStrategy::Stop
                 }
@@ -618,13 +615,13 @@ macro_rules! __heph_restart_supervisor_impl {
 
             fn second_restart_error(&mut self, err: NA::Error) {
                 ::log::warn!(
-                    std::concat!($actor_name, " actor failed to restart a second time, stopping it: {}", $log_extra),
-                    err, $( self.args $(. $log_arg_field )* ),*
+                    std::concat!("{} actor failed to restart a second time, stopping it: {}", $log_extra),
+                    NA::name(), err, $( self.args $(. $log_arg_field )* ),*
                 );
             }
 
             fn decide_on_panic(&mut self, panic: Box<dyn std::any::Any + Send + 'static>) -> $crate::SupervisorStrategy<NA::Argument> {
-                $crate::__heph_restart_supervisor_impl!{decide_on_panic_impl self, panic, $actor_name, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
+                $crate::__heph_restart_supervisor_impl!{decide_on_panic_impl NA, self, panic, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
             }
         }
 
@@ -634,11 +631,11 @@ macro_rules! __heph_restart_supervisor_impl {
             A::Error: std::fmt::Display,
         {
             fn decide(&mut self, err: A::Error) -> $crate::SupervisorStrategy<A::Argument> {
-                $crate::__heph_restart_supervisor_impl!{decide_impl self, err, $actor_name, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
+                $crate::__heph_restart_supervisor_impl!{decide_impl A, self, err, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
             }
 
             fn decide_on_panic(&mut self, panic: Box<dyn std::any::Any + Send + 'static>) -> $crate::SupervisorStrategy<A::Argument> {
-                $crate::__heph_restart_supervisor_impl!{decide_on_panic_impl self, panic, $actor_name, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
+                $crate::__heph_restart_supervisor_impl!{decide_on_panic_impl A, self, panic, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
             }
         }
     };
@@ -646,39 +643,39 @@ macro_rules! __heph_restart_supervisor_impl {
     // The `decide` implementation of `Supervisor` and `SyncSupervisor`.
     (
         decide_impl
+        $NA: ident,
         $self: ident,
         $err: ident,
-        $actor_name: expr,
         $max_restarts: expr,
         $log_extra: expr,
         $( args $(. $log_arg_field: tt )* ),*
         $(,)?
     ) => {
-        $crate::__heph_restart_supervisor_impl!{_decide_impl $self, "failed", $err, $actor_name, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
+        $crate::__heph_restart_supervisor_impl!{_decide_impl $NA, $self, "failed", $err, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
     };
 
     // The `decide_on_panic` implementation of `Supervisor` and `SyncSupervisor`.
     (
         decide_on_panic_impl
+        $NA: ident,
         $self: ident,
         $panic: ident,
-        $actor_name: expr,
         $max_restarts: expr,
         $log_extra: expr,
         $( args $(. $log_arg_field: tt )* ),*
         $(,)?
     ) => {
         let msg = $crate::panic_message(&*$panic);
-        $crate::__heph_restart_supervisor_impl!{_decide_impl $self, "panicked", msg, $actor_name, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
+        $crate::__heph_restart_supervisor_impl!{_decide_impl $NA, $self, "panicked", msg, $max_restarts, $log_extra, $( args $(. $log_arg_field )* ),*}
     };
 
     // The `decide`/`decide_on_panic` implementation of `Supervisor` and `SyncSupervisor`.
     (
         _decide_impl
+        $NA: ident,
         $self: ident,
         $kind: expr,
         $err: ident,
-        $actor_name: expr,
         $max_restarts: expr,
         $log_extra: expr,
         $( args $(. $log_arg_field: tt )* ),*
@@ -699,14 +696,14 @@ macro_rules! __heph_restart_supervisor_impl {
         if $self.restarts_left >= 1 {
             $self.restarts_left -= 1;
             ::log::warn!(
-                std::concat!($actor_name, " ", $kind, ", restarting it ({}/{} restarts left): {}", $log_extra),
-                $self.restarts_left, $max_restarts, $err, $( $self.args $(. $log_arg_field )* ),*
+                std::concat!("{} ", $kind, ", restarting it ({}/{} restarts left): {}", $log_extra),
+                $NA::name(), $self.restarts_left, $max_restarts, $err, $( $self.args $(. $log_arg_field )* ),*
             );
             $crate::SupervisorStrategy::Restart($self.args.clone())
         } else {
             ::log::warn!(
-                std::concat!($actor_name, " ", $kind, ", stopping it (no restarts left): {}", $log_extra),
-                $err, $( $self.args $(. $log_arg_field )* ),*
+                std::concat!("{} ", $kind, ", stopping it (no restarts left): {}", $log_extra),
+                $NA::name(), $err, $( $self.args $(. $log_arg_field )* ),*
             );
             $crate::SupervisorStrategy::Stop
         }

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -354,14 +354,7 @@ where
 /// This supervisor can be used for quick prototyping or for one off actors that
 /// shouldn't be restarted.
 #[derive(Copy, Clone, Debug)]
-pub struct StopSupervisor(&'static str);
-
-impl StopSupervisor {
-    /// Create a new `StopSupervisor` for the actor with `actor_name`.
-    pub const fn for_actor(actor_name: &'static str) -> StopSupervisor {
-        StopSupervisor(actor_name)
-    }
-}
+pub struct StopSupervisor;
 
 impl<NA> Supervisor<NA> for StopSupervisor
 where
@@ -370,22 +363,22 @@ where
     <NA::Actor as Actor>::Error: fmt::Display,
 {
     fn decide(&mut self, err: <NA::Actor as Actor>::Error) -> SupervisorStrategy<NA::Argument> {
-        warn!("{} failed, stopping it: {err}", self.0);
+        let name = NA::name();
+        warn!("{name} failed, stopping it: {err}");
         SupervisorStrategy::Stop
     }
 
     fn decide_on_restart_error(&mut self, err: NA::Error) -> SupervisorStrategy<NA::Argument> {
         // Shouldn't be called, but it should still have an implementation.
-        warn!("{} failed to restart, stopping it: {err}", self.0);
+        let name = NA::name();
+        warn!("{name} failed to restart, stopping it: {err}");
         SupervisorStrategy::Stop
     }
 
     fn second_restart_error(&mut self, err: NA::Error) {
         // Shouldn't be called, but it should still have an implementation.
-        warn!(
-            "{} failed to restart a second time, stopping it: {err}",
-            self.0
-        );
+        let name = NA::name();
+        warn!("{name} failed to restart a second time, stopping it: {err}");
     }
 
     fn decide_on_panic(
@@ -393,7 +386,8 @@ where
         panic: Box<dyn Any + Send + 'static>,
     ) -> SupervisorStrategy<NA::Argument> {
         let msg = panic_message(&*panic);
-        warn!("{} panicked, stopping it: {msg}", self.0);
+        let name = NA::name();
+        warn!("{name} panicked, stopping it: {msg}");
         SupervisorStrategy::Stop
     }
 }
@@ -404,7 +398,8 @@ where
     A::Error: fmt::Display,
 {
     fn decide(&mut self, err: A::Error) -> SupervisorStrategy<A::Argument> {
-        warn!("{} failed, stopping it: {err}", self.0);
+        let name = A::name();
+        warn!("{name} failed, stopping it: {err}");
         SupervisorStrategy::Stop
     }
 
@@ -412,8 +407,9 @@ where
         &mut self,
         panic: Box<dyn Any + Send + 'static>,
     ) -> SupervisorStrategy<A::Argument> {
+        let name = A::name();
         let msg = panic_message(&*panic);
-        warn!("{} panicked, stopping it: {msg}", self.0);
+        warn!("{name} panicked, stopping it: {msg}");
         SupervisorStrategy::Stop
     }
 }

--- a/tests/functional/restart_supervisor.rs
+++ b/tests/functional/restart_supervisor.rs
@@ -18,7 +18,7 @@ const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(5);
 
 #[test]
 fn new_actor_unit_argument() {
-    restart_supervisor!(Supervisor, "my actor");
+    restart_supervisor!(Supervisor);
     // Should be able to create it without arguments passed to `new`.
     let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
@@ -27,7 +27,7 @@ fn new_actor_unit_argument() {
 
 #[test]
 fn new_actor_unit_argument_explicit() {
-    restart_supervisor!(Supervisor, "my actor", ());
+    restart_supervisor!(Supervisor, ());
     // Should be able to create it without arguments passed to `new`.
     let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
@@ -36,7 +36,7 @@ fn new_actor_unit_argument_explicit() {
 
 #[test]
 fn new_actor_single_argument() {
-    restart_supervisor!(Supervisor, "my actor", String);
+    restart_supervisor!(Supervisor, String);
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned());
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
@@ -45,7 +45,7 @@ fn new_actor_single_argument() {
 
 #[test]
 fn new_actor_tuple_argument() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize));
+    restart_supervisor!(Supervisor, (String, usize));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123);
     assert_eq!(Supervisor::MAX_RESTARTS, DEFAULT_MAX_RESTARTS);
@@ -54,7 +54,7 @@ fn new_actor_tuple_argument() {
 
 #[test]
 fn no_log_unit_argument() {
-    restart_supervisor!(Supervisor, "my actor", (), 2, Duration::from_secs(10));
+    restart_supervisor!(Supervisor, (), 2, Duration::from_secs(10));
     let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
@@ -62,7 +62,7 @@ fn no_log_unit_argument() {
 
 #[test]
 fn no_log_single_argument() {
-    restart_supervisor!(Supervisor, "my actor", usize, 2, Duration::from_secs(10));
+    restart_supervisor!(Supervisor, usize, 2, Duration::from_secs(10));
     let _supervisor = Supervisor::new(123);
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
@@ -70,13 +70,7 @@ fn no_log_single_argument() {
 
 #[test]
 fn no_log_tuple_argument() {
-    restart_supervisor!(
-        Supervisor,
-        "my actor",
-        (u8, u16),
-        2,
-        Duration::from_secs(10)
-    );
+    restart_supervisor!(Supervisor, (u8, u16), 2, Duration::from_secs(10));
     let _supervisor = Supervisor::new(123, 456);
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
@@ -84,14 +78,7 @@ fn no_log_tuple_argument() {
 
 #[test]
 fn all_unit_argument() {
-    restart_supervisor!(
-        Supervisor,
-        "my actor",
-        (),
-        2,
-        Duration::from_secs(10),
-        ": log extra",
-    );
+    restart_supervisor!(Supervisor, (), 2, Duration::from_secs(10), ": log extra",);
     let _supervisor = Supervisor::new();
     assert_eq!(Supervisor::MAX_RESTARTS, 2);
     assert_eq!(Supervisor::MAX_DURATION, Duration::from_secs(10));
@@ -101,7 +88,6 @@ fn all_unit_argument() {
 fn all_single_argument() {
     restart_supervisor!(
         Supervisor,
-        "my actor",
         usize,
         2,
         Duration::from_secs(10),
@@ -117,7 +103,6 @@ fn all_single_argument() {
 fn all_tuple_argument() {
     restart_supervisor!(
         Supervisor,
-        "my actor",
         (u8, u16),
         2,
         Duration::from_secs(10),
@@ -132,46 +117,42 @@ fn all_tuple_argument() {
 
 #[test]
 fn tuple_2() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize));
+    restart_supervisor!(Supervisor, (String, usize));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123);
 }
 
 #[test]
 fn tuple_3() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize, u8));
+    restart_supervisor!(Supervisor, (String, usize, u8));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1);
 }
 
 #[test]
 fn tuple_4() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, &'static str));
+    restart_supervisor!(Supervisor, (String, usize, u8, &'static str));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, "arg");
 }
 
 #[test]
 fn tuple_5() {
-    restart_supervisor!(
-        Supervisor,
-        "my actor",
-        (String, usize, u8, &'static str, u8)
-    );
+    restart_supervisor!(Supervisor, (String, usize, u8, &'static str, u8));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, "arg", 1);
 }
 
 #[test]
 fn tuple_6() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, u8, u8, u8));
+    restart_supervisor!(Supervisor, (String, usize, u8, u8, u8, u8));
     // Should be able to directly pass argument.
     let _supervisor = Supervisor::new("Hello World".to_owned(), 123, 1, 2, 3, 4);
 }
 
 #[test]
 fn tuple_7() {
-    restart_supervisor!(Supervisor, "my actor", (String, usize, u8, u8, u8, u8, u8));
+    restart_supervisor!(Supervisor, (String, usize, u8, u8, u8, u8, u8));
     // Need to use tuple format.
     let _supervisor = Supervisor::new(("Hello World".to_owned(), 123, 1, 2, 3, 4, 5));
 }
@@ -256,7 +237,7 @@ fn decide_for_restart_second<NA, S>(
 
 #[test]
 fn decide() {
-    restart_supervisor!(Supervisor, "my actor", bool, 1, Duration::from_secs(60));
+    restart_supervisor!(Supervisor, bool, 1, Duration::from_secs(60));
 
     let arg = true;
     let mut supervisor = Supervisor::new(arg);
@@ -273,7 +254,7 @@ fn decide() {
 
 #[test]
 fn decide_max_duration_elapsed() {
-    restart_supervisor!(Supervisor, "my actor", bool, 1, Duration::from_millis(100));
+    restart_supervisor!(Supervisor, bool, 1, Duration::from_millis(100));
 
     let arg = true;
     let mut supervisor = Supervisor::new(arg);
@@ -301,7 +282,7 @@ fn decide_max_duration_elapsed() {
 
 #[test]
 fn decide_on_restart_error() {
-    restart_supervisor!(Supervisor, "my actor", bool, 1, Duration::from_secs(60));
+    restart_supervisor!(Supervisor, bool, 1, Duration::from_secs(60));
 
     let arg = true;
     let mut supervisor = Supervisor::new(arg);
@@ -318,7 +299,7 @@ fn decide_on_restart_error() {
 
 #[test]
 fn decide_on_second_restart_error() {
-    restart_supervisor!(Supervisor, "my actor", bool, 1, Duration::from_secs(60));
+    restart_supervisor!(Supervisor, bool, 1, Duration::from_secs(60));
 
     let arg = true;
     let mut supervisor = Supervisor::new(arg);


### PR DESCRIPTION
Instead use the NewActor::name or SyncActor::name implementations to get
the name of the actor.