### PR TITLE
Move spawning of tasks to spawn module

### DIFF
--- a/rt/src/access.rs
+++ b/rt/src/access.rs
@@ -37,7 +37,7 @@ use std::{fmt, task};
 use heph::{ActorRef, NewActor, Supervisor, actor, sync};
 
 use crate::setup::timers::TimerToken;
-use crate::spawn::{ActorOptions, FutureOptions, Spawn};
+use crate::spawn::{self, ActorOptions, FutureOptions, Spawn};
 use crate::trace::{self, Trace};
 use crate::{Runtime, RuntimeRef, shared};
 
@@ -297,7 +297,7 @@ where
         S: Supervisor<NA>,
         NA: NewActor<RuntimeAccess = ThreadSafe>,
     {
-        self.rt.try_spawn(supervisor, new_actor, arg, options)
+        spawn::try_spawn(&self.rt, supervisor, new_actor, arg, options)
     }
 }
 
@@ -423,7 +423,7 @@ where
         S: Supervisor<NA>,
         NA: NewActor<RuntimeAccess = ThreadSafe>,
     {
-        self.rt.try_spawn(supervisor, new_actor, arg, options)
+        spawn::try_spawn(&self.rt, supervisor, new_actor, arg, options)
     }
 }
 

--- a/rt/src/access.rs
+++ b/rt/src/access.rs
@@ -228,7 +228,7 @@ impl ThreadSafe {
     where
         Fut: Future<Output = ()> + Send + std::marker::Sync + 'static,
     {
-        self.rt.spawn_future(future, options);
+        spawn::spawn_future(&self.rt, future, options);
     }
 }
 
@@ -401,7 +401,7 @@ impl Sync {
     where
         Fut: Future<Output = ()> + Send + std::marker::Sync + 'static,
     {
-        self.rt.spawn_future(future, options);
+        spawn::spawn_future(&self.rt, future, options);
     }
 }
 

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -322,7 +322,7 @@ impl Runtime {
     where
         Fut: Future<Output = ()> + Send + std::marker::Sync + 'static,
     {
-        self.internals.spawn_future(future, options);
+        spawn::spawn_future(&self.internals, future, options);
     }
 
     /// Run the function `f` on all worker threads.
@@ -510,7 +510,7 @@ impl RuntimeRef {
     where
         Fut: Future<Output = ()> + Send + std::marker::Sync + 'static,
     {
-        self.internals.shared().spawn_future(future, options);
+        spawn::spawn_future(self.internals.shared(), future, options);
     }
 
     /// Receive process signals as messages.

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -187,7 +187,6 @@ use info::Info;
 use local::LocalRuntimeData;
 use metrics::{LocalMetrics, SharedMetrics};
 use setup::Setup;
-use setup::scheduler::{FutureTask, Task};
 use spawn::{ActorOptions, FutureOptions, Spawn, SyncActorOptions};
 
 /// The runtime that runs all actors.
@@ -499,12 +498,7 @@ impl RuntimeRef {
     where
         Fut: Future<Output = ()> + 'static,
     {
-        let task = FutureTask(future);
-        let name = task.name();
-        let pid = self
-            .internals
-            .add_local_task(options.priority(), Box::pin(task));
-        log::debug!(pid, name; "spawned thread-local future");
+        spawn::spawn_local_future(self, future, options);
     }
 
     /// Spawn a thread-safe [`Future`].

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -397,8 +397,7 @@ where
         S: Supervisor<NA>,
         NA: NewActor<RuntimeAccess = ThreadSafe>,
     {
-        self.internals
-            .try_spawn(supervisor, new_actor, arg, options)
+        spawn::try_spawn(&self.internals, supervisor, new_actor, arg, options)
     }
 }
 
@@ -605,9 +604,7 @@ where
         S: Supervisor<NA>,
         NA: NewActor<RuntimeAccess = ThreadSafe>,
     {
-        self.internals
-            .shared()
-            .try_spawn(supervisor, new_actor, arg, options)
+        spawn::try_spawn(self.internals.shared(), supervisor, new_actor, arg, options)
     }
 }
 

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -145,7 +145,7 @@ use std::time::Duration;
 
 use heph::actor_ref::{ActorGroup, ActorRef, SendError};
 use heph::supervisor::{Supervisor, SyncSupervisor};
-use heph::{ActorFutureBuilder, NewActor, SyncActor};
+use heph::{NewActor, SyncActor};
 
 pub mod access;
 mod bitmap;
@@ -589,17 +589,7 @@ where
         S: Supervisor<NA>,
         NA: NewActor<RuntimeAccess = ThreadLocal>,
     {
-        let rt = self.clone();
-        let (task, actor_ref) = ActorFutureBuilder::new()
-            .with_rt(rt)
-            .with_inbox_size(options.inbox_size())
-            .try_build(supervisor, new_actor, arg)?;
-        let pid = self
-            .internals
-            .add_local_task(options.priority(), Box::pin(task));
-        let name = NA::name();
-        log::debug!(pid, name; "spawned thread-local actor");
-        Ok(actor_ref)
+        spawn::try_spawn_local(self, supervisor, new_actor, arg, options)
     }
 }
 

