### PR TITLE
Add RestartableActor and PersistentActor traits

### DIFF
--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -118,7 +118,7 @@ mod tests;
 
 #[doc(inline)]
 pub use context::{Context, NoMessages, ReceiveMessage, ReceiveMessages, RecvError};
-pub use restartable::RestartableActor;
+pub use restartable::{PersistentActor, RestartableActor};
 
 /// Creating asynchronous actors.
 ///

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -112,11 +112,13 @@ use std::pin::Pin;
 use std::task::{self, Poll};
 
 mod context;
+mod restartable;
 #[cfg(test)]
 mod tests;
 
 #[doc(inline)]
 pub use context::{Context, NoMessages, ReceiveMessage, ReceiveMessages, RecvError};
+pub use restartable::RestartableActor;
 
 /// Creating asynchronous actors.
 ///

--- a/src/actor/restartable.rs
+++ b/src/actor/restartable.rs
@@ -28,3 +28,17 @@ pub trait RestartableActor: NewActor {
         state: Self::State,
     ) -> Result<Self::Actor, Self::Error>;
 }
+
+/// Actors that can create a persistent state of a running actor.
+pub trait PersistentActor: RestartableActor {
+    /// Returns the current state of the actor.
+    ///
+    /// Similar to [`RestartableActor::stop`], but called while the actor is
+    /// still running (and can be polled after calling this).
+    ///
+    /// # Notes
+    ///
+    /// This may be called with the actor is still actively running, but never
+    /// while the actor is being polled.
+    fn state(&mut self, actor: &mut Self::Actor) -> Self::State;
+}

--- a/src/actor/restartable.rs
+++ b/src/actor/restartable.rs
@@ -42,3 +42,5 @@ pub trait PersistentActor: RestartableActor {
     /// while the actor is being polled.
     fn state(&mut self, actor: &mut Self::Actor) -> Self::State;
 }
+
+// TODO: implementations using serde and sqlite3.

--- a/src/actor/restartable.rs
+++ b/src/actor/restartable.rs
@@ -1,0 +1,30 @@
+use crate::actor::{self, NewActor};
+
+/// Actors that can be stopped and restarted.
+pub trait RestartableActor: NewActor {
+    /// State from which the actor can be restarted.
+    ///
+    /// # Notes
+    ///
+    /// Any not received messages (not removed from the inbox) should not be
+    /// part of the state. Any messages that are received should be processed or
+    /// be part of the state (to be processed on restart).
+    ///
+    /// Implementations that use this trait to store the state to stable
+    /// storage, e.g. to disk, or to transfer the actor to another process or
+    /// even machine will have additional requirements on the `State` type.
+    type State;
+
+    /// Return the state of a stopped actor.
+    fn stop(&mut self, actor: Self::Actor) -> Self::State;
+
+    /// Restart an actor from a previously stopped state.
+    ///
+    /// Similar to [`NewActor::new`], but instead of starting argument a
+    /// previous state is passed.
+    fn restart(
+        &mut self,
+        ctx: actor::Context<Self::Message>,
+        state: Self::State,
+    ) -> Result<Self::Actor, Self::Error>;
+}


### PR DESCRIPTION
Allows for restarting actors, moving them to a different process and potentially even to another machine.

Closes #231