### PR TITLE
Rewrite Spawn trait

### DIFF
--- a/rt/examples/1_hello_world.rs
+++ b/rt/examples/1_hello_world.rs
@@ -2,7 +2,7 @@
 
 use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
-use heph_rt::spawn::ActorOptions;
+use heph_rt::spawn::{ActorOptions, SpawnLocal};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
 
 fn main() -> Result<(), rt::Error> {

--- a/rt/examples/2_my_ip.rs
+++ b/rt/examples/2_my_ip.rs
@@ -6,6 +6,7 @@ use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph::supervisor::{Supervisor, SupervisorStrategy};
 use heph_rt::net::{tcp, TcpStream};
 use heph_rt::spawn::options::{ActorOptions, Priority};
+use heph_rt::spawn::SpawnLocal;
 use heph_rt::{self as rt, Runtime, ThreadLocal};
 use log::{error, info};
 

--- a/rt/examples/3_rpc.rs
+++ b/rt/examples/3_rpc.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use heph::actor::{self, actor_fn};
 use heph::actor_ref::{ActorRef, RpcMessage};
 use heph::supervisor::NoSupervisor;
-use heph_rt::spawn::ActorOptions;
+use heph_rt::spawn::{ActorOptions, SpawnLocal};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
 
 fn main() -> Result<(), rt::Error> {

--- a/rt/examples/6_process_signals.rs
+++ b/rt/examples/6_process_signals.rs
@@ -3,7 +3,7 @@
 use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
 use heph::sync;
-use heph_rt::spawn::{ActorOptions, SyncActorOptions};
+use heph_rt::spawn::{ActorOptions, Spawn, SpawnLocal, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, Signal, ThreadLocal, ThreadSafe};
 
 fn main() -> Result<(), rt::Error> {

--- a/rt/examples/7_restart_supervisor.rs
+++ b/rt/examples/7_restart_supervisor.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use heph::actor::{self, actor_fn};
 use heph::{restart_supervisor, sync};
-use heph_rt::spawn::{ActorOptions, SyncActorOptions};
+use heph_rt::spawn::{ActorOptions, SpawnLocal, SyncActorOptions};
 use heph_rt::{self as rt, Runtime, RuntimeRef, ThreadLocal};
 
 fn main() -> Result<(), rt::Error> {

--- a/rt/examples/8_tracing.rs
+++ b/rt/examples/8_tracing.rs
@@ -7,7 +7,7 @@ use heph::actor::{self, actor_fn};
 use heph::actor_ref::{ActorRef, SendError};
 use heph::supervisor::{NoSupervisor, SupervisorStrategy};
 use heph::sync;
-use heph_rt::spawn::{ActorOptions, SyncActorOptions};
+use heph_rt::spawn::{ActorOptions, Spawn, SpawnLocal, SyncActorOptions};
 use heph_rt::trace::Trace;
 use heph_rt::{self as rt, Runtime, RuntimeRef};
 use log::warn;

--- a/rt/examples/99_stress_memory.rs
+++ b/rt/examples/99_stress_memory.rs
@@ -9,7 +9,7 @@ use std::future::pending;
 
 use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
-use heph_rt::spawn::ActorOptions;
+use heph_rt::spawn::{ActorOptions, SpawnLocal};
 use heph_rt::{self as rt, Runtime, ThreadLocal};
 use log::info;
 

--- a/rt/examples/9_systemd.rs
+++ b/rt/examples/9_systemd.rs
@@ -8,6 +8,7 @@ use heph::restart_supervisor;
 use heph::supervisor::StopSupervisor;
 use heph_rt::net::{tcp, TcpStream};
 use heph_rt::spawn::options::{ActorOptions, Priority};
+use heph_rt::spawn::{Spawn, SpawnLocal};
 use heph_rt::{self as rt, Runtime, ThreadLocal};
 use log::info;
 

--- a/rt/examples/redis.rs
+++ b/rt/examples/redis.rs
@@ -14,6 +14,7 @@ use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph::supervisor::{Supervisor, SupervisorStrategy};
 use heph_rt::net::{tcp, TcpStream};
 use heph_rt::spawn::options::{ActorOptions, Priority};
+use heph_rt::spawn::SpawnLocal;
 use heph_rt::timer::Deadline;
 use heph_rt::{self as rt, Runtime};
 use log::{error, info};

--- a/rt/src/access.rs
+++ b/rt/src/access.rs
@@ -169,6 +169,22 @@ impl From<&RuntimeRef> for ThreadLocal {
     }
 }
 
+// NOTE: this is for the `ThreadLocal: for<'a> From<&'a Self>` bound on
+// `SpawnLocal::try_spawn`.
+impl From<&ThreadLocal> for ThreadLocal {
+    fn from(rt: &ThreadLocal) -> ThreadLocal {
+        rt.clone()
+    }
+}
+
+// NOTE: this is for the `ThreadLocal: for<'a> From<&'a Self>` bound on
+// `SpawnLocal::try_spawn`.
+impl<M> From<&actor::Context<M, ThreadLocal>> for ThreadLocal {
+    fn from(ctx: &actor::Context<M, ThreadLocal>) -> ThreadLocal {
+        ctx.runtime_ref().clone()
+    }
+}
+
 impl Deref for ThreadLocal {
     type Target = RuntimeRef;
 
@@ -284,6 +300,22 @@ impl From<&Runtime> for ThreadSafe {
 impl From<&RuntimeRef> for ThreadSafe {
     fn from(rt: &RuntimeRef) -> ThreadSafe {
         ThreadSafe::new(rt.clone_shared())
+    }
+}
+
+// NOTE: this is for the `ThreadLocal: for<'a> From<&'a Self>` bound on
+// `SpawnLocal::try_spawn`.
+impl From<&ThreadSafe> for ThreadSafe {
+    fn from(rt: &ThreadSafe) -> ThreadSafe {
+        rt.clone()
+    }
+}
+
+// NOTE: this is for the `ThreadSafe: for<'a> From<&'a Self>` bound on
+// `Spawn::try_spawn`.
+impl<M> From<&actor::Context<M, ThreadSafe>> for ThreadSafe {
+    fn from(ctx: &actor::Context<M, ThreadSafe>) -> ThreadSafe {
+        ctx.runtime_ref().clone()
     }
 }
 

--- a/rt/src/access.rs
+++ b/rt/src/access.rs
@@ -161,6 +161,12 @@ impl From<RuntimeRef> for ThreadLocal {
     }
 }
 
+impl From<&RuntimeRef> for ThreadLocal {
+    fn from(rt: &RuntimeRef) -> ThreadLocal {
+        ThreadLocal::new(rt.clone())
+    }
+}
+
 impl Deref for ThreadLocal {
     type Target = RuntimeRef;
 

--- a/rt/src/net/tcp/server.rs
+++ b/rt/src/net/tcp/server.rs
@@ -32,7 +32,7 @@
 //! # use heph::messages::Terminate;
 //! use heph::supervisor::SupervisorStrategy;
 //! use heph_rt::net::{tcp, TcpStream};
-//! use heph_rt::spawn::ActorOptions;
+//! use heph_rt::spawn::{ActorOptions, SpawnLocal};
 //! use heph_rt::spawn::options::Priority;
 //! use heph_rt::{Runtime, RuntimeRef, ThreadLocal};
 //! use log::error;
@@ -103,6 +103,7 @@
 //! use heph::messages::Terminate;
 //! # use heph::supervisor::SupervisorStrategy;
 //! use heph_rt::net::{tcp, TcpStream};
+//! use heph_rt::spawn::SpawnLocal;
 //! use heph_rt::spawn::options::{ActorOptions, Priority};
 //! use heph_rt::RuntimeRef;
 //! # use heph_rt::{Runtime, ThreadLocal};
@@ -171,6 +172,7 @@
 //! # use heph::messages::Terminate;
 //! use heph::supervisor::{SupervisorStrategy};
 //! use heph_rt::net::{tcp, TcpStream};
+//! use heph_rt::spawn::Spawn;
 //! use heph_rt::spawn::options::{ActorOptions, Priority};
 //! use heph_rt::{self as rt, Runtime, ThreadSafe};
 //! use log::error;

--- a/rt/src/spawn/mod.rs
+++ b/rt/src/spawn/mod.rs
@@ -124,7 +124,7 @@ pub trait SpawnLocal {
             .with_rt(ThreadLocal::from(self))
             .with_inbox_size(options.inbox_size())
             .build(supervisor, new_actor, arg)?;
-        self.spawn_local_future(future, options.as_future_options());
+        self.spawn_local_future(future, options.into_future_options());
         Ok(actor_ref)
     }
 
@@ -181,7 +181,7 @@ pub trait Spawn {
             .with_rt(ThreadSafe::from(self))
             .with_inbox_size(options.inbox_size())
             .build(supervisor, new_actor, arg)?;
-        self.spawn_future(future, options.as_future_options());
+        self.spawn_future(future, options.into_future_options());
         Ok(actor_ref)
     }
 

--- a/rt/src/spawn/mod.rs
+++ b/rt/src/spawn/mod.rs
@@ -16,6 +16,9 @@
 //! they will cause less damage as thread-safe actors/futures, but this only
 //! hides the issue, it doesn't solve it.
 //!
+//! The [`SpawnLocal`] trait defines how thread-local actors and futures are
+//! spawn, while [`Spawn`] defines it for thread-safe variants.
+//!
 //! [`Actor`]: heph::actor::Actor
 //! [`SyncActor`]: heph::sync::SyncActor
 //! [`Future`]: std::future::Future
@@ -39,6 +42,8 @@
 //! with actor/futures/tasks that transparently move between threads and hide
 //! blocking/bad actors, Heph does not (for thread-local actors).
 //!
+//! Thread-local actors and futures are spawned using [`SpawnLocal`].
+//!
 //! [`RuntimeRef::try_spawn_local`]: crate::RuntimeRef::try_spawn_local
 //! [`ThreadLocal`]: crate::access::ThreadLocal
 //!
@@ -58,34 +63,39 @@
 //! A downside is that these actors are more expansive to run than thread-local
 //! actors.
 //!
+//! Thread-safe actors and futures are spawned using [`SpawnLocal`].
+//!
 //! [`RuntimeRef::try_spawn`]: crate::RuntimeRef::try_spawn
 //! [`ThreadSafe`]: crate::access::ThreadSafe
 
+use std::future::Future;
+
+use heph::future::ActorFutureBuilder;
 use heph::supervisor::Supervisor;
 use heph::{actor, ActorRef, NewActor};
+
+use crate::access::{ThreadLocal, ThreadSafe};
 
 pub mod options;
 
 #[doc(no_inline)]
 pub use options::{ActorOptions, FutureOptions, SyncActorOptions};
 
-/// The `Spawn` trait defines how new actors are added to the runtime.
+/// The `Spawn` trait defines how new thread-local [`Actor`]s and [`Future`]s
+/// are added to the runtime.
 ///
-/// This trait can be implemented using the two flavours of `RT`, either
-/// [`ThreadLocal`] or [`ThreadSafe`], because of this it's implemented twice
-/// for types that support spawning both thread-local and thread-safe actors.
-/// For information on the difference between thread-local and thread-safe
-/// actors see the [`spawn`] module.
-///
-/// [`spawn`]: crate::spawn
-/// [`ThreadLocal`]: crate::ThreadLocal
-/// [`ThreadSafe`]: crate::ThreadSafe
-pub trait Spawn<S, NA, RT> {
-    /// Attempt to spawn an actor.
+/// [`Actor`]: heph::actor::Actor
+pub trait SpawnLocal {
+    /// Spawn a thread-local [`Future`].
+    fn spawn_local_future<Fut>(&mut self, future: Fut, options: FutureOptions)
+    where
+        Fut: Future<Output = ()> + 'static;
+
+    /// Attempt to spawn a thread-local actor.
     ///
     /// Arguments:
     /// * `supervisor`: all actors need supervision, the `supervisor` is the
-    ///   supervisor for this actor, see the [`Supervisor`] trait for more
+    ///   supervisor for this actor, see the [`supervisor`] module for more
     ///   information.
     /// * `new_actor`: the [`NewActor`] implementation that defines how to start
     ///   the actor.
@@ -94,10 +104,11 @@ pub trait Spawn<S, NA, RT> {
     ///
     /// When using a [`NewActor`] implementation that never returns an error,
     /// such as the implementation provided by async functions, it's easier to
-    /// use the [`spawn`] method.
+    /// use the [`spawn_local`] method.
     ///
-    /// [`spawn`]: Spawn::spawn
-    fn try_spawn(
+    /// [`supervisor`]: heph::supervisor
+    /// [`spawn_local`]: SpawnLocal::spawn_local
+    fn try_spawn_local<S, NA>(
         &mut self,
         supervisor: S,
         new_actor: NA,
@@ -105,16 +116,25 @@ pub trait Spawn<S, NA, RT> {
         options: ActorOptions,
     ) -> Result<ActorRef<NA::Message>, NA::Error>
     where
-        S: Supervisor<NA>,
-        NA: NewActor<RuntimeAccess = RT>;
+        S: Supervisor<NA> + 'static,
+        NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
+        ThreadLocal: for<'a> From<&'a Self> + 'static,
+    {
+        let (future, actor_ref) = ActorFutureBuilder::new()
+            .with_rt(ThreadLocal::from(self))
+            .with_inbox_size(options.inbox_size())
+            .build(supervisor, new_actor, arg)?;
+        self.spawn_local_future(future, options.as_future_options());
+        Ok(actor_ref)
+    }
 
-    /// Spawn an actor.
+    /// Spawn a thread-local actor.
     ///
     /// This is a convenience method for `NewActor` implementations that never
     /// return an error, such as asynchronous functions.
     ///
-    /// See [`Spawn::try_spawn`] for more information.
-    fn spawn(
+    /// See [`SpawnLocal::try_spawn_local`] for more information.
+    fn spawn_local<S, NA>(
         &mut self,
         supervisor: S,
         new_actor: NA,
@@ -122,8 +142,68 @@ pub trait Spawn<S, NA, RT> {
         options: ActorOptions,
     ) -> ActorRef<NA::Message>
     where
-        S: Supervisor<NA>,
-        NA: NewActor<Error = !, RuntimeAccess = RT>,
+        S: Supervisor<NA> + 'static,
+        NA: NewActor<Error = !, RuntimeAccess = ThreadLocal> + 'static,
+        ThreadLocal: for<'a> From<&'a Self>,
+    {
+        match self.try_spawn_local(supervisor, new_actor, arg, options) {
+            Ok(actor_ref) => actor_ref,
+            Err(err) => err,
+        }
+    }
+}
+
+/// Thread-safe version of [`SpawnLocal`].
+pub trait Spawn {
+    /// Spawn a thread-safe [`Future`].
+    fn spawn_future<Fut>(&mut self, future: Fut, options: FutureOptions)
+    where
+        Fut: Future<Output = ()> + Sync + Send + 'static;
+
+    /// Attempt to spawn a thread-safe actor.
+    ///
+    /// See [`SpawnLocal::try_spawn_local`] for more information.
+    fn try_spawn<S, NA>(
+        &mut self,
+        supervisor: S,
+        new_actor: NA,
+        arg: NA::Argument,
+        options: ActorOptions,
+    ) -> Result<ActorRef<NA::Message>, NA::Error>
+    where
+        S: Supervisor<NA> + Send + Sync + 'static,
+        NA: NewActor<RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+        ThreadSafe: for<'a> From<&'a Self>,
+        NA::Actor: Send + Sync + 'static,
+        NA::Message: Send,
+    {
+        let (future, actor_ref) = ActorFutureBuilder::new()
+            .with_rt(ThreadSafe::from(self))
+            .with_inbox_size(options.inbox_size())
+            .build(supervisor, new_actor, arg)?;
+        self.spawn_future(future, options.as_future_options());
+        Ok(actor_ref)
+    }
+
+    /// Spawn a thread-safe actor.
+    ///
+    /// This is a convenience method for `NewActor` implementations that never
+    /// return an error, such as asynchronous functions.
+    ///
+    /// See [`Spawn::try_spawn`] for more information.
+    fn spawn<S, NA>(
+        &mut self,
+        supervisor: S,
+        new_actor: NA,
+        arg: NA::Argument,
+        options: ActorOptions,
+    ) -> ActorRef<NA::Message>
+    where
+        S: Supervisor<NA> + Send + Sync + 'static,
+        NA: NewActor<Error = !, RuntimeAccess = ThreadSafe> + Send + Sync + 'static,
+        ThreadSafe: for<'a> From<&'a Self>,
+        NA::Actor: Send + Sync + 'static,
+        NA::Message: Send,
     {
         match self.try_spawn(supervisor, new_actor, arg, options) {
             Ok(actor_ref) => actor_ref,
@@ -132,22 +212,26 @@ pub trait Spawn<S, NA, RT> {
     }
 }
 
-impl<M, RT, S, NA, RT2> Spawn<S, NA, RT2> for actor::Context<M, RT>
+impl<M, RT> SpawnLocal for actor::Context<M, RT>
 where
-    RT: Spawn<S, NA, RT2>,
+    RT: SpawnLocal,
 {
-    fn try_spawn(
-        &mut self,
-        supervisor: S,
-        new_actor: NA,
-        arg: NA::Argument,
-        options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, NA::Error>
+    fn spawn_local_future<Fut>(&mut self, future: Fut, options: FutureOptions)
     where
-        S: Supervisor<NA>,
-        NA: NewActor<RuntimeAccess = RT2>,
+        Fut: Future<Output = ()> + 'static,
     {
-        self.runtime()
-            .try_spawn(supervisor, new_actor, arg, options)
+        self.runtime().spawn_local_future(future, options);
+    }
+}
+
+impl<M, RT> Spawn for actor::Context<M, RT>
+where
+    RT: Spawn,
+{
+    fn spawn_future<Fut>(&mut self, future: Fut, options: FutureOptions)
+    where
+        Fut: Future<Output = ()> + 'static + Send + Sync,
+    {
+        self.runtime().spawn_future(future, options);
     }
 }

--- a/rt/src/spawn/options.rs
+++ b/rt/src/spawn/options.rs
@@ -72,7 +72,7 @@ impl ActorOptions {
     }
 
     /// Returns itself as `FutureOptions`.
-    pub(crate) const fn as_future_options(self) -> FutureOptions {
+    pub(crate) const fn into_future_options(self) -> FutureOptions {
         let ActorOptions {
             priority,
             inbox_size: _,

--- a/rt/src/spawn/options.rs
+++ b/rt/src/spawn/options.rs
@@ -70,6 +70,16 @@ impl ActorOptions {
         self.inbox_size = inbox_size;
         self
     }
+
+    /// Returns itself as `FutureOptions`.
+    pub(crate) const fn as_future_options(self) -> FutureOptions {
+        let ActorOptions {
+            priority,
+            inbox_size: _,
+        } = self;
+
+        FutureOptions { priority }
+    }
 }
 
 /// Priority for an actor or future in the scheduler.

--- a/rt/src/test.rs
+++ b/rt/src/test.rs
@@ -70,7 +70,7 @@ use heph::sync::{SyncActor, SyncWaker};
 use heph_inbox as inbox;
 use heph_inbox::oneshot::{self, new_oneshot};
 
-use crate::spawn::{ActorOptions, FutureOptions, SyncActorOptions};
+use crate::spawn::{ActorOptions, FutureOptions, Spawn, SpawnLocal, SyncActorOptions};
 use crate::worker::Worker;
 use crate::{
     self as rt, panic_message, shared, sync_worker, worker, Runtime, RuntimeRef, Setup, Sync,

--- a/rt/src/timer.rs
+++ b/rt/src/timer.rs
@@ -55,7 +55,7 @@ impl From<DeadlinePassed> for io::ErrorKind {
 /// use heph::actor;
 /// # use heph::actor::actor_fn;
 /// # use heph::supervisor::NoSupervisor;
-/// # use heph_rt::spawn::ActorOptions;
+/// # use heph_rt::spawn::{ActorOptions, SpawnLocal};
 /// # use heph_rt::{self as rt, Runtime, RuntimeRef};
 /// use heph_rt::ThreadLocal;
 /// use heph_rt::timer::Timer;
@@ -185,7 +185,7 @@ impl<RT: Access> Drop for Timer<RT> {
 /// # use heph::actor::actor_fn;
 /// # use heph::supervisor::NoSupervisor;
 /// use heph_rt::ThreadSafe;
-/// # use heph_rt::spawn::ActorOptions;
+/// # use heph_rt::spawn::{ActorOptions, Spawn};
 /// # use heph_rt::{self as rt, Runtime};
 /// use heph_rt::timer::Deadline;
 ///
@@ -326,7 +326,7 @@ impl<Fut: Unpin, RT: Access> Unpin for Deadline<Fut, RT> {}
 /// use heph::actor;
 /// # use heph::actor::actor_fn;
 /// # use heph::supervisor::NoSupervisor;
-/// # use heph_rt::spawn::ActorOptions;
+/// # use heph_rt::spawn::{ActorOptions, SpawnLocal};
 /// # use heph_rt::{self as rt, Runtime, RuntimeRef};
 /// use heph_rt::ThreadLocal;
 /// use heph_rt::timer::Interval;

--- a/rt/src/trace.rs
+++ b/rt/src/trace.rs
@@ -617,7 +617,7 @@ mod private {
                 }
 
                 fn write_attribute(&self, buf: &mut Vec<u8>) {
-                    #[allow(trivial_numeric_casts)] // for `u64 as u64`, etc.
+                    #[allow(trivial_numeric_casts, clippy::cast_lossless)] // for `u64 as u64`, etc.
                     let value = self.get() as $f_ty;
                     buf.extend_from_slice(&value.to_be_bytes());
                 }
@@ -632,7 +632,7 @@ mod private {
                 }
 
                 fn write_attribute(&self, buf: &mut Vec<u8>) {
-                    #[allow(trivial_numeric_casts)] // for `u64 as u64`, etc.
+                    #[allow(trivial_numeric_casts, clippy::cast_lossless)] // for `u64 as u64`, etc.
                     let value = *self as $f_ty;
                     buf.extend_from_slice(&value.to_be_bytes());
                 }

--- a/rt/src/worker.rs
+++ b/rt/src/worker.rs
@@ -31,7 +31,7 @@ use crate::error::StringError;
 use crate::local::RuntimeInternals;
 use crate::process::ProcessId;
 use crate::setup::set_cpu_affinity;
-use crate::spawn::options::ActorOptions;
+use crate::spawn::{ActorOptions, SpawnLocal};
 use crate::wakers::Wakers;
 use crate::{self as rt, shared, trace, RuntimeRef, Signal, ThreadLocal};
 

--- a/rt/tests/functional/actor_ref.rs
+++ b/rt/tests/functional/actor_ref.rs
@@ -11,8 +11,8 @@ use heph::actor::{self, actor_fn};
 use heph::actor_ref::{ActorRef, Join, RpcError, RpcMessage, SendError, SendValue};
 use heph::messages::from_message;
 use heph::supervisor::NoSupervisor;
-use heph_rt::spawn::options::Priority;
-use heph_rt::spawn::ActorOptions;
+use heph_rt::spawn::options::{ActorOptions, Priority};
+use heph_rt::spawn::SpawnLocal;
 use heph_rt::test::{init_local_actor, poll_actor, poll_future};
 use heph_rt::{Runtime, ThreadLocal};
 

--- a/rt/tests/functional/future.rs
+++ b/rt/tests/functional/future.rs
@@ -6,7 +6,7 @@ use std::task::{self, Poll};
 
 use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
-use heph_rt::spawn::{ActorOptions, FutureOptions};
+use heph_rt::spawn::{ActorOptions, FutureOptions, Spawn, SpawnLocal};
 use heph_rt::test::poll_future;
 use heph_rt::{Runtime, ThreadSafe};
 

--- a/rt/tests/functional/runtime.rs
+++ b/rt/tests/functional/runtime.rs
@@ -13,6 +13,7 @@ use heph::actor::{self, actor_fn, Actor, NewActor};
 use heph::supervisor::{NoSupervisor, Supervisor, SupervisorStrategy};
 use heph::sync;
 use heph_rt::spawn::options::{ActorOptions, FutureOptions, Priority, SyncActorOptions};
+use heph_rt::spawn::{Spawn, SpawnLocal};
 use heph_rt::{Runtime, ThreadLocal, ThreadSafe};
 
 use crate::util::temp_file;

--- a/rt/tests/functional/spawn.rs
+++ b/rt/tests/functional/spawn.rs
@@ -1,40 +1,18 @@
 //! Tests to check what types implement the Spawn trait.
 
-use std::future::Pending;
-use std::marker::PhantomData;
-
-use heph::actor::{self, NewActor};
-use heph::supervisor::NoSupervisor;
-use heph_rt::spawn::Spawn;
+use heph::actor;
+use heph_rt::spawn::{Spawn, SpawnLocal};
 use heph_rt::{Runtime, RuntimeRef, ThreadLocal, ThreadSafe};
-
-struct TestNewActor<RT>(PhantomData<RT>);
-
-impl<RT> NewActor for TestNewActor<RT> {
-    type Message = !;
-    type Argument = ();
-    type Actor = Pending<Result<(), !>>;
-    type Error = !;
-    type RuntimeAccess = RT;
-
-    fn new(
-        &mut self,
-        _: actor::Context<Self::Message, Self::RuntimeAccess>,
-        _: Self::Argument,
-    ) -> Result<Self::Actor, Self::Error> {
-        todo!()
-    }
-}
 
 fn can_spawn_thread_local<T>()
 where
-    T: Spawn<NoSupervisor, TestNewActor<ThreadLocal>, ThreadLocal>,
+    T: SpawnLocal,
 {
 }
 
 fn can_spawn_thread_safe<T>()
 where
-    T: Spawn<NoSupervisor, TestNewActor<ThreadSafe>, ThreadSafe>,
+    T: Spawn,
 {
 }
 

--- a/rt/tests/functional/spawn.rs
+++ b/rt/tests/functional/spawn.rs
@@ -2,7 +2,7 @@
 
 use heph::actor;
 use heph_rt::spawn::{Spawn, SpawnLocal};
-use heph_rt::{Runtime, RuntimeRef, ThreadLocal, ThreadSafe};
+use heph_rt::{Runtime, RuntimeRef, Sync, ThreadLocal, ThreadSafe};
 
 fn can_spawn_thread_local<T>()
 where
@@ -47,4 +47,9 @@ fn thread_local() {
 #[test]
 fn thread_safe() {
     can_spawn_thread_safe::<ThreadSafe>();
+}
+
+#[test]
+fn sync() {
+    can_spawn_thread_safe::<Sync>();
 }

--- a/rt/tests/functional/tcp/server.rs
+++ b/rt/tests/functional/tcp/server.rs
@@ -9,7 +9,7 @@ use heph::messages::Terminate;
 use heph::supervisor::{NoSupervisor, Supervisor, SupervisorStrategy};
 use heph::ActorRef;
 use heph_rt::net::{tcp, TcpStream};
-use heph_rt::spawn::ActorOptions;
+use heph_rt::spawn::{ActorOptions, Spawn, SpawnLocal};
 use heph_rt::test::{join_many, try_spawn_local, PanicSupervisor};
 use heph_rt::{self as rt, Runtime, Signal, ThreadLocal};
 

--- a/rt/tests/functional/timer.rs
+++ b/rt/tests/functional/timer.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
-use heph_rt::spawn::ActorOptions;
+use heph_rt::spawn::{ActorOptions, Spawn, SpawnLocal};
 use heph_rt::test::{block_on_local_actor, poll_future, poll_next};
 use heph_rt::timer::{Deadline, DeadlinePassed, Interval, Timer};
 use heph_rt::util::next;

--- a/rt/tests/process_signals.rs
+++ b/rt/tests/process_signals.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use heph::actor::{self, actor_fn};
 use heph::supervisor::NoSupervisor;
 use heph::sync;
-use heph_rt::spawn::options::{ActorOptions, FutureOptions, SyncActorOptions};
+use heph_rt::spawn::{ActorOptions, FutureOptions, Spawn, SpawnLocal, SyncActorOptions};
 use heph_rt::{Runtime, Signal};
 
 #[path = "util/mod.rs"] // rustfmt can't find the file.

--- a/rt/tests/regression/issue_145.rs
+++ b/rt/tests/regression/issue_145.rs
@@ -12,7 +12,7 @@ use heph::messages::Terminate;
 use heph::supervisor::{NoSupervisor, Supervisor, SupervisorStrategy};
 use heph::{Actor, ActorRef, NewActor};
 use heph_rt::net::{tcp, TcpListener, TcpStream};
-use heph_rt::spawn::ActorOptions;
+use heph_rt::spawn::{ActorOptions, SpawnLocal};
 use heph_rt::{Runtime, RuntimeRef, ThreadLocal};
 
 const N: usize = 4;


### PR DESCRIPTION
This splits it into two traits: SpawnLocal and Spawn. SpawnLocal is for
thread-local actors and futures, while Spawn is for thread-safe.

Closes #311