--- a/rt/src/shared.rs
+++ b/rt/src/shared.rs
@@ -7,22 +7,17 @@ use std::sync::{Arc, Mutex, OnceLock, TryLockError};
 use std::time::{Duration, Instant};
 use std::{io, task};
 
-use heph::actor_ref::ActorRef;
-use heph::supervisor::Supervisor;
-use heph::{ActorFutureBuilder, NewActor};
-
 use crate::bitmap::AtomicBitMap;
 use crate::info::Info;
 use crate::metrics::SharedMetrics;
 use crate::scheduler::shared::{Process, Scheduler};
 use crate::setup::scheduler::{FutureTask, ProcessId, RunStats, Task};
 use crate::setup::timers::{SharedTimers, TimerToken};
-#[cfg(test)]
+use crate::spawn::FutureOptions;
 use crate::spawn::options::Priority;
-use crate::spawn::{ActorOptions, FutureOptions};
 use crate::timing_wheel::SharedTimingWheel;
+use crate::trace;
 use crate::wakers::shared::Wakers;
-use crate::{ThreadSafe, trace};
 
 /// Shared internals of the runtime.
 #[derive(Debug)]
@@ -170,34 +165,6 @@ impl RuntimeInternals {
         }
     }
 
-    /// Spawn a thread-safe actor.
-    #[allow(clippy::needless_pass_by_value)] // For `ActorOptions`.
-    pub(crate) fn try_spawn<S, NA>(
-        self: &Arc<Self>,
-        supervisor: S,
-        new_actor: NA,
-        arg: NA::Argument,
-        options: ActorOptions,
-    ) -> Result<ActorRef<NA::Message>, NA::Error>
-    where
-        S: Supervisor<NA> + Send + Sync + 'static,
-        NA: NewActor<RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
-        NA::Actor: Send + Sync + 'static,
-        NA::Message: Send,
-    {
-        let rt = ThreadSafe::new(self.clone());
-        let (task, actor_ref) = ActorFutureBuilder::new()
-            .with_rt(rt)
-            .with_inbox_size(options.inbox_size())
-            .try_build(supervisor, new_actor, arg)?;
-        let pid = self
-            .scheduler
-            .add_new_task(options.priority(), Box::pin(task));
-        let name = NA::name();
-        log::debug!(pid, name; "spawned thread-safe actor");
-        Ok(actor_ref)
-    }
-
     /// Spawn a thread-safe `future`.
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn spawn_future<Fut>(&self, future: Fut, options: FutureOptions)
@@ -213,12 +180,12 @@ impl RuntimeInternals {
     }
 
     /// Add a new task to the scheduler.
-    #[cfg(test)]
-    pub(crate) fn add_new_task<T>(&self, priority: Priority, task: T) -> ProcessId
-    where
-        T: Task + Send + Sync + 'static,
-    {
-        self.scheduler.add_new_task(priority, Box::pin(task))
+    pub(crate) fn add_new_task(
+        &self,
+        priority: Priority,
+        task: Pin<Box<dyn Task + Send + Sync + 'static>>,
+    ) -> ProcessId {
+        self.scheduler.add_new_task(priority, task)
     }
 
     /// See [`Scheduler::mark_ready`].

--- a/rt/src/shared.rs
+++ b/rt/src/shared.rs
@@ -1,6 +1,5 @@
 //! Module with shared runtime internals.
 
-use std::future::Future;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock, TryLockError};
@@ -11,9 +10,8 @@ use crate::bitmap::AtomicBitMap;
 use crate::info::Info;
 use crate::metrics::SharedMetrics;
 use crate::scheduler::shared::{Process, Scheduler};
-use crate::setup::scheduler::{FutureTask, ProcessId, RunStats, Task};
+use crate::setup::scheduler::{ProcessId, RunStats, Task};
 use crate::setup::timers::{SharedTimers, TimerToken};
-use crate::spawn::FutureOptions;
 use crate::spawn::options::Priority;
 use crate::timing_wheel::SharedTimingWheel;
 use crate::trace;
@@ -163,20 +161,6 @@ impl RuntimeInternals {
             },
             None => current,
         }
-    }
-
-    /// Spawn a thread-safe `future`.
-    #[allow(clippy::needless_pass_by_value)]
-    pub(crate) fn spawn_future<Fut>(&self, future: Fut, options: FutureOptions)
-    where
-        Fut: Future<Output = ()> + Send + Sync + 'static,
-    {
-        let task = FutureTask(future);
-        let name = task.name();
-        let pid = self
-            .scheduler
-            .add_new_task(options.priority(), Box::pin(task));
-        log::debug!(pid, name; "spawned thread-safe future");
     }
 
     /// Add a new task to the scheduler.

--- a/rt/src/spawn/mod.rs
+++ b/rt/src/spawn/mod.rs
@@ -61,12 +61,14 @@
 //! [`RuntimeRef::try_spawn`]: crate::RuntimeRef::try_spawn
 //! [`ThreadSafe`]: crate::access::ThreadSafe
 
+use std::sync::Arc;
+
 use heph::supervisor::Supervisor;
 use heph::{ActorFutureBuilder, ActorRef, NewActor, actor};
 
-use crate::RuntimeRef;
-use crate::access::ThreadLocal;
+use crate::access::{ThreadLocal, ThreadSafe};
 use crate::setup::scheduler::{FutureTask, Task};
+use crate::{RuntimeRef, shared};
 
 pub mod options;
 
@@ -191,4 +193,28 @@ where
         .internals
         .add_local_task(options.priority(), Box::pin(task));
     log::debug!(pid, name; "spawned thread-local future");
+}
+
+#[allow(clippy::needless_pass_by_value)] // For `ActorOptions`.
+pub(crate) fn try_spawn<S, NA>(
+    rt: &Arc<shared::RuntimeInternals>,
+    supervisor: S,
+    new_actor: NA,
+    arg: NA::Argument,
+    options: ActorOptions,
+) -> Result<ActorRef<NA::Message>, NA::Error>
+where
+    S: Supervisor<NA> + Send + Sync + 'static,
+    NA: NewActor<RuntimeAccess = ThreadSafe> + Sync + Send + 'static,
+    NA::Actor: Send + Sync + 'static,
+    NA::Message: Send,
+{
+    let (task, actor_ref) = ActorFutureBuilder::new()
+        .with_rt(ThreadSafe::new(rt.clone()))
+        .with_inbox_size(options.inbox_size())
+        .try_build(supervisor, new_actor, arg)?;
+    let pid = rt.add_new_task(options.priority(), Box::pin(task));
+    let name = NA::name();
+    log::debug!(pid, name; "spawned thread-safe actor");
+    Ok(actor_ref)
 }

--- a/rt/src/spawn/mod.rs
+++ b/rt/src/spawn/mod.rs
@@ -66,6 +66,7 @@ use heph::{ActorFutureBuilder, ActorRef, NewActor, actor};
 
 use crate::RuntimeRef;
 use crate::access::ThreadLocal;
+use crate::setup::scheduler::{FutureTask, Task};
 
 pub mod options;
 
@@ -177,4 +178,17 @@ where
     let name = NA::name();
     log::debug!(pid, name; "spawned thread-local actor");
     Ok(actor_ref)
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::needless_pass_by_ref_mut)]
+pub(crate) fn spawn_local_future<Fut>(rt: &mut RuntimeRef, future: Fut, options: FutureOptions)
+where
+    Fut: Future<Output = ()> + 'static,
+{
+    let task = FutureTask(future);
+    let name = task.name();
+    let pid = rt
+        .internals
+        .add_local_task(options.priority(), Box::pin(task));
+    log::debug!(pid, name; "spawned thread-local future");
 }

--- a/rt/src/spawn/mod.rs
+++ b/rt/src/spawn/mod.rs
@@ -62,7 +62,10 @@
 //! [`ThreadSafe`]: crate::access::ThreadSafe
 
 use heph::supervisor::Supervisor;
-use heph::{ActorRef, NewActor, actor};
+use heph::{ActorFutureBuilder, ActorRef, NewActor, actor};
+
+use crate::RuntimeRef;
+use crate::access::ThreadLocal;
 
 pub mod options;
 
@@ -150,4 +153,28 @@ where
         self.runtime()
             .try_spawn(supervisor, new_actor, arg, options)
     }
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::needless_pass_by_ref_mut)]
+pub(crate) fn try_spawn_local<S, NA>(
+    rt: &mut RuntimeRef,
+    supervisor: S,
+    new_actor: NA,
+    arg: NA::Argument,
+    options: ActorOptions,
+) -> Result<ActorRef<NA::Message>, NA::Error>
+where
+    S: Supervisor<NA> + 'static,
+    NA: NewActor<RuntimeAccess = ThreadLocal> + 'static,
+{
+    let (task, actor_ref) = ActorFutureBuilder::new()
+        .with_rt(rt.clone())
+        .with_inbox_size(options.inbox_size())
+        .try_build(supervisor, new_actor, arg)?;
+    let pid = rt
+        .internals
+        .add_local_task(options.priority(), Box::pin(task));
+    let name = NA::name();
+    log::debug!(pid, name; "spawned thread-local actor");
+    Ok(actor_ref)
 }

--- a/rt/src/spawn/mod.rs
+++ b/rt/src/spawn/mod.rs
@@ -218,3 +218,17 @@ where
     log::debug!(pid, name; "spawned thread-safe actor");
     Ok(actor_ref)
 }
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn spawn_future<Fut>(
+    rt: &Arc<shared::RuntimeInternals>,
+    future: Fut,
+    options: FutureOptions,
+) where
+    Fut: Future<Output = ()> + Send + Sync + 'static,
+{
+    let task = FutureTask(future);
+    let name = task.name();
+    let pid = rt.add_new_task(options.priority(), Box::pin(task));
+    log::debug!(pid, name; "spawned thread-safe future");
+}

--- a/rt/src/wakers/tests.rs
+++ b/rt/src/wakers/tests.rs
@@ -34,7 +34,7 @@ mod shared {
     fn waker() {
         let shared_internals = new_internals();
 
-        let pid = shared_internals.add_new_task(Priority::NORMAL, TestTask);
+        let pid = shared_internals.add_new_task(Priority::NORMAL, Box::pin(TestTask));
         assert!(shared_internals.has_process());
         assert!(shared_internals.has_ready_process());
         let process = shared_internals.remove_process().unwrap();
@@ -66,7 +66,7 @@ mod shared {
         let shared_internals = new_internals();
 
         // Add a test process.
-        let pid = shared_internals.add_new_task(Priority::NORMAL, TestTask);
+        let pid = shared_internals.add_new_task(Priority::NORMAL, Box::pin(TestTask));
         assert!(shared_internals.has_process());
         assert!(shared_internals.has_ready_process());
         let process = shared_internals.remove_process().unwrap();
@@ -91,7 +91,7 @@ mod shared {
     fn wake_from_different_thread() {
         let shared_internals = new_internals();
 
-        let pid = shared_internals.add_new_task(Priority::NORMAL, TestTask);
+        let pid = shared_internals.add_new_task(Priority::NORMAL, Box::pin(TestTask));
         assert!(shared_internals.has_process());
         assert!(shared_internals.has_ready_process());
         let process = shared_internals.remove_process().unwrap();


### PR DESCRIPTION
Having the code in one place makes it a little nicer, even though it's still called from all over the place. It also means we can remove the spawn actor and futures methods from shared::RuntimeInternals, moving to using the Task trait instead.